### PR TITLE
update frontend directives to rum

### DIFF
--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -604,7 +604,7 @@ class LocalTest(unittest.TestCase):
             apm-server:
                 cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
                 cap_drop: [ALL]
-                command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
+                command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.rum.enabled=true, -E, apm-server.rum.event_rate.limit=1000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
                     -E, 'setup.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,


### PR DESCRIPTION
to fix test failures caused by disabled rum endpoint (since nothing enabled them)

following https://github.com/elastic/apm-server/pull/1751

```
<6.5 configures only v1
>=6.5,<7.0 configures both v1 and v2
>=7.0 configures only v2
```