### PR TITLE
[APM-CI] support to pass a branch, tag, or sha1 commit as a version of the go agent

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -1,12 +1,13 @@
 FROM golang:1.10
 WORKDIR /go/src/testapp
 COPY main.go /go/src/testapp
-ARG go_agent_package=master
-RUN go get github.com/elastic/apm-agent-go &&\
-  cd $GOPATH/src/github.com/elastic/apm-agent-go &&\
-  git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' &&\
-  git checkout -b ${go_agent_package} &&\
-  cd -
+ARG GO_AGENT_REPO=elastic/apm-agent-go
+ARG GO_AGENT_BRANCH=master
+RUN git clone https://github.com/${GO_AGENT_REPO}.git /go/src/go.elastic.co/apm
+RUN (cd /go/src/go.elastic.co/apm \
+  && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+  && git checkout ${GO_AGENT_BRANCH})
+RUN go get -v
 RUN CGO_ENABLED=0 go build
 
 FROM alpine:latest

--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -7,12 +7,11 @@ RUN git clone https://github.com/${GO_AGENT_REPO}.git /go/src/go.elastic.co/apm
 RUN (cd /go/src/go.elastic.co/apm \
   && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
   && git checkout ${GO_AGENT_BRANCH})
-RUN go get -v
-RUN CGO_ENABLED=0 go build
+RUN CGO_ENABLED=0 go get -v
 
 FROM alpine:latest
 RUN apk add --update curl && rm -rf /var/cache/apk/*
-COPY --from=0 /go/src/testapp/testapp /
+COPY --from=0 /go/bin/testapp /
 EXPOSE 8080
 ENV ELASTIC_APM_IGNORE_URLS /healthcheck
 CMD ["/testapp"]

--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -1,7 +1,12 @@
 FROM golang:1.10
 WORKDIR /go/src/testapp
 COPY main.go /go/src/testapp
-RUN go get github.com/elastic/apm-agent-go
+ARG go_agent_package=master
+RUN go get github.com/elastic/apm-agent-go &&\
+  cd $GOPATH/src/github.com/elastic/apm-agent-go &&\
+  git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' &&\
+  git checkout -b ${go_agent_package} &&\
+  cd -
 RUN CGO_ENABLED=0 go build
 
 FROM alpine:latest

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -803,10 +803,30 @@ class AgentRUMJS(Service):
 
 class AgentGoNetHttp(Service):
     SERVICE_PORT = 8080
+    DEFAULT_AGENT_PACKAGE = "master"
+
+    @classmethod
+    def add_arguments(cls, parser):
+        super(AgentGoNetHttp, cls).add_arguments(parser)
+        parser.add_argument(
+            "--go-agent-package",
+            default=cls.DEFAULT_AGENT_PACKAGE,
+            help='Use Go agent version (master, 0.5, v.0.5.2, ...)',
+        )
+
+    def __init__(self, **options):
+        super(AgentGoNetHttp, self).__init__(**options)
+        self.agent_package = options.get("go_agent_package", self.DEFAULT_AGENT_PACKAGE)
 
     def _content(self):
         return dict(
-            build={"context": "docker/go/nethttp", "dockerfile": "Dockerfile"},
+            build={
+                "context": "docker/go/nethttp",
+                "dockerfile": "Dockerfile",
+                "args": {
+                    "go_agent_package": self.agent_package,
+                },
+            },
             container_name="gonethttpapp",
             environment={
                 "ELASTIC_APM_API_REQUEST_TIME": "3s",

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -803,20 +803,20 @@ class AgentRUMJS(Service):
 
 class AgentGoNetHttp(Service):
     SERVICE_PORT = 8080
-    DEFAULT_AGENT_PACKAGE = "master"
+    DEFAULT_AGENT_VERSION = "master"
 
     @classmethod
     def add_arguments(cls, parser):
         super(AgentGoNetHttp, cls).add_arguments(parser)
         parser.add_argument(
-            "--go-agent-package",
-            default=cls.DEFAULT_AGENT_PACKAGE,
-            help='Use Go agent version (master, 0.5, v.0.5.2, ...)',
+            "--go-agent-version",
+            default=cls.DEFAULT_AGENT_VERSION,
+            help='Use Go agent version (master, 0.5, v0.5.2, ...)',
         )
 
     def __init__(self, **options):
         super(AgentGoNetHttp, self).__init__(**options)
-        self.agent_package = options.get("go_agent_package", self.DEFAULT_AGENT_PACKAGE)
+        self.agent_version = options.get("go_agent_version", self.DEFAULT_AGENT_VERSION)
 
     def _content(self):
         return dict(
@@ -824,7 +824,7 @@ class AgentGoNetHttp(Service):
                 "context": "docker/go/nethttp",
                 "dockerfile": "Dockerfile",
                 "args": {
-                    "go_agent_package": self.agent_package,
+                    "GO_AGENT_BRANCH": self.agent_version,
                 },
             },
             container_name="gonethttpapp",

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -25,7 +25,7 @@ class AgentServiceTest(ServiceTest):
                 agent-go-net-http:
                     build:
                         args:
-                            go_agent_package: master
+                            GO_AGENT_BRANCH: master
                         dockerfile: Dockerfile
                         context: docker/go/nethttp
                     container_name: gonethttpapp

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -24,6 +24,8 @@ class AgentServiceTest(ServiceTest):
             agent, yaml.load("""
                 agent-go-net-http:
                     build:
+                        args:
+                            go_agent_package: master
                         dockerfile: Dockerfile
                         context: docker/go/nethttp
                     container_name: gonethttpapp


### PR DESCRIPTION
* New Docker image argument to specity the version using `GO_AGENT_BRANCH=<branch|tag|sha1>`
* New composer padameter to specity the version using `--go-agent-version=<branch|tag|sha1>`
* Modify test