### PR TITLE
fix opbeans-rum healthcheck

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1508,7 +1508,7 @@ class OpbeansRum(Service):
             ],
             image=None,
             labels=None,
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, "opbeans-rum", path="/"),
+            healthcheck=curl_healthcheck(self.SERVICE_PORT, path="/"),
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
         return content

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -335,7 +335,7 @@ class OpbeansServiceTest(ServiceTest):
                          opbeans-node:
                              condition: service_healthy
                      healthcheck:
-                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-rum:9222/"]
+                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://localhost:9222/"]
                          interval: 5s
                          retries: 12""")  # noqa: 501
         )


### PR DESCRIPTION
working around need for host header