### PR TITLE
Use 6.2 by default

### DIFF
--- a/docker/apm_server/start.sh
+++ b/docker/apm_server/start.sh
@@ -20,7 +20,7 @@ fi
 
 echo "APM_SERVER_VERSION: ${APM_SERVER_VERSION}, ${APM_SERVER_VERSION_STATE}"
 
-if [[ ${APM_SERVER_VERSION_STATE} != "release" ]];then
+if [[ ${APM_SERVER_VERSION_STATE} == "github" ]];then
   docker build -f 'docker/apm_server/Dockerfile' -t ${APM_SERVER_NAME}:${APM_SERVER_VERSION} .
   docker run -d \
     --name="${APM_SERVER_NAME}" \
@@ -36,6 +36,20 @@ if [[ ${APM_SERVER_VERSION_STATE} != "release" ]];then
         make update apm-server
         ./apm-server -e -d \"*\" -c ../apm-server.yml"
 else
+  image_name="docker.elastic.co/apm/apm-server:${APM_SERVER_VERSION}"
+
+  if [[ ${APM_SERVER_VERSION_STATE} == "snapshot" ]];then
+    registry="https://snapshots.elastic.co/docker/"
+    name="apm-server"
+    version="${APM_SERVER_VERSION}-SNAPSHOT"
+    file_type="tar.gz"
+    file="${name}-${version}.${file_type}"
+    wget "${registry}${file}"
+    docker load -i "${file}"
+    rm "${file}"
+    image_name="docker.elastic.co/apm/${name}:${version}"
+  fi
+
   docker run -d \
     --name="${APM_SERVER_NAME}" \
     --network="${NETWORK}" \
@@ -43,5 +57,5 @@ else
     -e "ES_HOST=${ES_HOST}" \
     -e "ES_PORT=${ES_PORT}" \
     -v "$(pwd)/docker/apm_server/apm-server.yml:/usr/share/apm-server/apm-server.yml" \
-    --rm "docker.elastic.co/apm/apm-server:${APM_SERVER_VERSION}"
+    --rm "${image_name}"
 fi

--- a/docker/elasticsearch/start.sh
+++ b/docker/elasticsearch/start.sh
@@ -2,13 +2,30 @@
 
 set -ex
 
-if [[ -z ${ES_NAME} ]] || [[ -z ${ES_VERSION} ]] || [[ -z ${ES_PORT} ]]; then
-  echo "ES_NAME, ES_VERSION and ES_PORT expected"
+if [[ -z ${ES_NAME} ]] || 
+   [[ -z ${ES_VERSION} ]] || 
+   [[ -z ${ES_VERSION_STATE} ]] || 
+   [[ -z ${ES_PORT} ]]; then
+  echo "ES_NAME, ES_VERSION, ES_VERSION_STATE and ES_PORT expected"
   exit 2
 fi
 if [[ -z ${NETWORK} ]]; then
   echo "NETWORK expected"
   exit 2
+fi
+
+image_name="docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}"
+
+if [[ ${ES_VERSION_STATE} == "snapshot" ]]; then
+  registry="https://snapshots.elastic.co/docker/"
+  name="elasticsearch"
+  version="${ES_VERSION}-SNAPSHOT"
+  file_type="tar.gz"
+  file="${name}-${version}.${file_type}"
+  wget "${registry}${file}"
+  docker load -i "${file}"
+  rm "${file}"
+  image_name="docker.elastic.co/elasticsearch/${name}:${version}"
 fi
 
 docker run -d \
@@ -21,4 +38,4 @@ docker run -d \
   -e "transport.host=0.0.0.0"\
   -e "http.host=0.0.0.0"\
   -e "xpack.security.enabled=${ES_XPACK:-false}" \
-  --rm docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+  --rm "${image_name}"

--- a/docker/kibana/start.sh
+++ b/docker/kibana/start.sh
@@ -16,6 +16,19 @@ if [[ -z ${NETWORK} ]]; then
 fi
 
 
+image_name="docker.elastic.co/kibana/kibana:${KIBANA_VERSION}"
+
+if [[ ${KIBANA_VERSION_STATE} == "snapshot" ]]; then
+  registry="https://snapshots.elastic.co/docker/"
+  name="kibana"
+  version="${KIBANA_VERSION}-SNAPSHOT"
+  file_type="tar.gz"
+  file="${name}-${version}.${file_type}"
+  wget "${registry}${file}"
+  docker load -i "${file}"
+  rm "${file}"
+  image_name="docker.elastic.co/kibana/${name}:${version}"
+fi
 docker run -d \
   --name="${KIBANA_HOST}" \
   --network="${NETWORK}" \
@@ -25,4 +38,4 @@ docker run -d \
   -e "http.host=0.0.0.0"\
   -e "xpack.security.enabled=${KIBANA_XPACK:-false}" \
   -e "elasticsearch.url=${ES_URL}" \
-  --rm "docker.elastic.co/kibana/kibana:${KIBANA_VERSION}"
+  --rm "${image_name}"

--- a/scripts/start_services.py
+++ b/scripts/start_services.py
@@ -13,7 +13,7 @@ def elasticsearch():
         os.environ['ES_NAME'] = 'elasticsearch'
         os.environ['ES_URL'] = "http://elasticsearch:{}".format(
             os.environ['ES_PORT'])
-        set_version('ES_VERSION', "6.1.1", "release")
+        set_version('ES_VERSION', "6.2.0", "snapshot")
         start("docker/elasticsearch/start.sh")
     else:
         parsed_url = urlparse(os.environ['ES_URL'])
@@ -28,7 +28,7 @@ def kibana():
         os.environ['KIBANA_HOST'] = 'kibana'
         os.environ['KIBANA_URL'] = "http://kibana:{}".format(
             os.environ['KIBANA_PORT'])
-        set_version('KIBANA_VERSION', "6.1.1", "release")
+        set_version('KIBANA_VERSION', "6.2.0", "snapshot")
         start("docker/kibana/start.sh")
     return os.environ['KIBANA_URL']
 

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,3 +1,4 @@
 APM_SERVER:
   - 'github;master'
   - 'github;6.x'
+  - 'snapshot;6.2.0'


### PR DESCRIPTION
Enable automated integration testing for the `6.2` stack also for Kibana and Elasticsearch.

- If `version_state==snapshot`, download latest snapshot from registry and load docker image from it. 
- Make version 6.2.0 default version for Elasticsearch and Kibana. 

As we are probably going to rewrite the dockerization to use docker-compose similar to the manual testing script I did only change as much as necessary to have the automated tests run with version 6.2.

closes #44 

