### PR TITLE
pin sqlite3 ruby gem

### DIFF
--- a/docker/ruby/rails/testapp/Gemfile
+++ b/docker/ruby/rails/testapp/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 

--- a/docker/ruby/rails/testapp/config/elastic_apm.yml
+++ b/docker/ruby/rails/testapp/config/elastic_apm.yml
@@ -1,1 +1,0 @@
-flush_interval: 1


### PR DESCRIPTION
to address startup error causing some test failures for the ruby agent:

```
=> Booting Puma
=> Rails 5.2.2 application starting in production 
=> Run `rails server -h` for more startup options
W, [2019-02-05T02:13:53.731384 #1]  WARN -- : [ElasticAPM] The option `flush_interval=' has been removed.
/usr/local/lib/ruby/2.6.0/bundler/rubygems_integration.rb:408:in `block (2 levels) in replace_gem': Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0. Make sure all dependencies are added to Gemfile. (LoadError)
```

takes care of that `flush_interval` warning too, `api_request_time` is already `50ms` for v2 communication.