### PR TITLE
only add flavour flags for services that are part of the Elastic Stack

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -156,6 +156,8 @@ def parse_version(version):
 class Service(object):
     """encapsulate docker-compose service definition"""
 
+    is_stack_component = False
+
     def __init__(self, **options):
         self.options = options
 
@@ -270,20 +272,21 @@ class Service(object):
                 dest=cls.option_name() + '_port',
                 help="service port"
             )
-        for image_detail_key in ("bc", "version"):
-            parser.add_argument(
-                "--" + cls.name() + "-" + image_detail_key,
-                type=str,
-                dest=cls.option_name() + "_" + image_detail_key,
-                help="stack {} override".format(image_detail_key),
-            )
-        for image_detail_key in ("oss", "release", "snapshot"):
-            parser.add_argument(
-                "--" + cls.name() + "-" + image_detail_key,
-                action="store_true",
-                dest=cls.option_name() + "_" + image_detail_key,
-                help="stack {} override".format(image_detail_key),
-            )
+        if cls.is_stack_component:
+            for image_detail_key in ("bc", "version"):
+                parser.add_argument(
+                    "--" + cls.name() + "-" + image_detail_key,
+                    type=str,
+                    dest=cls.option_name() + "_" + image_detail_key,
+                    help="stack {} override".format(image_detail_key),
+                )
+            for image_detail_key in ("oss", "release", "snapshot"):
+                parser.add_argument(
+                    "--" + cls.name() + "-" + image_detail_key,
+                    action="store_true",
+                    dest=cls.option_name() + "_" + image_detail_key,
+                    help="stack {} override".format(image_detail_key),
+                )
 
     def image_download_url(self):
         pass
@@ -323,6 +326,7 @@ class DockerLoadableService(object):
 #
 class ApmServer(DockerLoadableService, Service):
     docker_path = "apm"
+    is_stack_component = True
 
     SERVICE_PORT = 8200
     DEFAULT_MONITOR_PORT = "6060"
@@ -411,6 +415,7 @@ class Elasticsearch(DockerLoadableService, Service):
         "-Xms": "1g",
         "-Xmx": "1g",
     }
+    is_stack_component = True
 
     SERVICE_PORT = 9200
 
@@ -458,6 +463,7 @@ class Elasticsearch(DockerLoadableService, Service):
 
 class Filebeat(DockerLoadableService, Service):
     docker_path = "beats"
+    is_stack_component = True
 
     def __init__(self, **options):
         super(Filebeat, self).__init__(**options)
@@ -483,6 +489,7 @@ class Filebeat(DockerLoadableService, Service):
 
 class Kibana(DockerLoadableService, Service):
     default_environment = {"SERVER_NAME": "kibana.example.org", "ELASTICSEARCH_URL": "http://elasticsearch:9200"}
+    is_stack_component = True
 
     SERVICE_PORT = 5601
 
@@ -511,6 +518,7 @@ class Kibana(DockerLoadableService, Service):
 
 class Logstash(DockerLoadableService, Service):
     SERVICE_PORT = 5044
+    is_stack_component = True
 
     def _content(self):
         return dict(
@@ -524,6 +532,7 @@ class Logstash(DockerLoadableService, Service):
 
 class Metricbeat(DockerLoadableService, Service):
     docker_path = "beats"
+    is_stack_component = True
 
     def _content(self):
         return dict(


### PR DESCRIPTION
this removes a lot of meaningless flags (e.g. `--opbeans-node-oss`) from
the config options