### PR TITLE
add workaround to opbeans-go to ensure docker layer invalidation

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -8,6 +8,8 @@ RUN git clone https://github.com/elastic/opbeans-go.git .
 RUN rm -fr vendor/go.elastic.co/apm
 ARG GO_AGENT_REPO=elastic/apm-agent-go
 ARG GO_AGENT_BRANCH=master
+# adding this file will invalidate the layer cache when the branch head changes
+ADD https://api.github.com/repos/${GO_AGENT_REPO}/git/refs/heads/${GO_AGENT_BRANCH} version.json
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /go/src/go.elastic.co/apm
 RUN (cd /go/src/go.elastic.co/apm && git checkout ${GO_AGENT_BRANCH})
 RUN go get -v


### PR DESCRIPTION
this fetches a JSON file from the GitHub API, the content of which
changes if the branch changes. With this trick, we can ensure that local
docker layer caches are invalidated when the remote branch is updated.

A drawback of this is that it will stop us from building the image if
the GitHub API is not accessible.