### PR TITLE
add --elasticsearch-data-dir option

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -590,7 +590,7 @@ class Elasticsearch(StackService, Service):
 
         java_opts_env = "ES_JAVA_OPTS=" + " ".join(["-{}{}".format(k, v) for k, v in sorted(es_java_opts.items())])
         self.environment = self.default_environment + [
-            java_opts_env, "path.data=/usr/share/elasticsearch/data/" + self.version]
+            java_opts_env, "path.data=/usr/share/elasticsearch/data/"]
         if not self.oss:
             self.environment.append("xpack.security.enabled=false")
             self.environment.append("xpack.license.self_generated.type=trial")

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -589,8 +589,11 @@ class Elasticsearch(StackService, Service):
             es_java_opts["XX:UseAVX"] = "=2"
 
         java_opts_env = "ES_JAVA_OPTS=" + " ".join(["-{}{}".format(k, v) for k, v in sorted(es_java_opts.items())])
+        # falsy empty string permitted
+        data_dir = self.version if options.get("elasticsearch_data_dir") is None else options["elasticsearch_data_dir"]
+
         self.environment = self.default_environment + [
-            java_opts_env, "path.data=/usr/share/elasticsearch/data/" + self.version]
+            java_opts_env, "path.data=/usr/share/elasticsearch/data/" + data_dir]
         if not self.oss:
             self.environment.append("xpack.security.enabled=false")
             self.environment.append("xpack.license.self_generated.type=trial")
@@ -600,6 +603,11 @@ class Elasticsearch(StackService, Service):
     @classmethod
     def add_arguments(cls, parser):
         super(Elasticsearch, cls).add_arguments(parser)
+        parser.add_argument(
+            "--elasticsearch-data-dir",
+            help="override elasticsearch data dir.  Defaults to the current es version."
+        )
+
         parser.add_argument(
             "--elasticsearch-heap",
             default=Elasticsearch.default_heap_size,

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -590,7 +590,7 @@ class Elasticsearch(StackService, Service):
 
         java_opts_env = "ES_JAVA_OPTS=" + " ".join(["-{}{}".format(k, v) for k, v in sorted(es_java_opts.items())])
         self.environment = self.default_environment + [
-            java_opts_env, "path.data=/usr/share/elasticsearch/data/"]
+            java_opts_env, "path.data=/usr/share/elasticsearch/data"]
         if not self.oss:
             self.environment.append("xpack.security.enabled=false")
             self.environment.append("xpack.license.self_generated.type=trial")

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -590,7 +590,7 @@ class Elasticsearch(StackService, Service):
 
         java_opts_env = "ES_JAVA_OPTS=" + " ".join(["-{}{}".format(k, v) for k, v in sorted(es_java_opts.items())])
         self.environment = self.default_environment + [
-            java_opts_env, "path.data=/usr/share/elasticsearch/data"]
+            java_opts_env, "path.data=/usr/share/elasticsearch/data/" + self.version]
         if not self.oss:
             self.environment.append("xpack.security.enabled=false")
             self.environment.append("xpack.license.self_generated.type=trial")

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -473,7 +473,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.2.10_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
+                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -550,7 +550,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.3.10_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -630,7 +630,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_7.0.10-alpha1_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/7.0.10-alpha1, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -473,7 +473,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.2.10_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
+                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -550,7 +550,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.3.10_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -630,7 +630,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_7.0.10-alpha1_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/7.0.10-alpha1, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -417,6 +417,22 @@ class ElasticsearchServiceTest(ServiceTest):
             "xpack.license.self_generated.type=trial" in elasticsearch["environment"], "xpack.license type"
         )
 
+    def test_data_dir(self):
+        # default
+        elasticsearch = Elasticsearch(version="6.3.100").render()["elasticsearch"]
+        data_path = [e for e in elasticsearch["environment"] if e.startswith("path.data=")]
+        self.assertListEqual(["path.data=/usr/share/elasticsearch/data/6.3.100"], data_path)
+
+        # override empty
+        elasticsearch = Elasticsearch(version="6.3.100", elasticsearch_data_dir="").render()["elasticsearch"]
+        data_path = [e for e in elasticsearch["environment"] if e.startswith("path.data=")]
+        self.assertListEqual(["path.data=/usr/share/elasticsearch/data/"], data_path)
+
+        # override non-empty
+        elasticsearch = Elasticsearch(version="6.3.100", elasticsearch_data_dir="foo").render()["elasticsearch"]
+        data_path = [e for e in elasticsearch["environment"] if e.startswith("path.data=")]
+        self.assertListEqual(["path.data=/usr/share/elasticsearch/data/foo"], data_path)
+
     def test_heap(self):
         elasticsearch = Elasticsearch(version="6.3.100", elasticsearch_heap="5m").render()["elasticsearch"]
         java_opts = [e for e in elasticsearch["environment"] if e.startswith("ES_JAVA_OPTS=")]


### PR DESCRIPTION
To enable upgrade testing, like:

```
./scripts/compose.py start 6.6 --elasticsearch-data-dir "" ...
# don't remove any volumes here
./scripts/compose.py start 7.0.0 --elasticsearch-data-dir "" ...
```

@beniwohli I'm pretty sure this versioned data dir has been here for a long time, do you recall why or if this is a bad idea?  I hesitate to add yet another option to control this but can do it if there's a risk this will cause people problems.