### PR TITLE
set nodejs/express test agent framework explicitly

### DIFF
--- a/docker/nodejs/express/app.js
+++ b/docker/nodejs/express/app.js
@@ -1,6 +1,8 @@
 'use strict'
 
 var apm = require('elastic-apm-node').start({
+  frameworkName: 'express',
+  frameworkVersion: 'unknown',
   serviceName: process.env.EXPRESS_SERVICE_NAME,
   flushInterval: 1,
   maxQueueSize: 1,


### PR DESCRIPTION
Test whether this resolves test failures.  Probably should not be merged as it indicates framework detection might be actually be broken.