### PR TITLE
tests: exclude apm-server events from counts

### DIFF
--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -109,9 +109,9 @@ class Concurrent:
         def assert_count(terms, cnt):
             """wait a bit for doc count to reach expectation"""
             rs = {'count': -1}
+            q = self.elasticsearch.term_q(terms, exclude_terms=[{"context.service.name": "apm-server"}])
             while rs['count'] < cnt:
-                rs = self.es.count(index=self.index,
-                                   body=self.elasticsearch.term_q(terms))
+                rs = self.es.count(index=self.index, body=q)
                 time.sleep(backoff)
             assert rs['count'] == cnt, err.format(terms, cnt, rs)
 

--- a/tests/fixtures/es.py
+++ b/tests/fixtures/es.py
@@ -18,12 +18,17 @@ def es():
             self.es.indices.delete(self.index)
             self.es.indices.refresh()
 
-        def term_q(self, terms):
-            t = []
-            for idx in range(len(terms)):
-                for k in terms[idx]:
-                    t.append({"term": {k: {"value": terms[idx][k]}}})
-            return {"query": {"bool": {"must": t}}}
+        def term_q(self, terms, exclude_terms=None):
+            def make_terms(terms):
+                t = []
+                for idx in range(len(terms)):
+                    for k in terms[idx]:
+                        t.append({"term": {k: {"value": terms[idx][k]}}})
+                return t
+            bool_q = {"must": make_terms(terms)}
+            if exclude_terms:
+                bool_q["must_not"] = make_terms(exclude_terms)
+            return {"query": {"bool": bool_q}}
 
         @timeout_decorator.timeout(10)
         def fetch(self, q):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,20 @@ def check_elasticsearch_content(elasticsearch,
                                 processor='transaction',
                                 query=None):
     if query is None:
-        query = {'query': {'term': {'processor.name': processor}}}
+        query = {
+          'query': {
+            'bool': {
+              'must': {
+                'term': {'processor.name': processor},
+              },
+              # apm-server sends itself transactions,
+              # we exclude them from results by default.
+              'must_not': {
+                'term': {'context.service.name': 'apm-server'},
+              }
+            }
+          }
+        }
 
     actual_count = 0
     retries = 0


### PR DESCRIPTION
When running tests, ignore the tracing events that the apm-server sends itself by default. They are being incorrectly counted in the agent trace events.