### PR TITLE
Multiple apm servers

### DIFF
--- a/docker/apm-server/haproxy/Dockerfile
+++ b/docker/apm-server/haproxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM haproxy:1.8
+
+COPY docker-entrypoint.sh /

--- a/docker/apm-server/haproxy/docker-entrypoint.sh
+++ b/docker/apm-server/haproxy/docker-entrypoint.sh
@@ -22,11 +22,12 @@ frontend http
 backend servers
     mode http
     balance roundrobin
+    option httpchk HEAD /healthcheck HTTP/1.0
 EOF
 
 for ((i=1; i<=$backends; i++)); do
 cat >> $config <<EOF
-    server apm-server-${i} apm-server-${i}:8200
+    server apm-server-${i} apm-server-${i}:8200 check fall 3 rise 2
 EOF
 done
 

--- a/docker/apm-server/haproxy/docker-entrypoint.sh
+++ b/docker/apm-server/haproxy/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+backends=${APM_SERVER_COUNT:-1}
+
+config=/usr/local/etc/haproxy/haproxy.cfg
+
+# generate configuration file
+cat > $config <<EOF
+defaults
+    timeout connect 1h
+    timeout client  1h
+    timeout server  1h
+
+frontend http
+    bind *:8200
+    mode http
+    default_backend servers
+    stats enable
+
+backend servers
+    mode http
+    balance roundrobin
+EOF
+
+for ((i=1; i<=$backends; i++)); do
+cat >> $config <<EOF
+    server apm-server-${i} apm-server-${i}:8200
+EOF
+done
+
+exec "$@"

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -392,7 +392,7 @@ class ApmServer(StackService, Service):
             cap_drop=["ALL"],
             command=["apm-server", "-e", "--httpprof", ":{}".format(self.apm_server_monitor_port)] + command_args,
             depends_on=self.depends_on,
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, "apm-server"),
+            healthcheck=curl_healthcheck(self.SERVICE_PORT),
             labels=["co.elatic.apm.stack-version=" + self.version],
             ports=[
                 self.publish_port(self.port, self.SERVICE_PORT),

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -303,7 +303,7 @@ class StackService(object):
 class ApmServer(StackService, Service):
     docker_path = "apm"
 
-    SERVICE_PORT = 8200
+    SERVICE_PORT = "8200"
     DEFAULT_MONITOR_PORT = "6060"
     DEFAULT_OUTPUT = "elasticsearch"
     OUTPUTS = {"elasticsearch", "kafka", "logstash"}
@@ -362,6 +362,8 @@ class ApmServer(StackService, Service):
                     ("output.logstash.hosts", "[\"logstash:5044\"]"),
                 ])
 
+        self.apm_server_count = options.get("apm_server_count", 1)
+
     @classmethod
     def add_arguments(cls, parser):
         super(ApmServer, cls).add_arguments(parser)
@@ -374,6 +376,12 @@ class ApmServer(StackService, Service):
             choices=cls.OUTPUTS,
             default='elasticsearch',
             help='apm-server output'
+        )
+        parser.add_argument(
+            '--apm-server-count',
+            type=int,
+            default=1,
+            help="apm-server count. >1 adds a load balancer service to round robin traffic between servers.",
         )
         parser.add_argument(
             "--no-apm-server-dashboards",
@@ -421,6 +429,39 @@ class ApmServer(StackService, Service):
     @staticmethod
     def enabled():
         return True
+
+    def render(self):
+        """hack up render to support multiple apm servers behind a load balancer"""
+        ren = super(ApmServer, self).render()
+        if self.apm_server_count == 1:
+            return ren
+
+        # save a single server for use as backend template
+        single = ren[self.name()]
+        single["ports"] = [p.rsplit(":", 1)[-1] for p in single["ports"]]
+
+        # render proxy + backends
+        ren = self.render_proxy()
+        # individualize each backend instance
+        for i in range(1, self.apm_server_count+1):
+            backend = dict(single)
+            backend["container_name"] = backend["container_name"] + "-" + str(i)
+            ren.update({"-".join([self.name(), str(i)]): backend})
+        return ren
+
+    def render_proxy(self):
+        condition = {"condition": "service_healthy"}
+        content = dict(
+            build={"context": "docker/apm-server/haproxy"},
+            container_name=self.default_container_name() + "-load-balancer",
+            depends_on={"apm-server-{}".format(i): condition for i in range(1, self.apm_server_count + 1)},
+            environment={"APM_SERVER_COUNT": self.apm_server_count},
+            healthcheck={"test": ["CMD", "haproxy", "-c", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]},
+            ports=[
+                self.publish_port(self.port, self.SERVICE_PORT),
+            ],
+        )
+        return {self.name(): content}
 
 
 class Elasticsearch(StackService, Service):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -438,7 +438,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://apm-server:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:6.2.10-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=6.2.10]
                 logging:
@@ -517,7 +517,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://apm-server:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:6.3.10-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=6.3.10]
                 logging:
@@ -597,7 +597,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://apm-server:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:7.0.10-alpha1-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=7.0.10-alpha1]
                 logging:

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -265,6 +265,14 @@ class ApmServerServiceTest(ServiceTest):
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 
+    def test_apm_server_count(self):
+        render = ApmServer(version="6.4.100", apm_server_count=2).render()
+        apm_server_lb = render["apm-server"]
+        apm_server_2 = render["apm-server-2"]
+        self.assertIn("build", apm_server_lb)
+        self.assertListEqual(["127.0.0.1:8200:8200"], apm_server_lb["ports"], apm_server_lb["ports"])
+        self.assertListEqual(["8200", "6060"], apm_server_2["ports"], apm_server_2["ports"])
+
     def test_apm_server_custom_port(self):
         custom_port = "8203"
         apm_server = ApmServer(version="6.3.100", apm_server_port=custom_port).render()["apm-server"]


### PR DESCRIPTION
While developing the monitoring UI, it's helpful to have multiple apm-servers report metrics to ensure the UI is still usable.

This change introduces an `--apm-server-count` option to start multiple apm servers fronted by a round robin haproxy load balancer.  http://localhost:8200/haproxy?stats is the only URL not proxied to the backend set.

cc @chrisronline