### PR TITLE
update agent/stack version matrix

### DIFF
--- a/tests/versions/java.yml
+++ b/tests/versions/java.yml
@@ -1,3 +1,6 @@
 JAVA_AGENT:
   - 'github;master'
   - 'github;v1.0.1'
+  - 'github;v1.1.0'
+  - 'github;v1.2.0'
+  - 'github;v1.3.0'

--- a/tests/versions/nodejs.yml
+++ b/tests/versions/nodejs.yml
@@ -2,5 +2,5 @@ NODEJS_AGENT:
   # github;version -> npm install elastic/apm-agent-nodejs#version
   # release;version -> npm install elastic-apm-node@version
   - 'github;master'
-  - 'release;1'
   - 'release;latest'
+  - 'release;2'

--- a/tests/versions/python.yml
+++ b/tests/versions/python.yml
@@ -4,4 +4,4 @@ PYTHON_AGENT:
   # release;release -> pip install elastic-apm==version
   - 'github;master'
   - 'release;latest'
-  - 'release;3.0'
+  - 'release;4.0'

--- a/tests/versions/ruby.yml
+++ b/tests/versions/ruby.yml
@@ -3,5 +3,5 @@ RUBY_AGENT:
   # release;latest -> gem elastic-apm
   # release;version -> gem elastic-apm, version
   - 'github;master'
-  - 'github;1.x'
+  - 'github;2.x'
   - 'release;latest'


### PR DESCRIPTION
based on https://www.elastic.co/guide/en/apm/get-started/6.6/agent-server-compatibility.html, restrict tests against the latest Elastic Stack to compatible agent versions.