### PR TITLE
make dashboard loading depend on kibana

### DIFF
--- a/docker/filebeat/filebeat.simple.yml
+++ b/docker/filebeat/filebeat.simple.yml
@@ -3,13 +3,14 @@ setup.template.settings:
   index.codec: best_compression
   index.number_of_replicas: 0
 
-setup.dashboards.enabled: true
-
 setup.kibana:
   host: "kibana:5601"
 
 output.elasticsearch:
   hosts: ["elasticsearch:9200"]
+
+logging.json: true
+logging.metrics.enabled: false
 
 filebeat.prospectors:
   - type: log

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -3,8 +3,6 @@ setup.template.settings:
   index.codec: best_compression
   index.number_of_replicas: 0
 
-setup.dashboards.enabled: true
-
 setup.kibana:
   host: "kibana:5601"
 

--- a/docker/metricbeat/metricbeat.yml
+++ b/docker/metricbeat/metricbeat.yml
@@ -1,13 +1,7 @@
-metricbeat.config.modules:
-  path: /dev/null
-  reload.enabled: false
-
 setup.template.settings:
   index.number_of_shards: 1
   index.codec: best_compression
   index.number_of_replicas: 0
-
-setup.dashboards.enabled: true
 
 setup.kibana:
   host: "kibana:5601"
@@ -22,6 +16,10 @@ xpack.monitoring.enabled: true
 ###################################################################################################
 ## modules
 ###################################################################################################
+metricbeat.config.modules:
+  path: /dev/null
+  reload.enabled: false
+
 metricbeat.modules:
 - module: golang
   metricsets: ["expvar","heap"]

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -399,7 +399,7 @@ class ApmServer(StackService, Service):
             "--no-apm-server-dashboards",
             action="store_false",
             dest="apm_server_dashboards",
-            help="apm-server output",
+            help="skip loading apm-server dashboards (setup.dashboards.enabled=false)",
         )
 
     def _content(self):


### PR DESCRIPTION
* load apm-server dashboards by default for now, probably to default to false for >= 6.5

closes #161 