### PR TITLE
Revert api_request_time for ruby.

### DIFF
--- a/docker/ruby/rails/testapp/config/application.rb
+++ b/docker/ruby/rails/testapp/config/application.rb
@@ -30,5 +30,10 @@ module Minimal
 
     # Elastic APM config
     config.elastic_apm.ignore_url_patterns = '/healthcheck'
+
+
+    if apm = Gem.loaded_specs["elastic-apm"]
+      config.elastic_apm.api_request_time = '50ms' if apm.version >= Gem::Version.new("2.0")
+    end
   end
 end

--- a/docker/ruby/rails/testapp/config/elastic_apm.yml
+++ b/docker/ruby/rails/testapp/config/elastic_apm.yml
@@ -1,2 +1,1 @@
 flush_interval: 1
-api_request_time: 50ms


### PR DESCRIPTION
The ruby agent silently fails to deliver data when an invalid config option is set, see Issue https://github.com/elastic/apm-agent-ruby/issues/251.

Therefore `api_request_time` can only be set when agents version `>= 2.x`.

cc @mikker