### PR TITLE
add --kibana-with-canvas option

### DIFF
--- a/docker/kibana/Dockerfile
+++ b/docker/kibana/Dockerfile
@@ -1,0 +1,5 @@
+ARG kibana_base_image=docker.elastic.co/kibana/kibana:7.0.0-alpha1-SNAPSHOT
+
+FROM ${kibana_base_image}
+ARG kibana_canvas_version=2174
+RUN /bin/bash -c "NODE_OPTIONS='--max-old-space-size=4096' ./bin/kibana-plugin install https://download.elastic.co/kibana/canvas/kibana-canvas-0.1.${kibana_canvas_version}.zip"

--- a/docker/kibana/Dockerfile
+++ b/docker/kibana/Dockerfile
@@ -2,4 +2,4 @@ ARG kibana_base_image=docker.elastic.co/kibana/kibana:7.0.0-alpha1-SNAPSHOT
 
 FROM ${kibana_base_image}
 ARG kibana_canvas_version=2174
-RUN /bin/bash -c "NODE_OPTIONS='--max-old-space-size=4096' ./bin/kibana-plugin install https://download.elastic.co/kibana/canvas/kibana-canvas-0.1.${kibana_canvas_version}.zip"
+RUN /bin/bash -c "NODE_OPTIONS='--max-old-space-size=4096' ./bin/kibana-plugin install https://download.elastic.co/kibana/canvas/kibana-canvas-${kibana_canvas_version}.zip"

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -526,11 +526,15 @@ class Kibana(StackService, Service):
     @classmethod
     def add_arguments(cls, parser):
         super(Kibana, cls).add_arguments(parser)
+        canvas_default_version = "0.1.2174"
         parser.add_argument(
             "--kibana-with-canvas",
-            const="2174",
+            const=canvas_default_version,
             nargs="?",
-            help="build custom kibana image with canvas",
+            help=(
+                "build custom kibana image with canvas, "
+                "override default version {!r} by providing an argument.".format(canvas_default_version)
+            ),
         )
 
     def _content(self):

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -514,6 +514,7 @@ class Kibana(StackService, Service):
 
     def __init__(self, **options):
         super(Kibana, self).__init__(**options)
+        self.kibana_with_canvas = options.get("kibana_with_canvas")
         if not self.at_least_version("6.3") and not self.oss:
             self.docker_name = self.name() + "-x-pack"
         self.environment = self.default_environment.copy()
@@ -522,13 +523,35 @@ class Kibana(StackService, Service):
             if self.at_least_version("6.3"):
                 self.environment["XPACK_XPACK_MAIN_TELEMETRY_ENABLED"] = "false"
 
+    @classmethod
+    def add_arguments(cls, parser):
+        super(Kibana, cls).add_arguments(parser)
+        parser.add_argument(
+            "--kibana-with-canvas",
+            const="2174",
+            nargs="?",
+            help="build custom kibana image with canvas",
+        )
+
     def _content(self):
-        return dict(
+        content = dict(
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "kibana", path="/", interval="5s", retries=20),
             depends_on={"elasticsearch": {"condition": "service_healthy"}},
             environment=self.environment,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
+        if self.kibana_with_canvas:
+            content.update({
+                "build": {
+                    "context": "docker/kibana",
+                    "args": {
+                        "kibana_base_image": self.default_image(),
+                        "kibana_canvas_version": self.kibana_with_canvas,
+                    }
+                },
+                "image": None,
+            })
+        return content
 
     @staticmethod
     def enabled():

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -403,6 +403,14 @@ class KafkaServiceTest(ServiceTest):
 
 
 class KibanaServiceTest(ServiceTest):
+    def test_canvas(self):
+        kibana = Kibana(version="6.4.0", release=True, kibana_with_canvas="0.1.2").render()["kibana"]
+        self.assertIsNone(kibana.get("image"))
+        self.assertDictEqual(kibana["build"], {
+            'args': {'kibana_base_image': 'docker.elastic.co/kibana/kibana:6.4.0',
+                     'kibana_canvas_version': '0.1.2'},
+            'context': 'docker/kibana'})
+
     def test_6_2_release(self):
         kibana = Kibana(version="6.2.4", release=True).render()
         self.assertEqual(


### PR DESCRIPTION
#167 demonstrated a straightforward path to customizing container images.  Here's one for adding canvas to kibana.

## Example usage

```
./scripts/compose.py start 6.4 --release --kibana-with-canvas
```

builds `apm-integration-testing_kibana` from `docker.elastic.co/kibana/kibana:6.4.0`

`--kibana-with-canvas` takes an optional argument to use a different build version.