### PR TITLE
updated python test matrix to only test latest release with 6.5+

### DIFF
--- a/tests/versions/nodejs.yml
+++ b/tests/versions/nodejs.yml
@@ -2,7 +2,7 @@ NODEJS_AGENT:
   # github;version -> npm install elastic/apm-agent-nodejs#version
   # release;version -> npm install elastic-apm-node@version
   - 'github;master'
-  - 'release;1.14.3'
+  - 'release;1'
   - 'release;latest'
 
 exclude:

--- a/tests/versions/nodejs.yml
+++ b/tests/versions/nodejs.yml
@@ -2,6 +2,19 @@ NODEJS_AGENT:
   # github;version -> npm install elastic/apm-agent-nodejs#version
   # release;version -> npm install elastic-apm-node@version
   - 'github;master'
+  - 'release;1.14.3'
   - 'release;latest'
 
-exclude: []
+exclude:
+- NODEJS_AGENT: 'release;latest'
+  APM_SERVER: '6.4'
+- NODEJS_AGENT: 'release;latest'
+  APM_SERVER: '6.3'
+- NODEJS_AGENT: 'release;latest'
+  APM_SERVER: '6.2;--release'
+- NODEJS_AGENT: 'github;master'
+  APM_SERVER: '6.4'
+- NODEJS_AGENT: 'github;master'
+  APM_SERVER: '6.3'
+- NODEJS_AGENT: 'github;master'
+  APM_SERVER: '6.2;--release'

--- a/tests/versions/python.yml
+++ b/tests/versions/python.yml
@@ -4,9 +4,15 @@ PYTHON_AGENT:
   # release;release -> pip install elastic-apm==version
   - 'github;master'
   - 'release;latest' 
-  - 'release;2.0'
+  - 'release;3.0'
 
 exclude:
+  - PYTHON_AGENT: 'release;latest'
+    APM_SERVER: '6.4'
+  - PYTHON_AGENT: 'release;latest'
+    APM_SERVER: '6.3'
+  - PYTHON_AGENT: 'release;latest'
+    APM_SERVER: '6.2;--release'
   - PYTHON_AGENT: 'github;master'
     APM_SERVER: '6.4' 
   - PYTHON_AGENT: 'github;master'

--- a/tests/versions/ruby.yml
+++ b/tests/versions/ruby.yml
@@ -6,4 +6,16 @@ RUBY_AGENT:
   - 'github;1.x'
   - 'release;latest'
 
-exclude: []
+exclude:
+  - RUBY_AGENT: 'release;latest'
+    APM_SERVER: '6.4'
+  - RUBY_AGENT: 'release;latest'
+    APM_SERVER: '6.3'
+  - RUBY_AGENT: 'release;latest'
+    APM_SERVER: '6.2;--release'
+  - RUBY_AGENT: 'github;master'
+    APM_SERVER: '6.4'
+  - RUBY_AGENT: 'github;master'
+    APM_SERVER: '6.3'
+  - RUBY_AGENT: 'github;master'
+    APM_SERVER: '6.2;--release'


### PR DESCRIPTION
Version 4 of the agent doesn't support earlier APM Server versions

/edit also added excludes for NodeJS and Ruby. @watson @mikker please review :) 