### PR TITLE
[APM-CI] ignore errors when get docker info

### DIFF
--- a/scripts/docker-get-logs.sh
+++ b/scripts/docker-get-logs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 STEP=${1:-""}
 
@@ -13,6 +13,6 @@ DOCKER_IDS=$(docker ps -aq)
 for id in ${DOCKER_IDS}
 do
   docker ps -af id=${id} --no-trunc &> ${id}-cmd.txt
-  docker logs ${id} &> ${id}.log
-  docker inspect ${id} &> ${id}-inspect.json
+  docker logs ${id} &> ${id}.log || echo "It is not possible to grab the logs of ${id}"
+  docker inspect ${id} &> ${id}-inspect.json || echo "It is not possible to grab the inspect of ${id}"
 done

--- a/scripts/docker-summary.sh
+++ b/scripts/docker-summary.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 echo "***************Docker Containers Summary***************"
 docker ps -a
@@ -10,6 +10,6 @@ for id in ${DOCKER_IDS}
 do
   echo "***************Docker Container ${id}***************"
   docker ps -af id=${id} --no-trunc
-  docker logs ${id} | tail -n 10
+  docker logs ${id} | tail -n 10 || echo "It is not possible to grab the logs of ${id}"
 done
 echo "*******************************************************"


### PR DESCRIPTION
In some cases, the script tries to grab info from Docker image stages, it cannot grab logs and it fails.