### PR TITLE
fix support to use APM server token

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -399,7 +399,7 @@ class ApmServer(StackService, Service):
                     ("setup.dashboards.enabled", "true")
                 )
 
-        if self.options.get("apm-server-secret-token"):
+        if self.options.get("apm_server_secret_token"):
             self.apm_server_command_args.append(("apm-server.secret_token", self.options["apm_server_secret_token"]))
 
         self.apm_server_monitor_port = options.get("apm_server_monitor_port", self.DEFAULT_MONITOR_PORT)
@@ -496,6 +496,7 @@ class ApmServer(StackService, Service):
         )
         parser.add_argument(
             '--apm-server-secret-token',
+            dest="apm_server_secret_token",
             help="apm-server secret token.",
         )
         parser.add_argument(
@@ -992,7 +993,7 @@ class AgentPythonDjango(AgentPython):
     SERVICE_PORT = 8003
 
     @add_agent_environment([
-        ("apm_server_secret_token", "APM_SERVER_SECRET_TOKEN"),
+        ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):
@@ -1017,7 +1018,7 @@ class AgentPythonFlask(AgentPython):
     SERVICE_PORT = 8001
 
     @add_agent_environment([
-        ("apm_server_secret_token", "APM_SERVER_SECRET_TOKEN"),
+        ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):


### PR DESCRIPTION
The `apm-server.secret_token` parameter now is set to the APM Server command line and every client container has set the `ELASTIC_APM_SECRET_TOKEN` environment variable.