### PR TITLE
rudimentary xpack security support

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -1,12 +1,4 @@
-admin:
-  cluster:
-    - all
+apm_server:
   indices:
-    - names:
-        - '*'
-      privileges:
-        - all
-
-test_admin:
-  cluster:
-    - all
+    - names: [ 'apm-*' ]
+      privileges: [ 'all' ]

--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -1,0 +1,12 @@
+admin:
+  cluster:
+    - all
+  indices:
+    - names:
+        - '*'
+      privileges:
+        - all
+
+test_admin:
+  cluster:
+    - all

--- a/docker/elasticsearch/users
+++ b/docker/elasticsearch/users
@@ -1,2 +1,4 @@
-admin:$2y$05$bgM5Jq55QVzmR5XeOGeumOvMLefWijeAJS3wM4TK7LtDt/nvdAU2.
-test_admin_user:$2y$05$OarkAe72m1mFguy0qr7XHOsNe8NFJxyEhaTUOtw2V8oJMaXLO1u6a
+admin:$2a$10$xiY0ZzOKmDDN1p3if4t4muUBwh2.bFHADoMRAWQgSClm4ZJ4132Y.
+apm_server_user:$2a$10$iTy29qZaCSVn4FXlIjertuO8YfYVLCbvoUAJ3idaXfLRclg9GXdGG
+apm_user_ro:$2a$10$hQfy2o2u33SapUClsx8NCuRMpQyHP9b2l4t3QqrBA.5xXN2S.nT4u
+kibana_system_user:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW

--- a/docker/elasticsearch/users
+++ b/docker/elasticsearch/users
@@ -1,0 +1,2 @@
+admin:$2y$05$bgM5Jq55QVzmR5XeOGeumOvMLefWijeAJS3wM4TK7LtDt/nvdAU2.
+test_admin_user:$2y$05$OarkAe72m1mFguy0qr7XHOsNe8NFJxyEhaTUOtw2V8oJMaXLO1u6a

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -1,0 +1,2 @@
+admin:admin
+test_admin:test_admin_user

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -1,2 +1,7 @@
-admin:admin
-test_admin:test_admin_user
+apm_server:apm_server_user
+apm_system:apm_server_user
+apm_user:apm_user_ro
+ingest_admin:apm_server_user
+kibana_system:kibana_system_user
+kibana_user:apm_user_ro
+superuser:admin

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -394,7 +394,8 @@ class ApmServer(StackService, Service):
 
         if self.options.get("enable_kibana", True):
             self.depends_on["kibana"] = {"condition": "service_healthy"}
-            if options.get("apm_server_dashboards", True) and not self.at_least_version("7.0"):
+            if options.get("apm_server_dashboards", True) and not self.at_least_version("7.0") \
+                    and not self.options.get("xpack_secure"):
                 self.apm_server_command_args.append(
                     ("setup.dashboards.enabled", "true")
                 )

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -739,8 +739,8 @@ class Kibana(StackService, Service):
             if self.at_least_version("6.3"):
                 self.environment["XPACK_XPACK_MAIN_TELEMETRY_ENABLED"] = "false"
             if options.get("xpack_secure"):
-                self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
+                self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
 
     def _content(self):

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -625,7 +625,8 @@ class Elasticsearch(StackService, Service):
             xpack_security_enabled = "false"
             if self.xpack_secure:
                 xpack_security_enabled = "true"
-                # self.environment.append("xpack.security.audit.enabled=true")
+                if options.get("elasticsearch_xpack_audit"):
+                    self.environment.append("xpack.security.audit.enabled=true")
                 self.environment.append("xpack.security.authc.anonymous.roles=remote_monitoring_collector")
                 if self.at_least_version("7.0"):
                     self.environment.append("xpack.security.authc.realms.file.file1.order=0")
@@ -648,6 +649,12 @@ class Elasticsearch(StackService, Service):
             "--elasticsearch-heap",
             default=Elasticsearch.default_heap_size,
             help="min/max elasticsearch heap size, for -Xms -Xmx jvm options."
+        )
+
+        parser.add_argument(
+            "--elasticsearch-xpack-audit",
+            action="store_true",
+            help="enable very verbose xpack auditing",
         )
 
         class storeDict(argparse.Action):

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -412,14 +412,14 @@ class ApmServer(StackService, Service):
 
         def add_es_config(args, prefix="output"):
             """add elasticsearch configuration options."""
