### PR TITLE
healthcheck as postgres user

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -514,7 +514,7 @@ class Postgres(Service):
     def _content(self):
         return dict(
             environment=["POSTGRES_DB=opbeans", "POSTGRES_PASSWORD=verysecure"],
-            healthcheck={"interval": "10s", "test": ["CMD", "pg_isready", "-h", "postgres"]},
+            healthcheck={"interval": "10s", "test": ["CMD", "pg_isready", "-h", "postgres", "-U", "postgres"]},
             image="postgres:10",
             labels=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT, expose=True)],
@@ -1707,7 +1707,7 @@ class PostgresServiceTest(ServiceTest):
                         - pgdata:/var/lib/postgresql/data
                     healthcheck:
                         interval: 10s
-                        test: ["CMD", "pg_isready", "-h", "postgres"]""")
+                        test: ["CMD", "pg_isready", "-h", "postgres", "-U", "postgres"]""")
         )
 
 


### PR DESCRIPTION
instead of root user, which worked but triggered these logs with each invocation:
```
[244] FATAL:  password authentication failed for user "root"
[244] DETAIL:  Role "root" does not exist.
Connection matched pg_hba.conf line 95: "host all all all md5"
```