### PR TITLE
use opbeans/opbeans-go base image for the opbeans-go service

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -1,23 +1,11 @@
-FROM golang:1.10
-ARG GO_AGENT_BRANCH=master
-ARG GO_AGENT_REPO=elastic/apm-agent-go
+FROM opbeans/opbeans-go:latest
 
-WORKDIR /go/src/github.com/elastic/apm-agent-go
-RUN curl -L https://github.com/$GO_AGENT_REPO/archive/$GO_AGENT_BRANCH.tar.gz | tar --strip-components=1 -xzv
-
-WORKDIR /go/src/github.com/elastic/opbeans-go
-RUN curl -L https://github.com/elastic/opbeans-go/archive/master.tar.gz | tar --strip-components=1 -xzv
-RUN CGO_ENABLED=0 go get -v
-
-FROM alpine:latest
-COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
-COPY --from=0 /go/bin/opbeans-go /
 ENV OPBEANS_CACHE=inmem
-ENV OPBEANS_PORT=3003
+ENV OPBEANS_PORT=3000
 EXPOSE $OPBEANS_PORT
 
 HEALTHCHECK \
   --interval=10s --retries=10 --timeout=3s \
-  CMD /opbeans-go -healthcheck localhost:${OPBEANS_PORT}
+  CMD ["/opbeans-go", "-healthcheck", "localhost:3000"]
 
-CMD /opbeans-go -listen=:$OPBEANS_PORT -frontend=/opbeans-frontend -db=postgres: -cache=$OPBEANS_CACHE
+CMD ["/opbeans-go", "-listen=:3000", "-frontend=/opbeans-frontend", "-db=postgres:", "-cache=redis://redis:6379"]

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -859,7 +859,7 @@ class OpbeansGo(OpbeansService):
                 "ELASTIC_APM_SAMPLE_RATE=1",
                 "ELASTICSEARCH_URL=http://elasticsearch:9200",
                 "OPBEANS_CACHE=redis://redis:6379",
-                "OPBEANS_PORT={:d}".format(self.SERVICE_PORT),
+                "OPBEANS_PORT=3000",
                 "PGHOST=postgres",
                 "PGPORT=5432",
                 "PGUSER=postgres",
@@ -869,7 +869,7 @@ class OpbeansGo(OpbeansService):
             depends_on=depends_on,
             image=None,
             labels=None,
-            ports=[self.publish_port(self.port, self.SERVICE_PORT)],
+            ports=[self.publish_port(self.port, 3000)],
         )
         return content
 
@@ -1660,7 +1660,7 @@ class OpbeansServiceTest(ServiceTest):
                         - GO_AGENT_REPO=elastic/apm-agent-go
                     container_name: localtesting_6.3.10_opbeans-go
                     ports:
-                      - "127.0.0.1:3003:3003"
+                      - "127.0.0.1:3003:3000"
                     environment:
                       - ELASTIC_APM_SERVER_URL=http://apm-server:8200
                       - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
@@ -1669,7 +1669,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_SAMPLE_RATE=1
                       - ELASTICSEARCH_URL=http://elasticsearch:9200
                       - OPBEANS_CACHE=redis://redis:6379
-                      - OPBEANS_PORT=3003
+                      - OPBEANS_PORT=3000
                       - PGHOST=postgres
                       - PGPORT=5432
                       - PGUSER=postgres


### PR DESCRIPTION
also, hardcode internal port to 3000

Unfortunately I had to hardcode port and cache URL in the `CMD`, since the image is based on the "Distroless", which lacks `/bin/sh`, which is needed for environment variable interpolation in `CMD`...