### PR TITLE
v2 compatibility 

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -765,10 +765,11 @@ class AgentGoNetHttp(Service):
             build={"context": "docker/go/nethttp", "dockerfile": "Dockerfile"},
             container_name="gonethttpapp",
             environment={
-                "ELASTIC_APM_SERVICE_NAME": "gonethttpapp",
-                "ELASTIC_APM_SERVER_URL": "http://apm-server:8200",
-                "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
+                "ELASTIC_APM_API_REQUEST_TIME": "3s",
                 "ELASTIC_APM_FLUSH_INTERVAL": "500ms",
+                "ELASTIC_APM_SERVER_URL": "http://apm-server:8200",
+                "ELASTIC_APM_SERVICE_NAME": "gonethttpapp",
+                "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
             },
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "gonethttpapp"),
             image=None,
@@ -912,6 +913,7 @@ class AgentRubyRails(Service):
             container_name="railsapp",
             environment={
                 "APM_SERVER_URL": "http://apm-server:8200",
+                "ELASTIC_APM_API_REQUEST_TIME": "3s",
                 "ELASTIC_APM_SERVER_URL": "http://apm-server:8200",
                 "ELASTIC_APM_SERVICE_NAME": "railsapp",
                 "RAILS_PORT": self.SERVICE_PORT,
@@ -938,8 +940,9 @@ class AgentJavaSpring(Service):
             labels=None,
             logging=None,
             environment={
-                "ELASTIC_APM_SERVICE_NAME": "springapp",
+                "ELASTIC_APM_API_REQUEST_TIME": "3s",
                 "ELASTIC_APM_SERVER_URL": "http://apm-server:8200",
+                "ELASTIC_APM_SERVICE_NAME": "springapp",
             },
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "javaspring"),
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -28,10 +28,11 @@ class AgentServiceTest(ServiceTest):
                         context: docker/go/nethttp
                     container_name: gonethttpapp
                     environment:
-                        ELASTIC_APM_SERVICE_NAME: gonethttpapp
-                        ELASTIC_APM_SERVER_URL: http://apm-server:8200
-                        ELASTIC_APM_TRANSACTION_IGNORE_NAMES: healthcheck
+                        ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_FLUSH_INTERVAL: 500ms
+                        ELASTIC_APM_SERVER_URL: http://apm-server:8200
+                        ELASTIC_APM_SERVICE_NAME: gonethttpapp
+                        ELASTIC_APM_TRANSACTION_IGNORE_NAMES: healthcheck
                     healthcheck:
                         interval: 5s
                         retries: 12
@@ -126,6 +127,7 @@ class AgentServiceTest(ServiceTest):
                     command: bash -c "bundle install && RAILS_ENV=production bundle exec rails s -b 0.0.0.0 -p 8020"
                     environment:
                         APM_SERVER_URL: http://apm-server:8200
+                        ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_SERVER_URL: http://apm-server:8200
                         ELASTIC_APM_SERVICE_NAME: railsapp
                         RAILS_SERVICE_NAME: railsapp
@@ -151,8 +153,9 @@ class AgentServiceTest(ServiceTest):
                         context: docker/java/spring
                     container_name: javaspring
                     environment:
-                        ELASTIC_APM_SERVICE_NAME: springapp
+                        ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_SERVER_URL: http://apm-server:8200
+                        ELASTIC_APM_SERVICE_NAME: springapp
                     healthcheck:
                         interval: 5s
                         retries: 12

--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -238,8 +238,9 @@ class Concurrent:
                 span_app_name = lookup(span_context, 'service', 'name')
                 assert span_app_name == ep.app_name, span_context
 
-                span_start = lookup(span, 'start', 'us')
-                assert not anomaly(span_start), span_start
+                if 'start' in span:
+                    span_start = lookup(span, 'start', 'us')
+                    assert not anomaly(span_start), span_start
 
                 span_duration = lookup(span, 'duration', 'us')
                 assert not anomaly(span_duration), span_duration


### PR DESCRIPTION
* lower ELASTIC_APM_API_REQUEST_TIME for tests for v2 agents
* loosen `start` requirements for spans