### PR TITLE
Bump duration threshold to fix intermitent failures

### DIFF
--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -20,7 +20,7 @@ def lookup(d, *keys):
 
 
 def anomaly(x):
-    return x > 100000 or x < 0  # 100000 = 0.1 sec
+    return x > 500000 or x < 0  # 0.5 secs
 
 
 class Concurrent:


### PR DESCRIPTION
This is still enough to catch duration unit errors, etc