### PR TITLE
[APM-CI] move the job location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
 }
 
 def runJob(agentName){
-  def job = build(job: 'apm-server/apm-integration-test-axis-pipeline',
+  def job = build(job: 'apm-integration-test-axis-pipeline',
     parameters: [
     string(name: 'agent_integration_test', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),


### PR DESCRIPTION
We move the job in a PR to the infra repo, as soon as it is merged we have to merge this one to change the downstream job location.
