### PR TITLE
Increase start timeout for docker services

### DIFF
--- a/scripts/wait_until_services_running.py
+++ b/scripts/wait_until_services_running.py
@@ -5,7 +5,7 @@ import requests
 import timeout_decorator
 
 
-@timeout_decorator.timeout(90)
+@timeout_decorator.timeout(180)
 def wait_until_setup(url):
     def call_service():
         try:


### PR DESCRIPTION
As snapshots have to be downloaded first, timeout needs to be increased.