### PR TITLE
disable elasticsearch disk allocation decider

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -581,7 +581,12 @@ class ApmServer(StackService, Service):
 
 
 class Elasticsearch(StackService, Service):
-    default_environment = ["cluster.name=docker-cluster", "bootstrap.memory_lock=true", "discovery.type=single-node"]
+    default_environment = [
+        "bootstrap.memory_lock=true",
+        "cluster.name=docker-cluster",
+        "discovery.type=single-node",
+        "cluster.routing.allocation.disk.threshold_enabled=false",
+    ]
     default_heap_size = "1g"
 
     SERVICE_PORT = 9200

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -473,7 +473,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.2.10_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
+                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, discovery.type=single-node, cluster.routing.allocation.disk.threshold_enabled=false, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -550,7 +550,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.3.10_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, discovery.type=single-node, cluster.routing.allocation.disk.threshold_enabled=false, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -630,7 +630,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_7.0.10-alpha1_elasticsearch
-                environment: [cluster.name=docker-cluster, bootstrap.memory_lock=true, discovery.type=single-node, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/7.0.10-alpha1, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, discovery.type=single-node, cluster.routing.allocation.disk.threshold_enabled=false, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/7.0.10-alpha1, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10


### PR DESCRIPTION
resolved issues locally with:
```ClusterBlockException[blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];]```

I hope this is resolves some of the flakiness seen under CI.