### PR TITLE
use /api/status for kibana healthcheck, and use --fail for the curl cmd

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -114,7 +114,7 @@ def curl_healthcheck(port, host="localhost", path="/healthcheck",
     return {
                 "interval": interval,
                 "retries": retries,
-                "test": ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null",
+                "test": ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null",
                          "http://{}:{}{}".format(host, port, path)]
             }
 
@@ -580,7 +580,7 @@ class Kibana(StackService, Service):
 
     def _content(self):
         content = dict(
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, "kibana", path="/", interval="5s", retries=20),
+            healthcheck=curl_healthcheck(self.SERVICE_PORT, "kibana", path="/api/status", interval="5s", retries=20),
             depends_on={"elasticsearch": {"condition": "service_healthy"}},
             environment=self.environment,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -114,7 +114,8 @@ def curl_healthcheck(port, host="localhost", path="/healthcheck",
     return {
                 "interval": interval,
                 "retries": retries,
-                "test": ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null",
+                "test": ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent",
+                         "--output", "/dev/null",
                          "http://{}:{}{}".format(host, port, path)]
             }
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -444,7 +444,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:6.2.10-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=6.2.10]
                 logging:
@@ -478,7 +478,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 20
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://kibana:5601/']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana-x-pack:6.2.10-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=6.2.10]
                 logging:
@@ -523,7 +523,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:6.3.10-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=6.3.10]
                 logging:
@@ -557,7 +557,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 20
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://kibana:5601/']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana:6.3.10-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=6.3.10]
                 logging:
@@ -603,7 +603,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:7.0.10-alpha1-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=7.0.10-alpha1]
                 logging:
@@ -637,7 +637,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 20
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --silent, --output, /dev/null, 'http://kibana:5601/']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana:7.0.10-alpha1-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=7.0.10-alpha1]
                 logging:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -127,7 +127,7 @@ class OpbeansServiceTest(ServiceTest):
                     volumes:
                       - .:/local-install
                     healthcheck:
-                      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-java:3000/"]
+                      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-java:3000/"]
                       interval: 5s
                       retries: 12""")  # noqa: 501
         )
@@ -177,7 +177,7 @@ class OpbeansServiceTest(ServiceTest):
                         apm-server:
                             condition: service_healthy
                     healthcheck:
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-node:3000/"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-node:3000/"]
                         interval: 5s
                         retries: 12
                     volumes:
@@ -231,7 +231,7 @@ class OpbeansServiceTest(ServiceTest):
                     volumes:
                         - .:/local-install
                     healthcheck:
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
                         interval: 5s
                         retries: 12
             """)  # noqa: 501
@@ -296,7 +296,7 @@ class OpbeansServiceTest(ServiceTest):
                     volumes:
                       - .:/local-install
                     healthcheck:
-                      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-ruby:3000/"]
+                      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-ruby:3000/"]
                       interval: 5s
                       retries: 100""")  # noqa: 501
 
@@ -326,7 +326,7 @@ class OpbeansServiceTest(ServiceTest):
                          opbeans-node:
                              condition: service_healthy
                      healthcheck:
-                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-rum:9222/"]
+                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-rum:9222/"]
                          interval: 5s
                          retries: 12""")  # noqa: 501
         )

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -35,7 +35,7 @@ class AgentServiceTest(ServiceTest):
                     healthcheck:
                         interval: 5s
                         retries: 12
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://gonethttpapp:8080/healthcheck"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://gonethttpapp:8080/healthcheck"]
                     ports:
                         - 127.0.0.1:8080:8080
             """)  # noqa: 501
@@ -58,7 +58,7 @@ class AgentServiceTest(ServiceTest):
                     healthcheck:
                         interval: 5s
                         retries: 12
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://expressapp:8010/healthcheck"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://expressapp:8010/healthcheck"]
                     ports:
                         - 127.0.0.1:8010:8010
             """)  # noqa: 501
@@ -85,7 +85,7 @@ class AgentServiceTest(ServiceTest):
                     healthcheck:
                         interval: 5s
                         retries: 12
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://djangoapp:8003/healthcheck"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://djangoapp:8003/healthcheck"]
                     ports:
                         - 127.0.0.1:8003:8003
             """)  # noqa: 501
@@ -108,7 +108,7 @@ class AgentServiceTest(ServiceTest):
                     healthcheck:
                         interval: 5s
                         retries: 12
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://flaskapp:8001/healthcheck"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://flaskapp:8001/healthcheck"]
                     ports:
                         - 127.0.0.1:8001:8001
             """)  # noqa: 501
@@ -135,7 +135,7 @@ class AgentServiceTest(ServiceTest):
                     healthcheck:
                         interval: 10s
                         retries: 60
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://railsapp:8020/healthcheck"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://railsapp:8020/healthcheck"]
                     ports:
                         - 127.0.0.1:8020:8020
             """)  # noqa: 501
@@ -156,7 +156,7 @@ class AgentServiceTest(ServiceTest):
                     healthcheck:
                         interval: 5s
                         retries: 12
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output",
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output",
                         "/dev/null", "http://javaspring:8090/healthcheck"]
                     ports:
                         - 127.0.0.1:8090:8090
@@ -438,7 +438,7 @@ class KibanaServiceTest(ServiceTest):
                             max-size: '2m'
                             max-file: '5'
                     healthcheck:
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://kibana:5601/"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
                         interval: 5s
                         retries: 20
                     depends_on:
@@ -468,7 +468,7 @@ class KibanaServiceTest(ServiceTest):
                             max-size: '2m'
                             max-file: '5'
                     healthcheck:
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://kibana:5601/"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
                         interval: 5s
                         retries: 20
                     depends_on:
@@ -499,7 +499,7 @@ class LogstashServiceTest(ServiceTest):
                 elasticsearch: {condition: service_healthy}
             environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200'}
             healthcheck:
-                test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://logstash:9600/"]
+                test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://logstash:9600/"]
                 interval: 5s
                 retries: 12
             image: docker.elastic.co/logstash/logstash:6.3.0


### PR DESCRIPTION
This ensures that the health check will fail on a non-200 status code