### PR TITLE
[APM-CI] not use flyweight Jenkins agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'flyweight' }
+      agent { label 'master || (linux && immutable)' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -42,7 +42,7 @@ pipeline {
     }
 
     stage("All Test Only") {
-      agent { label 'flyweight' }
+      agent { label 'master || (linux && immutable)' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
@@ -56,7 +56,7 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests") {
-      agent { label 'flyweight' }
+      agent { label 'master || (linux && immutable)' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -78,7 +78,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'flyweight' }
+      agent { label 'master || (linux && immutable)' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -105,7 +105,7 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests"){
-      agent { label 'flyweight' }
+      agent { label 'master || (linux && immutable)' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true


### PR DESCRIPTION
There are some problems with the use of the flyweight Jenkins agents, the recommendation is to not use them.