### PR TITLE
Limit api_request_time to 50ms for all integration test apps

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -14,4 +14,5 @@ RUN apk add --update curl && rm -rf /var/cache/apk/*
 COPY --from=0 /go/bin/testapp /
 EXPOSE 8080
 ENV ELASTIC_APM_IGNORE_URLS *healthcheck*
+ENV ELASTIC_APM_API_REQUEST_TIME 50ms
 CMD ["/testapp"]

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get -qq update \
   && rm -fr /var/lib/apt/lists/* 
 WORKDIR /app
 EXPOSE 8090
+ENV ELASTIC_APM_API_REQUEST_TIME 50ms
 CMD ["java", "-javaagent:/app/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","/app/target/hello-spring-0.1.jar"]
 
 

--- a/docker/python/django/testapp/testapp/settings.py
+++ b/docker/python/django/testapp/testapp/settings.py
@@ -42,13 +42,14 @@ INSTALLED_APPS = [
 
 ELASTIC_APM = {
     'SERVICE_NAME': os.environ['DJANGO_SERVICE_NAME'],
-    'SERVER': os.environ['APM_SERVER_URL'], # 1.x
+    'SERVER': os.environ['APM_SERVER_URL'],  # 1.x
     'SERVER_URL': os.environ['APM_SERVER_URL'],
     'SECRET_TOKEN': os.getenv('APM_SERVER_SECRET_TOKEN', '1234_test'),
-    'TRANSACTION_SEND_FREQ': 1, # 1.x
-    'FLUSH_INTERVAL': 1, # 2.x
-    'MAX_EVENT_QUEUE_LENGTH': 1, # 1.x
-    'MAX_QUEUE_SIZE': 1, # 2.x
+    'TRANSACTION_SEND_FREQ': 1,  # 1.x
+    'FLUSH_INTERVAL': 1,  # 2.x
+    'MAX_EVENT_QUEUE_LENGTH': 1,  # 1.x
+    'MAX_QUEUE_SIZE': 1,  # 2.x
+    'API_REQUEST_TIME': '50ms',  # 4.x
     'TRANSACTIONS_IGNORE_PATTERNS': ['.*healthcheck']
 }
 

--- a/docker/python/flask/app.py
+++ b/docker/python/flask/app.py
@@ -14,10 +14,11 @@ app.config['ELASTIC_APM'] = {
     'DEBUG': True,
     'SERVER_URL': os.environ['APM_SERVER_URL'],
     'SERVICE_NAME': os.environ['FLASK_SERVICE_NAME'],
-    'TRANSACTION_SEND_FREQ': 1, # 1.x
-    'FLUSH_INTERVAL': 1, # 2.x
-    'MAX_EVENT_QUEUE_LENGTH': 1, # 1.x
-    'MAX_QUEUE_SIZE': 1, # 2.x
+    'TRANSACTION_SEND_FREQ': 1,  # 1.x
+    'FLUSH_INTERVAL': 1,  # 2.x
+    'MAX_EVENT_QUEUE_LENGTH': 1,  # 1.x
+    'MAX_QUEUE_SIZE': 1,  # 2.x
+    'API_REQUEST_TIME': '50ms',  # 4.x
     'SECRET_TOKEN': os.getenv('APM_SERVER_SECRET_TOKEN', '1234'),
     'TRANSACTIONS_IGNORE_PATTERNS': ['.*healthcheck']
 }

--- a/docker/ruby/rails/testapp/config/elastic_apm.yml
+++ b/docker/ruby/rails/testapp/config/elastic_apm.yml
@@ -1,1 +1,2 @@
 flush_interval: 1
+api_request_time: 50ms

--- a/docker/ruby/rails/testapp/config/elastic_apm.yml
+++ b/docker/ruby/rails/testapp/config/elastic_apm.yml
@@ -1,1 +1,2 @@
+flush_interval: 1
 api_request_time: 50ms

--- a/docker/ruby/rails/testapp/config/elastic_apm.yml
+++ b/docker/ruby/rails/testapp/config/elastic_apm.yml
@@ -1,2 +1,1 @@
-flush_interval: 1
 api_request_time: 50ms


### PR DESCRIPTION
For nodejs, this is done in #235 