### PR TITLE
[6.x] fix support to use APM server token (#292)

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -386,7 +386,7 @@ class ApmServer(StackService, Service):
                     ("setup.dashboards.enabled", "true")
                 )
 
-        if self.options.get("apm-server-secret-token"):
+        if self.options.get("apm_server_secret_token"):
             self.apm_server_command_args.append(("apm-server.secret_token", self.options["apm_server_secret_token"]))
 
         self.apm_server_monitor_port = options.get("apm_server_monitor_port", self.DEFAULT_MONITOR_PORT)
@@ -481,6 +481,7 @@ class ApmServer(StackService, Service):
         )
         parser.add_argument(
             '--apm-server-secret-token',
+            dest="apm_server_secret_token",
             help="apm-server secret token.",
         )
         parser.add_argument(
@@ -964,7 +965,7 @@ class AgentPythonDjango(AgentPython):
     SERVICE_PORT = 8003
 
     @add_agent_environment([
-        ("apm_server_secret_token", "APM_SERVER_SECRET_TOKEN"),
+        ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):
@@ -989,7 +990,7 @@ class AgentPythonFlask(AgentPython):
     SERVICE_PORT = 8001
 
     @add_agent_environment([
-        ("apm_server_secret_token", "APM_SERVER_SECRET_TOKEN"),
+        ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix support to use APM server token  (#292)