### PR TITLE
[APM-CI] access to variable using "params"

### DIFF
--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -88,7 +88,7 @@ pipeline {
           )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{
-          currentBuild.description = "Agent ${params.agent_integration_test} Integration test ${UPSTREAM_BUILD}"
+          currentBuild.description = "Agent ${params.agent_integration_test} Integration test ${params.UPSTREAM_BUILD}"
         }
       }
     }


### PR DESCRIPTION
the environment variable is not defined in the first build, so we have to use params to access to it