### PR TITLE
use _count api

### DIFF
--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -157,7 +157,12 @@ class Concurrent:
 
             # ensure query for docs returns results
             tr_cnt = ep.count("transaction") * it
-            assert tr_cnt == lookup(rs, 'hits', 'total')
+            total = lookup(rs, 'hits', 'total')
+            if "value" in total:
+                actual_cnt = total["value"]
+            else:
+                actual_cnt = total
+            assert tr_cnt == actual_cnt, "expected {} hits, got: {}".format(tr_cnt, actual_cnt)
 
             # check the first existing transaction for every endpoint
             hit = lookup(rs, 'hits', 'hits')[0]

--- a/tests/agent/test_rum.py
+++ b/tests/agent/test_rum.py
@@ -10,4 +10,4 @@ def test_rum(rum):
 
     r = requests.get(endpoint.url)
     utils.check_request_response(r, endpoint)
-    utils.check_elasticsearch_content(elasticsearch, 1, query={'query': {'term': {'processor.event': 'transaction'}}})
+    utils.check_elasticsearch_count(elasticsearch, 1, query={'query': {'term': {'processor.event': 'transaction'}}})

--- a/tests/fixtures/es.py
+++ b/tests/fixtures/es.py
@@ -26,13 +26,12 @@ def es():
             return {"query": {"bool": {"must": t}}}
 
         @timeout_decorator.timeout(10)
-        def fetch(self, q):
+        def count(self, q):
             ct = 0
-            s = {}
             while ct == 0:
                 time.sleep(3)
-                s = self.es.search(index=self.index, body=q)
-                ct = s['hits']['total']
-            return s
+                s = self.es.count(index=self.index, body=q)
+                ct = s['count']
+            return ct
 
     return Elasticsearch(default.from_env("ES_URL"))


### PR DESCRIPTION
_search was fine but unnecessary.  Since the _search response changes format from 6.x -> 7.x, use _count instead where possible.  Otherwise, just handle both return formats.

6.x:
```
"hits": {
    "total": 1863364,
...
```

7.x:
```
"hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
...
```