### PR TITLE
chore: unpin pm2 for opbeans-node

### DIFF
--- a/docker/opbeans/node/Dockerfile
+++ b/docker/opbeans/node/Dockerfile
@@ -1,7 +1,7 @@
 FROM opbeans/opbeans-node:latest
 
 ENV NODE_ENV=production
-RUN npm install pm2@2 -g
+RUN npm install pm2 -g
 
 COPY entrypoint.sh /app/entrypoint.sh
 COPY processes.config.js /app/processes.config.js


### PR DESCRIPTION
The bug with pm2 v3 have now been fixed:
https://github.com/Unitech/pm2/pull/3826