### PR TITLE
Ruby agent return filtered payload.

### DIFF
--- a/docker/ruby/rails/testapp/config.ru
+++ b/docker/ruby/rails/testapp/config.ru
@@ -6,6 +6,7 @@ ElasticAPM.add_filter(:healthcheck) do |payload|
   payload[:transactions]&.reject! do |t| 
     t[:name] == 'ApplicationController#healthcheck' 
   end
+  payload
 end
 
 run Rails.application


### PR DESCRIPTION
When adding a filter for the ruby agent,
return the filtered payload,
instead of the rejected elements.