### PR TITLE
define snapshot file system repository

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -585,8 +585,9 @@ class Elasticsearch(StackService, Service):
     default_environment = [
         "bootstrap.memory_lock=true",
         "cluster.name=docker-cluster",
-        "discovery.type=single-node",
         "cluster.routing.allocation.disk.threshold_enabled=false",
+        "discovery.type=single-node",
+        "path.repo=/usr/share/elasticsearch/data/backups",
     ]
     default_heap_size = "1g"
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -473,7 +473,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.2.10_elasticsearch
-                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, discovery.type=single-node, cluster.routing.allocation.disk.threshold_enabled=false, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
+                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, cluster.routing.allocation.disk.threshold_enabled=false, discovery.type=single-node, path.repo=/usr/share/elasticsearch/data/backups, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -550,7 +550,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_6.3.10_elasticsearch
-                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, discovery.type=single-node, cluster.routing.allocation.disk.threshold_enabled=false, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, cluster.routing.allocation.disk.threshold_enabled=false, discovery.type=single-node, path.repo=/usr/share/elasticsearch/data/backups, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -630,7 +630,7 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_7.0.10-alpha1_elasticsearch
-                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, discovery.type=single-node, cluster.routing.allocation.disk.threshold_enabled=false, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/7.0.10-alpha1, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, cluster.routing.allocation.disk.threshold_enabled=false, discovery.type=single-node, path.repo=/usr/share/elasticsearch/data/backups, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/7.0.10-alpha1, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
                 healthcheck:
                     interval: '20'
                     retries: 10


### PR DESCRIPTION
On the es volume.

Quick summary of backup/restore for apm, based on https://www.elastic.co/guide/en/elasticsearch/reference/6.6/modules-snapshots.html:

# Backup

## Create snapshot repo

```
PUT _snapshot/apm-backup
{
  "type": "fs",
  "settings": {
    "location": "/usr/share/elasticsearch/data/backups",
    "compress": true
  }
}
```

## Take backup
```
PUT _snapshot/apm-backup/snapshot?wait_for_completion=true
{
  "indices": "apm-*",
  "ignore_unavailable": true,
  "include_global_state": false
}
```

## Export backup from container
```
docker-compose exec -T elasticsearch tar -C /usr/share/elasticsearch/data -czf - backups/ > apm-backup.tar.gz
```

# Restore

## Create snapshot repo
```
PUT _snapshot/apm-restore
{
  "type": "fs",
  "settings": {
    "location": "/usr/share/elasticsearch/data/backups",
    "compress": true
  }
}
```

## Copy backup into container
```
docker-compose exec -T elasticsearch tar -C /usr/share/elasticsearch/data -xzf - < apm-backup.tar.gz 
```

## Restore backup
```
POST /_snapshot/apm-restore/snapshot/_restore
```
