### PR TITLE
[ruby] Inc queue size, avoid deprecated method call. (#372)

### DIFF
--- a/docker/ruby/rails/testapp/Gemfile
+++ b/docker/ruby/rails/testapp/Gemfile
@@ -25,7 +25,7 @@ if ENV['RUBY_AGENT_VERSION_STATE']=='release'
   if ENV['RUBY_AGENT_VERSION'] == 'latest' 
     gem 'elastic-apm'
   else 
-    gem 'elastic-apm', ENV['RUBY_AGENT_VERSION']
+    gem 'elastic-apm', "~> #{ENV['RUBY_AGENT_VERSION']}"
   end
 else
   gem 'elastic-apm', git: 'https://github.com/elastic/apm-agent-ruby.git', branch: ENV['RUBY_AGENT_VERSION']

--- a/docker/ruby/rails/testapp/app/controllers/application_controller.rb
+++ b/docker/ruby/rails/testapp/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::API
   end
 
   def extra_span
-    ElasticAPM.span 'app.extra' do
+    ElasticAPM.with_span 'app.extra' do
       "extra"
     end
   end

--- a/docker/ruby/rails/testapp/config/application.rb
+++ b/docker/ruby/rails/testapp/config/application.rb
@@ -31,9 +31,9 @@ module Minimal
     # Elastic APM config
     config.elastic_apm.ignore_url_patterns = '/healthcheck'
 
-
     if apm = Gem.loaded_specs["elastic-apm"]
-      config.elastic_apm.api_request_time = '50ms' if apm.version >= Gem::Version.new("2.0")
+      config.elastic_apm.api_request_time = '50ms'
+      config.elastic_apm.api_buffer_size = 2000
     end
   end
 end

--- a/tests/agent/test_ruby.py
+++ b/tests/agent/test_ruby.py
@@ -5,18 +5,21 @@ from tests.agent.concurrent_requests import Concurrent
 
 
 @pytest.mark.version
+@pytest.mark.rails
 def test_req_rails(rails):
     utils.check_agent_transaction(
         rails.foo, rails.apm_server.elasticsearch)
 
 
 @pytest.mark.version
+@pytest.mark.rails
 def test_rails_error(rails):
     utils.check_agent_error(
         rails.oof, rails.apm_server.elasticsearch)
 
 
 @pytest.mark.version
+@pytest.mark.rails
 def test_conc_req_rails(es, apm_server, rails):
     foo = Concurrent.Endpoint(rails.foo.url,
                               rails.app_name,
@@ -27,6 +30,7 @@ def test_conc_req_rails(es, apm_server, rails):
 
 
 @pytest.mark.version
+@pytest.mark.rails
 def test_conc_req_rails_foobar(es, apm_server, rails):
     foo = Concurrent.Endpoint(rails.foo.url,
                               rails.app_name,


### PR DESCRIPTION
Set internal queue size from 250 to 2000 to avoid flaky results due to
dropping events. Install proper agent version. Use new API and remove deprecated call to `span`.