### PR TITLE
 give --service-release precedence over global --bc

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -265,7 +265,7 @@ class StackService(object):
 
     def image_download_url(self):
         # Elastic releases are public
-        if not self.bc:
+        if self.release or not self.bc:
             return
 
         version = self.version

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -760,6 +760,33 @@ class LocalTest(unittest.TestCase):
                 'https://staging.elastic.co/6.9.5-abcd1234/docker/elasticsearch-6.9.5.tar.gz',
                 'https://staging.elastic.co/6.9.5-abcd1234/docker/kibana-6.9.5.tar.gz'
             },
+            image_cache_dir)\
+
+    @mock.patch(compose.__name__ + '.load_images')
+    def test_start_bc_with_release(self, mock_load_images):
+        docker_compose_yml = stringIO()
+        image_cache_dir = "/foo"
+        version = "6.9.5"
+        apm_server_version = "6.2.4"
+        bc = "abcd1234"
+        self.assertNotIn(version, LocalSetup.SUPPORTED_VERSIONS)
+        setup = LocalSetup(
+            argv=["start", version, "--bc" , bc, "--docker-compose-path", "-", "--image-cache-dir", image_cache_dir,
+                  "--apm-server-version", apm_server_version, "--apm-server-release"])
+        setup.set_docker_compose_path(docker_compose_yml)
+        setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        services = got["services"]
+        self.assertEqual(
+            "docker.elastic.co/apm/apm-server:{}".format(apm_server_version),
+            services["apm-server"]["image"]
+        )
+        mock_load_images.assert_called_once_with(
+            {
+                'https://staging.elastic.co/6.9.5-abcd1234/docker/elasticsearch-6.9.5.tar.gz',
+                'https://staging.elastic.co/6.9.5-abcd1234/docker/kibana-6.9.5.tar.gz'
+            },
             image_cache_dir)
 
     def test_docker_download_image_url(self):


### PR DESCRIPTION
Fixes:
```
./scripts/compose.py start 6.4.1 --bc 38edca33 --apm-server-version=6.2.4 --apm-server-release 
```
which otherwise throws:
```
Error while fetching https://staging.elastic.co/6.2.4-38edca33/docker/apm-server-6.2.4.tar.gz: HTTP Error 404: Not Found
```