### PR TITLE
[6.x] pin sqlite3 ruby gem (#303)

### DIFF
--- a/docker/ruby/rails/testapp/Gemfile
+++ b/docker/ruby/rails/testapp/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 

--- a/docker/ruby/rails/testapp/config/elastic_apm.yml
+++ b/docker/ruby/rails/testapp/config/elastic_apm.yml
@@ -1,1 +1,0 @@
-flush_interval: 1


### PR DESCRIPTION
Backports the following commits to 6.x:
 - pin sqlite3 ruby gem  (#303)