### PR TITLE
add healthcheck to go integration test app

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -8,4 +8,5 @@ FROM alpine:latest
 RUN apk add --update curl && rm -rf /var/cache/apk/*
 COPY --from=0 /go/src/testapp/testapp /
 EXPOSE 8080
+ENV ELASTIC_APM_IGNORE_URLS /healthcheck
 CMD ["/testapp"]

--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -5,6 +5,7 @@ RUN go get github.com/elastic/apm-agent-go
 RUN CGO_ENABLED=0 go build
 
 FROM alpine:latest
+RUN apk add --update curl && rm -rf /var/cache/apk/*
 COPY --from=0 /go/src/testapp/testapp /
 EXPOSE 8080
 CMD ["/testapp"]


### PR DESCRIPTION
non-issue so far but could possibly cause flakiness if tests are able to start running before the container is ready.