### PR TITLE
configure logstash to use processor name in apm index

### DIFF
--- a/docker/logstash/pipeline/apm.conf
+++ b/docker/logstash/pipeline/apm.conf
@@ -12,9 +12,21 @@ input {
   }
 }
 
+filter {
+  if ![processor] {
+    mutate {
+      add_field => { "[@metadata][index_suffix]" => "" }
+    }
+  } else {
+    mutate {
+      add_field => { "[@metadata][index_suffix]" => "-%{[processor][event]}" }
+    }
+  }
+}
+
 output {
   elasticsearch {
     hosts => ["elasticsearch:9200"]
-    index => "apm-%{[beat][version]}-%{+YYYY.MM.dd}"
+    index => "apm-%{[beat][version]}%{[@metadata][index_suffix]}-%{+YYYY.MM.dd}"
   }
 }


### PR DESCRIPTION
to match the [default apm-server.yml configuration](https://github.com/elastic/apm-server/blob/94ec6fdf34b4af8bd79dad68866f354eb394cfaf/apm-server.yml#L331-L350).