### PR TITLE
[APM-CI] support to pass a branch, tag, or sha1 commit as a version of the java agent

### DIFF
--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -1,5 +1,7 @@
 FROM maven:3.5.3-jdk-10
 
+ARG java_agent_package=master
+
 RUN mkdir /agent \
     && mkdir /app
 
@@ -7,7 +9,10 @@ COPY testapp /app
 
 WORKDIR /agent
 
-RUN curl -L https://github.com/elastic/apm-agent-java/archive/master.tar.gz | tar --strip-components=1 --exclude=demo/db.sql.bz2 -xzv \
+RUN git clone https://github.com/elastic/apm-agent-java.git \
+    && cd apm-agent-java \
+    && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+    && git checkout -b ${java_agent_package}  \
     && mvn --batch-mode package -DskipTests \
     && export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
     && mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar apm-agent.jar \

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.5.3-jdk-10
 
-ARG java_agent_package=master
+ARG JAVA_AGENT_REPO=elastic/apm-agent-java
+ARG JAVA_AGENT_BRANCH=master
 
 RUN mkdir /agent \
     && mkdir /app
@@ -9,21 +10,24 @@ COPY testapp /app
 
 WORKDIR /agent
 
-RUN git clone https://github.com/elastic/apm-agent-java.git \
-    && cd apm-agent-java \
-    && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
-    && git checkout -b ${java_agent_package}  \
+RUN git clone https://github.com/${JAVA_AGENT_REPO}.git /agent/apm-agent-java
+RUN cd /agent/apm-agent-java \
+  && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+  && git checkout ${JAVA_AGENT_BRANCH}
+
+RUN cd /agent/apm-agent-java \
     && mvn --batch-mode package -DskipTests \
     && export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
-    && mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar apm-agent.jar \
+    && mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar \
     && mvn --batch-mode install:install-file -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} -Dpackaging=jar \
     && cd /app \
     && mvn --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} package
 
+FROM openjdk:10-jre
+COPY --from=0 /app /app
+COPY --from=0 /agent/apm-agent.jar  /app
 WORKDIR /app
-
 EXPOSE 8090
-
-CMD ["java", "-javaagent:../agent/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","target/hello-spring-0.1.jar"]
+CMD ["java", "-javaagent:/app/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","/app/target/hello-spring-0.1.jar"]
 
 

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -23,7 +23,7 @@ RUN cd /agent/apm-agent-java \
     && cd /app \
     && mvn --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} package
 
-FROM openjdk:10-jre
+FROM openjdk:10-jre-slim
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar  /app
 WORKDIR /app

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -17,15 +17,26 @@ RUN cd /agent/apm-agent-java \
 
 RUN cd /agent/apm-agent-java \
     && mvn --batch-mode package -DskipTests \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     && export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
     && mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar \
-    && mvn --batch-mode install:install-file -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} -Dpackaging=jar \
+    && mvn --batch-mode install:install-file \
+      -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar \
+      -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
+      -Dpackaging=jar \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     && cd /app \
-    && mvn --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} package
+    && mvn --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+      package
 
 FROM openjdk:10-jre-slim
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar  /app
+RUN apt-get update \
+  && apt-get install -y curl \
+  && apt-get clean \
+  && rm -fr /var/lib/apt/lists/* 
 WORKDIR /app
 EXPOSE 8090
 CMD ["java", "-javaagent:/app/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","/app/target/hello-spring-0.1.jar"]

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -975,20 +975,20 @@ class AgentRubyRails(Service):
 
 class AgentJavaSpring(Service):
     SERVICE_PORT = 8090
-    DEFAULT_AGENT_PACKAGE = "master"
+    DEFAULT_AGENT_VERSION = "master"
 
     @classmethod
     def add_arguments(cls, parser):
         super(AgentJavaSpring, cls).add_arguments(parser)
         parser.add_argument(
-            "--java-agent-package",
-            default=cls.DEFAULT_AGENT_PACKAGE,
+            "--java-agent-version",
+            default=cls.DEFAULT_AGENT_VERSION,
             help='Use Java agent version (master, 0.5, v.0.7.1, ...)',
         )
 
     def __init__(self, **options):
         super(AgentJavaSpring, self).__init__(**options)
-        self.agent_version = options.get("java_agent_package", self.DEFAULT_AGENT_PACKAGE)
+        self.agent_version = options.get("java_agent_version", self.DEFAULT_AGENT_VERSION)
 
     def _content(self):
         return dict(
@@ -996,7 +996,7 @@ class AgentJavaSpring(Service):
                 "context": "docker/java/spring",
                 "dockerfile": "Dockerfile",
                 "args": {
-                    "java_agent_package": self.agent_version,
+                    "JAVA_AGENT_BRANCH": self.agent_version,
                 }
             },
             container_name="javaspring",

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -975,10 +975,30 @@ class AgentRubyRails(Service):
 
 class AgentJavaSpring(Service):
     SERVICE_PORT = 8090
+    DEFAULT_AGENT_PACKAGE = "master"
+
+    @classmethod
+    def add_arguments(cls, parser):
+        super(AgentJavaSpring, cls).add_arguments(parser)
+        parser.add_argument(
+            "--java-agent-package",
+            default=cls.DEFAULT_AGENT_PACKAGE,
+            help='Use Java agent version (master, 0.5, v.0.7.1, ...)',
+        )
+
+    def __init__(self, **options):
+        super(AgentJavaSpring, self).__init__(**options)
+        self.agent_version = options.get("java_agent_package", self.DEFAULT_AGENT_PACKAGE)
 
     def _content(self):
         return dict(
-            build={"context": "docker/java/spring", "dockerfile": "Dockerfile"},
+            build={
+                "context": "docker/java/spring",
+                "dockerfile": "Dockerfile",
+                "args": {
+                    "java_agent_package": self.agent_version,
+                }
+            },
             container_name="javaspring",
             image=None,
             labels=None,

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -149,6 +149,8 @@ class AgentServiceTest(ServiceTest):
             agent, yaml.load("""
                 agent-java-spring:
                     build:
+                        args:
+                            java_agent_package: master
                         dockerfile: Dockerfile
                         context: docker/java/spring
                     container_name: javaspring

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -150,7 +150,7 @@ class AgentServiceTest(ServiceTest):
                 agent-java-spring:
                     build:
                         args:
-                            java_agent_package: master
+                            JAVA_AGENT_BRANCH: master
                         dockerfile: Dockerfile
                         context: docker/java/spring
                     container_name: javaspring


### PR DESCRIPTION
* New Docker image argument to specity the version using `JAVA_AGENT_BRANCH=<branch|tag|sha1>`
* New composer padameter to specity the version using `--java-agent-version=<branch|tag|sha1>`
* Modify test