### PR TITLE
chore: use renamed pm2 command

### DIFF
--- a/docker/opbeans/node/Dockerfile
+++ b/docker/opbeans/node/Dockerfile
@@ -6,5 +6,5 @@ RUN npm install pm2@2 -g
 COPY entrypoint.sh /app/entrypoint.sh
 COPY processes.config.js /app/processes.config.js
 
-CMD ["pm2-docker", "processes.config.js"]
+CMD ["pm2-runtime", "processes.config.js"]
 ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]


### PR DESCRIPTION
These commands come from the `pm2` npm package: http://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/#docker-integration

It used to be pm2-docker, but was renamed pm2-runtime. The old one still works, but who knows for how long:

![image](https://user-images.githubusercontent.com/10602/43162190-8c895040-8f8a-11e8-850d-050d0cef8aca.png)
