### PR TITLE
[APM-CI] get docker logs and containers info at the end of tests

### DIFF
--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -205,7 +205,10 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
   public Closure generateStep(x, y){
     return {
       steps.node('linux && immutable'){
-        def env = ["APM_SERVER_BRANCH=${y}", "${agentEnvVar[tag]}=${x}"]
+        def env = ["APM_SERVER_BRANCH=${y}", 
+          "${agentEnvVar[tag]}=${x}",
+          "REUSE_CONTAINERS=true"
+          ]
         def label = "${tag}-${x}-${y}"
         try{
           steps.runScript(label: label, agentType: tag, env: env)
@@ -214,6 +217,12 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
           saveResult(x, y, 0)
           error("${label} tests failed : ${e}\n")
         } finally {
+          steps.sh('./scripts/docker-get-logs.sh')
+          steps.sh('make stop-env || echo 0')
+          steps.archiveArtifacts(
+              allowEmptyArchive: true, 
+              artifacts: 'docker-info', 
+              defaultExcludes: false)
           steps.junit(
             allowEmptyResults: false, 
             keepLongStdio: true, 

--- a/scripts/docker-get-logs.sh
+++ b/scripts/docker-get-logs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+mkdir -p docker-info
+cd docker-info
+
+docker ps -a &> docker-containers.txt
+
+DOCKER_IDS=$(docker ps -aq)
+
+for id in ${DOCKER_IDS}
+do
+  docker ps -af id=${id} --no-trunc &> ${id}-cmd.txt
+  docker logs ${id} &> ${id}.log
+  docker inspect ${id} &> ${id}-inspect.json
+done


### PR DESCRIPTION
same https://github.com/elastic/apm-integration-testing/pull/293 for 6.x branch