### PR TITLE
[APM-CI] store docker info in folders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,12 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '100', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   triggers {
     cron 'H H(3-4) * * 1-5'

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -59,7 +59,7 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '100', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '300', artifactNumToKeepStr: '300', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()
@@ -152,7 +152,7 @@ pipeline {
       }
       post {
         always {
-          wrappingup('-all')
+          wrappingup('all')
         }
       }
     }
@@ -255,16 +255,14 @@ def runScript(Map params = [:]){
 
 def wrappingup(label){
   dir("${BASE_DIR}"){
-    def stepName = "-" + label.replace(";","_")
-      .replace("#","_")
-      .replace(":","_")
-      .replace("-","_")
+    def stepName = "-" + label.replace(";","/")
+      .replace("--","_")
       .replace(".","_")
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
     sh('make stop-env || echo 0')
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info*/**',
+        artifacts: 'docker-info/**',
         defaultExcludes: false)
     junit(
       allowEmptyResults: false,

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -255,7 +255,7 @@ def runScript(Map params = [:]){
 
 def wrappingup(label){
   dir("${BASE_DIR}"){
-    def stepName = "-" + label.replace(";","/")
+    def stepName = label.replace(";","/")
       .replace("--","_")
       .replace(".","_")
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")

--- a/scripts/docker-get-logs.sh
+++ b/scripts/docker-get-logs.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 STEP=${1:-""}
 
-mkdir -p docker-info${STEP}
-cd docker-info${STEP}
+mkdir -p docker-info/${STEP}
+cd docker-info/${STEP}
 
 docker ps -a &> docker-containers.txt
 


### PR DESCRIPTION
* It changes the way to store the docker info in folders instead of only one folder.
* Increase the build history
* Limit to 60 the max number of builds per hour 