### PR TITLE
make logs less verbose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -SLO https://dl.google.com/linux/direct/google-chrome-stable_current_am
 	rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install -q -r requirements.txt
 
 RUN useradd -U -m -s /bin/bash -d /app tester
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	test -d $(VENV) || virtualenv --python=$(PYTHON3) $(VENV);\
-	pip install -r requirements.txt;\
+	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
+	pip install -q -r requirements.txt;\
 	touch $(VENV);\
 
 lint: venv

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -4,7 +4,7 @@ ARG go_version=1.10
 FROM golang:${go_version} AS build
 
 # install make update prerequisites
-RUN apt-get update && apt-get install -y python-virtualenv
+RUN apt-get -qq update && apt-get -qq install -y python-virtualenv
 
 ARG apm_server_branch=master
 ARG apm_server_repo=https://github.com/elastic/apm-server.git

--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_AGENT_REPO=elastic/apm-agent-go
 ARG GO_AGENT_BRANCH=master
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /go/src/go.elastic.co/apm
 RUN (cd /go/src/go.elastic.co/apm \
-  && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+  && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
   && git checkout ${GO_AGENT_BRANCH})
 RUN CGO_ENABLED=0 go get -v
 

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -12,30 +12,30 @@ WORKDIR /agent
 
 RUN git clone https://github.com/${JAVA_AGENT_REPO}.git /agent/apm-agent-java
 RUN cd /agent/apm-agent-java \
-  && git fetch origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+  && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
   && git checkout ${JAVA_AGENT_BRANCH}
 
 RUN cd /agent/apm-agent-java \
-    && mvn --batch-mode package -DskipTests \
+    && mvn -q --batch-mode package -DskipTests \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     && export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
     && mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar \
-    && mvn --batch-mode install:install-file \
+    && mvn -q --batch-mode install:install-file \
       -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar \
       -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
       -Dpackaging=jar \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     && cd /app \
-    && mvn --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
+    && mvn -q --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       package
 
 FROM openjdk:10-jre-slim
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar  /app
-RUN apt-get update \
-  && apt-get install -y curl \
-  && apt-get clean \
+RUN apt-get -qq update \
+  && apt-get -qq install -y curl \
+  && apt-get -qq clean \
   && rm -fr /var/lib/apt/lists/* 
 WORKDIR /app
 EXPOSE 8090

--- a/docker/opbeans/frontend/Dockerfile
+++ b/docker/opbeans/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get -qq update && apt-get -qq install -y \
 	apt-transport-https \
 	ca-certificates \
 	curl \
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
 	&& echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-	&& apt-get update && apt-get install -y \
+	&& apt-get -qq update && apt-get -qq install -y \
 	google-chrome-stable \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*

--- a/docker/opbeans/python/entrypoint.sh
+++ b/docker/opbeans/python/entrypoint.sh
@@ -7,14 +7,14 @@ if [[ -f /local-install/setup.py ]]; then
     cd ~/local-install && python setup.py install
     cd -
 elif [[ $PYTHON_AGENT_VERSION ]]; then
-    pip install -U elastic-apm==$PYTHON_AGENT_VERSION
+    pip install -q -U elastic-apm==$PYTHON_AGENT_VERSION
 elif [[ $PYTHON_AGENT_BRANCH ]]; then
     if [[ -z ${PYTHON_AGENT_REPO} ]]; then
         PYTHON_AGENT_REPO="elastic/apm-agent-python"
     fi
-    pip install -U https://github.com/${PYTHON_AGENT_REPO}/archive/${PYTHON_AGENT_BRANCH}.zip
+    pip install -q -U https://github.com/${PYTHON_AGENT_REPO}/archive/${PYTHON_AGENT_BRANCH}.zip
 else
-    pip install -U elastic-apm
+    pip install -q -U elastic-apm
 fi
 rm -f celerybeat.pid
 python manage.py migrate

--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get -qq update && apt-get -qq install -y \
 	apt-transport-https \
 	ca-certificates \
 	curl \
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
 	&& echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-	&& apt-get update && apt-get install -y \
+	&& apt-get -qq update && apt-get -qq install -y \
 	google-chrome-stable \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*

--- a/docker/python/django/Dockerfile
+++ b/docker/python/django/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-RUN pip install -U django
+RUN pip install -q -U django
 
 RUN mkdir -p /app
 COPY testapp /app/testapp

--- a/docker/python/flask/Dockerfile
+++ b/docker/python/flask/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-RUN pip install -U Flask blinker gunicorn
+RUN pip install -q -U Flask blinker gunicorn
 
 RUN mkdir -p /app
 COPY app.py /app

--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:latest
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
     build-essential \
     nodejs 
 

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -3,15 +3,15 @@ FROM node:8-slim
 ARG RUM_AGENT_BRANCH
 ARG RUM_AGENT_REPO
 
-RUN apt-get update && apt-get install -yq libgconf-2-4 \
-    && apt-get install -y wget git --no-install-recommends \
+RUN apt-get -qq update && apt-get -qq install -yq libgconf-2-4 \
+    && apt-get -qq install -y wget git --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    && apt-get -qq update \
+    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get purge --auto-remove -y curl \
+    && apt-get -qq purge --auto-remove -y curl \
     && rm -rf /src/*.deb
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -940,7 +940,7 @@ class AgentPythonDjango(AgentPython):
     def _content(self):
         return dict(
             build={"context": "docker/python/django", "dockerfile": "Dockerfile"},
-            command="bash -c \"pip install -U {} && python testapp/manage.py runserver 0.0.0.0:{}\"".format(
+            command="bash -c \"pip install -q -U {} && python testapp/manage.py runserver 0.0.0.0:{}\"".format(
                 self.agent_package, self.SERVICE_PORT),
             container_name="djangoapp",
             environment={
@@ -965,7 +965,7 @@ class AgentPythonFlask(AgentPython):
     def _content(self):
         return dict(
             build={"context": "docker/python/flask", "dockerfile": "Dockerfile"},
-            command="bash -c \"pip install -U {} && gunicorn app:app\"".format(self.agent_package),
+            command="bash -c \"pip install -q -U {} && gunicorn app:app\"".format(self.agent_package),
             container_name="flaskapp",
             image=None,
             labels=None,

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -85,7 +85,7 @@ class AgentServiceTest(ServiceTest):
                     build:
                         dockerfile: Dockerfile
                         context: docker/python/django
-                    command: bash -c "pip install -U elastic-apm && python testapp/manage.py runserver 0.0.0.0:8003"
+                    command: bash -c "pip install -q -U elastic-apm && python testapp/manage.py runserver 0.0.0.0:8003"
                     container_name: djangoapp
                     environment:
                         DJANGO_SERVICE_NAME: djangoapp
@@ -111,7 +111,7 @@ class AgentServiceTest(ServiceTest):
                     build:
                         dockerfile: Dockerfile
                         context: docker/python/flask
-                    command: bash -c "pip install -U elastic-apm && gunicorn app:app"
+                    command: bash -c "pip install -q -U elastic-apm && gunicorn app:app"
                     container_name: flaskapp
                     environment:
                         FLASK_SERVICE_NAME: flaskapp


### PR DESCRIPTION
The integration testing logs contain a really verbose output for the Docker images creation, let's make those logs a little less verbose by changing some commands

* Change `apt-get` commands to `apt-get -qq`
* Change `git fetch` commands to `git fetch -q`
* Change `mvn` commands to `mvn -q`
* Change `pip` commands to `pip -q`
* Change `virtualenv` commands to `virtualenv -q`