### PR TITLE
opbeans-go: structured logging

### DIFF
--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -76,6 +76,17 @@ filebeat.autodiscover:
             multiline.match: after
       - condition:
           contains:
+            docker.container.image: "opbeans-go"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            processors:
+              - decode_json_fields:
+                  fields: ["message"]
+                  target: "opbeans-go"
+      - condition:
+          contains:
             docker.container.image: "postgres"
         config:
           - type: docker
@@ -101,6 +112,9 @@ filebeat.autodiscover:
             - not:
                 contains:
                   docker.container.image: "opbeans-node"
+            - not:
+                contains:
+                  docker.container.image: "opbeans-go"
             - not:
                 contains:
                   docker.container.image: "postgres"

--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -26,4 +26,4 @@ HEALTHCHECK \
   --interval=10s --retries=10 --timeout=3s \
   CMD ["/opbeans-go", "-healthcheck", "localhost:3000"]
 
-CMD ["/opbeans-go", "-listen=:3000", "-frontend=/opbeans-frontend", "-db=postgres:", "-cache=redis://redis:6379"]
+CMD ["/opbeans-go", "-log-json", "-log-level=debug", "-listen=:3000", "-frontend=/opbeans-frontend", "-db=postgres:", "-cache=redis://redis:6379"]


### PR DESCRIPTION
Pass "-log-json" and "-log-level=debug" to opbeans-go. These are new flags, opbeans-go will need to be rebuilt.

Update filebeat.yml to decode the JSON.