+            default_apm_server_creds = {"username": "apm_server_user", "password": "changeme"}
             args.append((prefix+".elasticsearch.hosts", json.dumps(es_urls)))
             for cfg in ("username", "password"):
                 es_opt = "apm_server_elasticsearch_{}".format(cfg)
                 if self.options.get(es_opt):
                     args.append((prefix + ".elasticsearch.{}".format(cfg), self.options[es_opt]))
                 elif self.options.get("xpack_secure"):
-                    args.append((prefix + ".elasticsearch.{}".format(cfg),
-                        {"username": "apm_server_user", "password": "changeme"}.get(cfg)))
+                    args.append((prefix + ".elasticsearch.{}".format(cfg), default_apm_server_creds.get(cfg)))
 
         add_es_config(self.apm_server_command_args)
 

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -656,6 +656,13 @@ class Elasticsearch(StackService, Service):
         )
 
     def _content(self):
+        volumes = ["esdata:/usr/share/elasticsearch/data"]
+        if self.secure:
+            volumes.extend([
+                "./docker/elasticsearch/roles.yml:/usr/share/elasticsearch/config/roles.yml",
+                "./docker/elasticsearch/users:/usr/share/elasticsearch/config/users",
+                "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles",
+            ])
         return dict(
             environment=self.environment,
             healthcheck={
@@ -667,7 +674,7 @@ class Elasticsearch(StackService, Service):
             ulimits={
                 "memlock": {"hard": -1, "soft": -1},
             },
-            volumes=["esdata:/usr/share/elasticsearch/data"]
+            volumes=volumes,
         )
 
     @staticmethod

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -621,7 +621,7 @@ class Elasticsearch(StackService, Service):
             xpack_security_enabled = "false"
             if self.secure:
                 xpack_security_enabled = "true"
-                self.environment.append("xpack.security.authc.realms.file1.type=file")
+                self.environment.append("xpack.security.authc.realms.file.file1.order=0")
             self.environment.append("xpack.security.enabled=" + xpack_security_enabled)
             self.environment.append("xpack.license.self_generated.type=trial")
             if self.at_least_version("6.3"):

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -625,7 +625,7 @@ class Elasticsearch(StackService, Service):
             xpack_security_enabled = "false"
             if self.xpack_secure:
                 xpack_security_enabled = "true"
-                self.environment.append("xpack.security.audit.enabled=true")
+                # self.environment.append("xpack.security.audit.enabled=true")
                 self.environment.append("xpack.security.authc.anonymous.roles=monitoring_user")
                 if self.at_least_version("7.0"):
                     self.environment.append("xpack.security.authc.realms.file.file1.order=0")

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -626,7 +626,7 @@ class Elasticsearch(StackService, Service):
             if self.xpack_secure:
                 xpack_security_enabled = "true"
                 # self.environment.append("xpack.security.audit.enabled=true")
-                self.environment.append("xpack.security.authc.anonymous.roles=monitoring_user")
+                self.environment.append("xpack.security.authc.anonymous.roles=remote_monitoring_collector")
                 if self.at_least_version("7.0"):
                     self.environment.append("xpack.security.authc.realms.file.file1.order=0")
                 else:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -681,6 +681,7 @@ class LocalTest(unittest.TestCase):
         apm_server_cmd = got["services"]["apm-server"]["command"]
         self.assertTrue(any(cmd.startswith("output.elasticsearch.password=") for cmd in apm_server_cmd), apm_server_cmd)
         self.assertTrue(any(cmd.startswith("output.elasticsearch.username=") for cmd in apm_server_cmd), apm_server_cmd)
+        self.assertFalse(any(cmd == "setup.dashboards.enabled=true" for cmd in apm_server_cmd), apm_server_cmd)
         # elasticsearch configuration
         es_env = got["services"]["elasticsearch"]["environment"]
         ## auditing enabled

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -687,7 +687,7 @@ class LocalTest(unittest.TestCase):
         ## auditing enabled
         #self.assertIn("xpack.security.audit.enabled=true", es_env)
         ## allow anonymous healthcheck (doesn't work in 6.x though)
-        self.assertIn("xpack.security.authc.anonymous.roles=monitoring_user", es_env)
+        self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
         ## file based realm
         self.assertIn("xpack.security.authc.realms.file1.type=file", es_env)
         # kibana should use user/pass -> es
@@ -715,7 +715,7 @@ class LocalTest(unittest.TestCase):
         ## auditing enabled
         #self.assertIn("xpack.security.audit.enabled=true", es_env)
         ## allow anonymous healthcheck
-        self.assertIn("xpack.security.authc.anonymous.roles=monitoring_user", es_env)
+        self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
         ## file based realm
         self.assertIn("xpack.security.authc.realms.file.file1.order=0", es_env)
         # kibana should use user/pass -> es

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -672,7 +672,7 @@ class LocalTest(unittest.TestCase):
     def test_start_6_x_xpack_secure(self, _ignore_load_images):
         docker_compose_yml = stringIO()
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.6': '6.6.10'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["6.6", "--xpack-secure"])
+            setup = LocalSetup(argv=self.common_setup_args + ["6.6", "--xpack-secure", "--elasticsearch-xpack-audit"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -685,8 +685,8 @@ class LocalTest(unittest.TestCase):
         # elasticsearch configuration
         es_env = got["services"]["elasticsearch"]["environment"]
         ## auditing enabled
-        #self.assertIn("xpack.security.audit.enabled=true", es_env)
-        ## allow anonymous healthcheck (doesn't work in 6.x though)
+        self.assertIn("xpack.security.audit.enabled=true", es_env)
+        ## allow anonymous healthcheck
         self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
         ## file based realm
         self.assertIn("xpack.security.authc.realms.file1.type=file", es_env)
@@ -712,8 +712,8 @@ class LocalTest(unittest.TestCase):
         self.assertTrue(any(cmd.startswith("output.elasticsearch.username=") for cmd in apm_server_cmd), apm_server_cmd)
         # elasticsearch configuration
         es_env = got["services"]["elasticsearch"]["environment"]
-        ## auditing enabled
-        #self.assertIn("xpack.security.audit.enabled=true", es_env)
+        ## auditing disabled by default
+        self.assertNotIn("xpack.security.audit.enabled=true", es_env)
         ## allow anonymous healthcheck
         self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
         ## file based realm

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -669,6 +669,62 @@ class LocalTest(unittest.TestCase):
         self.assertDictEqual(got, want)
 
     @mock.patch(compose.__name__ + '.load_images')
+    def test_start_6_x_xpack_secure(self, _ignore_load_images):
+        docker_compose_yml = stringIO()
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.6': '6.6.10'}):
+            setup = LocalSetup(argv=self.common_setup_args + ["6.6", "--xpack-secure"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        # apm-server should use user/pass -> es
+        apm_server_cmd = got["services"]["apm-server"]["command"]
+        self.assertTrue(any(cmd.startswith("output.elasticsearch.password=") for cmd in apm_server_cmd), apm_server_cmd)
+        self.assertTrue(any(cmd.startswith("output.elasticsearch.username=") for cmd in apm_server_cmd), apm_server_cmd)
+        # elasticsearch configuration
+        es_env = got["services"]["elasticsearch"]["environment"]
+        ## auditing enabled
+        self.assertIn("xpack.security.audit.enabled=true", es_env)
+        ## allow anonymous healthcheck (doesn't work in 6.x though)
+        self.assertIn("xpack.security.authc.anonymous.roles=monitoring_user", es_env)
+        ## file based realm
+        self.assertIn("xpack.security.authc.realms.file1.type=file", es_env)
+        # kibana should use user/pass -> es
+        kibana_env = got["services"]["kibana"]["environment"]
+        self.assertIn("ELASTICSEARCH_PASSWORD", kibana_env)
+        self.assertIn("ELASTICSEARCH_USERNAME", kibana_env)
+        ## allow anonymous healthcheck
+        self.assertIn("STATUS_ALLOWANONYMOUS", kibana_env)
+
+    @mock.patch(compose.__name__ + '.load_images')
+    def test_start_7_0_xpack_secure(self, _ignore_load_images):
+        docker_compose_yml = stringIO()
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '7.0.10'}):
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--xpack-secure"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        # apm-server should use user/pass -> es
+        apm_server_cmd = got["services"]["apm-server"]["command"]
+        self.assertTrue(any(cmd.startswith("output.elasticsearch.password=") for cmd in apm_server_cmd), apm_server_cmd)
+        self.assertTrue(any(cmd.startswith("output.elasticsearch.username=") for cmd in apm_server_cmd), apm_server_cmd)
+        # elasticsearch configuration
+        es_env = got["services"]["elasticsearch"]["environment"]
+        ## auditing enabled
+        self.assertIn("xpack.security.audit.enabled=true", es_env)
+        ## allow anonymous healthcheck
+        self.assertIn("xpack.security.authc.anonymous.roles=monitoring_user", es_env)
+        ## file based realm
+        self.assertIn("xpack.security.authc.realms.file.file1.order=0", es_env)
+        # kibana should use user/pass -> es
+        kibana_env = got["services"]["kibana"]["environment"]
+        self.assertIn("ELASTICSEARCH_PASSWORD", kibana_env)
+        self.assertIn("ELASTICSEARCH_USERNAME", kibana_env)
+        ## allow anonymous healthcheck
+        self.assertIn("STATUS_ALLOWANONYMOUS", kibana_env)
+
+    @mock.patch(compose.__name__ + '.load_images')
     def test_start_no_elasticesarch(self, _ignore_load_images):
         docker_compose_yml = stringIO()
         setup = LocalSetup(argv=self.common_setup_args + ["master", "--no-elasticsearch"])

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -685,7 +685,7 @@ class LocalTest(unittest.TestCase):
         # elasticsearch configuration
         es_env = got["services"]["elasticsearch"]["environment"]
         ## auditing enabled
-        self.assertIn("xpack.security.audit.enabled=true", es_env)
+        #self.assertIn("xpack.security.audit.enabled=true", es_env)
         ## allow anonymous healthcheck (doesn't work in 6.x though)
         self.assertIn("xpack.security.authc.anonymous.roles=monitoring_user", es_env)
         ## file based realm
@@ -713,7 +713,7 @@ class LocalTest(unittest.TestCase):
         # elasticsearch configuration
         es_env = got["services"]["elasticsearch"]["environment"]
         ## auditing enabled
-        self.assertIn("xpack.security.audit.enabled=true", es_env)
+        #self.assertIn("xpack.security.audit.enabled=true", es_env)
         ## allow anonymous healthcheck
         self.assertIn("xpack.security.authc.anonymous.roles=monitoring_user", es_env)
         ## file based realm


### PR DESCRIPTION
Introduce a new option `--xpack-secure` to enable xpack security in elasticsearch, requiring authentication for all es operations except cluster monitoring.  Kibana prompts for login except for status checks.  Only kibana and apm-server are automatically to communicate with elasticsearch with a password - that's probably a problem for any opbeans apps that use es.

Provided users are: `admin` `apm_server_user` `apm_user_ro` `kibana_system_user` all with password `changeme`

This doesn't work perfectly with 6.x.  No care was taken to make it work with pre-6.6 versions, yet.
* apm-server is not able to load dashboards, it doesn't try to regardless of `--no-apm-server-dashboards` setting when `--xpack-secure` is set.
```
localtesting_6.6.0_apm-server | Exiting: Error importing Kibana dashboards: fail to import the dashboards in Kibana: Error importing directory /usr/share/apm-server/kibana: Failed to import index-pattern: Failed to load directory /usr/share/apm-server/kibana/6/index-pattern:
localtesting_6.6.0_apm-server |   error loading /usr/share/apm-server/kibana/6/index-pattern/apmserver.json: action [indices:data/write/bulk[s]] is unauthorized for user [apm_server_user]. Response: {"objects":[{"id":"apm-*","type":"index-pattern","error":{"message":"action [indices:data/write/bulk[s]] is unauthorized for user [apm_server_user]"}}]}
```

Fun fact, the elasticsearch healthcheck passes even when it shouldn't, eg this passes:
```
curl -s http://localhost:9200/_cluster/health 
{"error":{"root_cause":[{"type":"security_exception","reason":"action [cluster:monitor/health] is unauthorized for user [_anonymous]"}],"type":"security_exception","reason":"action [cluster:monitor/health] is unauthorized for user [_anonymous]"},"status":403}
```

To set passwords for built-in users, something like this works:
`docker-compose exec elasticsearch bin/elasticsearch-setup-passwords auto` 