### PR TITLE
Remove memory limits for ES container

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -468,8 +468,8 @@ class ApmServer(StackService, Service):
 class Elasticsearch(StackService, Service):
     default_environment = ["cluster.name=docker-cluster", "bootstrap.memory_lock=true", "discovery.type=single-node"]
     default_es_java_opts = {
-        "-Xms": "1g",
-        "-Xmx": "1g",
+        "-Xms": "5g",
+        "-Xmx": "5g",
     }
 
     SERVICE_PORT = 9200
@@ -503,7 +503,6 @@ class Elasticsearch(StackService, Service):
                 "retries": 10,
                 "test": ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"],
             },
-            mem_limit="5g",
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
             ulimits={
                 "memlock": {"hard": -1, "soft": -1},


### PR DESCRIPTION
Why does elasticsearch, as the only container, have memory restriction on the Docker level?
Also, can we increase the heap size to 5gb?

