### PR TITLE
collect logs with filebeat

### DIFF
--- a/docker/filebeat/filebeat.simple.yml
+++ b/docker/filebeat/filebeat.simple.yml
@@ -1,0 +1,21 @@
+setup.template.settings:
+  index.number_of_shards: 1
+  index.codec: best_compression
+  index.number_of_replicas: 0
+
+setup.dashboards.enabled: true
+
+setup.kibana:
+  host: "kibana:5601"
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+
+filebeat.prospectors:
+  - type: log
+    paths:
+     - '/var/lib/docker/containers/*/*.log'
+    json.message_key: log
+    json.overwrite_keys: true
+    json.keys_under_root: false
+    json.add_error_key: true

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -41,6 +41,26 @@ filebeat.autodiscover:
                   fields: ["message"]
                   target: "filebeat"
       - condition:
+          contains:
+            docker.container.image: "opbeans-node"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            multiline.pattern: '^ '
+            multiline.negate: false
+            multiline.match: after
+      - condition:
+          contains:
+            docker.container.image: "postgres"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            multiline.pattern: '^\t'
+            multiline.negate: false
+            multiline.match: after
+      - condition:
           and:
             - not:
                 contains:
@@ -48,6 +68,12 @@ filebeat.autodiscover:
             - not:
                 contains:
                   docker.container.image: "filebeat"
+            - not:
+                contains:
+                  docker.container.image: "opbeans-node"
+            - not:
+                contains:
+                  docker.container.image: "postgres"
         config:
           - type: docker
             containers.ids:

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -42,6 +42,17 @@ filebeat.autodiscover:
                   target: "filebeat"
       - condition:
           contains:
+            docker.container.image: "kibana"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            processors:
+              - decode_json_fields:
+                  fields: ["message"]
+                  target: "kibana"
+      - condition:
+          contains:
             docker.container.image: "opbeans-node"
         config:
           - type: docker
@@ -68,6 +79,9 @@ filebeat.autodiscover:
             - not:
                 contains:
                   docker.container.image: "filebeat"
+            - not:
+                contains:
+                  docker.container.image: "kibana"
             - not:
                 contains:
                   docker.container.image: "opbeans-node"

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -1,0 +1,54 @@
+setup.template.settings:
+  index.number_of_shards: 1
+  index.codec: best_compression
+  index.number_of_replicas: 0
+
+setup.dashboards.enabled: true
+
+setup.kibana:
+  host: "kibana:5601"
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+
+logging.json: true
+logging.metrics.enabled: false
+
+filebeat.autodiscover:
+  providers:
+    - type: docker
+      templates:
+      - condition:
+          contains:
+            docker.container.image: "apm-server"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            processors:
+              - decode_json_fields:
+                  fields: ["message"]
+                  target: "apm-server"
+      - condition:
+          contains:
+            docker.container.image: "filebeat"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            processors:
+              - decode_json_fields:
+                  fields: ["message"]
+                  target: "filebeat"
+      - condition:
+          and:
+            - not:
+                contains:
+                  docker.container.image: "apm-server"
+            - not:
+                contains:
+                  docker.container.image: "filebeat"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"


### PR DESCRIPTION
In version 6.1+, use docker autodiscovery and parse logs for apm-server
and filebeat.