### PR TITLE
pin base image to Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 # install latest Google Chrome & Chromedriver
 RUN curl -SLO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \


### PR DESCRIPTION
pyyaml==3.12 fails to build on Python 3.7, a newer release is not yet
available.