### PR TITLE
use `docker-compose build` to build images instead of `--build` flag

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1806,7 +1806,7 @@ class LocalSetup(object):
             print("Starting stack services..\n")
             cmd = ['docker-compose', '-f', docker_compose_path.name, 'up', '-d']
             if args["force_build"]:
-                cmd.append("--build")
+                subprocess.call(['docker-compose', '-f', docker_compose_path.name, 'build', '--pull'])
             subprocess.call(cmd)
 
     @staticmethod


### PR DESCRIPTION
When using the `--build` flag, docker-compose will only pull images if
it doesn't have a matching image locally. But since we update the
opbeans images semi-often, we want to ensure that the newest version
is always pulled. This is what `docker-compose build --pull` does.

@graphaelli any reason we don't _always_ build the images? That's what we did in localtesting. With the layer cache, it takes only a second or two if everything is current, and I suspect it would save us from countless hours of people wondering and trying to debug why they don't have the current version of the different opbeans variations running.