### PR TITLE
use the correct healthcheck path for apm-server >= 6.5

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -470,7 +470,7 @@ class ApmServer(StackService, Service):
         try:
             version_tuple = map(int, self.version.split("."))[:3]
             if version_tuple < (6, 5):
-                healthcheck_path = "/"
+                healthcheck_path = "/healthcheck"
         except ValueError:
             pass
         content = dict(

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -468,7 +468,7 @@ class ApmServer(StackService, Service):
             command_args.extend(["-E", param + "=" + value])
         healthcheck_path = "/"
         try:
-            version_tuple = map(int, self.version.split("."))[:3]
+            version_tuple = tuple(map(int, self.version.split(".")))[:3]
             if version_tuple < (6, 5):
                 healthcheck_path = "/healthcheck"
         except ValueError:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -620,7 +620,7 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 5s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
+                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/']
                 image: docker.elastic.co/apm/apm-server:7.0.10-alpha1-SNAPSHOT
                 labels: [co.elatic.apm.stack-version=7.0.10-alpha1]
                 logging:


### PR DESCRIPTION
this makes the logs somewhat less noisy as the apm-server stops complaining about deprecated healthcheck URLs