### PR TITLE
opbeans-node: don't overwrite service name

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1138,8 +1138,6 @@ class OpbeansNode(OpbeansService):
             environment=[
                 "ELASTIC_APM_SERVER_URL={}".format(self.apm_server_url),
                 "ELASTIC_APM_JS_SERVER_URL={}".format(self.apm_js_server_url),
-                "ELASTIC_APM_APP_NAME=opbeans-node",
-                "ELASTIC_APM_SERVICE_NAME={}".format(self.service_name),
                 "ELASTIC_APM_LOG_LEVEL=info",
                 "ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES",
                 "ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES=5",

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -152,8 +152,6 @@ class OpbeansServiceTest(ServiceTest):
                     environment:
                         - ELASTIC_APM_SERVER_URL=http://apm-server:8200
                         - ELASTIC_APM_JS_SERVER_URL=http://apm-server:8200
-                        - ELASTIC_APM_APP_NAME=opbeans-node
-                        - ELASTIC_APM_SERVICE_NAME=opbeans-node
                         - ELASTIC_APM_LOG_LEVEL=info
                         - ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES
                         - ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES=5


### PR DESCRIPTION
The opbeans-node container runs several apps inside it that all need different names. They are each configured with their own service name, but if the `ELASTIC_APM_SERVICE_NAME` environment variable is found, those names will all be overwritten with the same name and so the data from different apps will be mixed together.