### PR TITLE
[APM-CI] stabilize integration test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,14 @@
 # editorconfig.org
 root = true
 
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 [Jenkinsfile*]
 indent_style = space
 indent_size = 2
@@ -10,6 +18,22 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.groovy]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
 indent_style = space
 indent_size = 2
 end_of_line = lf

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
         /*
           Declarative pipeline's parallel stages lose the reference to the downstream job,
           because of that, I use the parallel step. It is probably a bug.
+          https://issues.jenkins-ci.org/browse/JENKINS-56562
         */
         script {
           def downstreamJobs = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
@@ -34,7 +35,6 @@ pipeline {
     */
     stage('Checkout'){
       agent { label 'master || immutable' }
-      options { skipDefaultCheckout() }
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
@@ -103,7 +103,7 @@ def runJob(agentName, buildOpts = ''){
     string(name: 'INTEGRATION_TESTING_VERSION', value: env.GIT_BASE_COMMIT),
     string(name: 'BUILD_OPTS', value: buildOpts),
     string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
-    booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: true)],
+    booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: false)],
     propagate: true,
     quietPeriod: 10,
     wait: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@v1.0.9') _
+@Library('apm@current') _
 
 pipeline {
   agent any
@@ -103,6 +103,9 @@ pipeline {
             },
             "Ruby": {
               runJob('Ruby')
+            },
+            "RUM": {
+              runJob('RUM')
             },
             "All": {
               runJob('All')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,11 +16,12 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '100', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,9 +57,7 @@ pipeline {
         changeRequest()
       }
       steps {
-        // TODO commented to test
-        //runJob('All')
-        echo "NOOP"
+        runJob('All')
       }
     }
     /**
@@ -72,10 +70,9 @@ pipeline {
         beforeAgent true
         allOf {
           anyOf {
-            // TODO commented to test
-            //not {
+            not {
               changeRequest()
-            //}
+            }
             branch 'master'
             branch "\\d+\\.\\d+"
             branch "v\\d?"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'master || (linux && immutable)' }
+      agent { label 'master || immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -50,7 +50,7 @@ pipeline {
     }
 
     stage("All Test Only") {
-      agent { label 'master || (linux && immutable)' }
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
@@ -66,7 +66,7 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests") {
-      agent { label 'master || (linux && immutable)' }
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,9 @@ pipeline {
         changeRequest()
       }
       steps {
-        runJob('All')
+        // TODO commented to test
+        //runJob('All')
+        echo "NOOP"
       }
     }
     /**
@@ -70,9 +72,10 @@ pipeline {
         beforeAgent true
         allOf {
           anyOf {
-            not {
+            // TODO commented to test
+            //not {
               changeRequest()
-            }
+            //}
             branch 'master'
             branch "\\d+\\.\\d+"
             branch "v\\d?"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
-    booleanParam(name: 'Run_As_Master_Branch', defaultValue: true, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
+    booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }
   stages{
     /**
@@ -101,9 +101,9 @@ def runJob(agentName, buildOpts = ''){
     string(name: 'agent_integration_test', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
     string(name: 'INTEGRATION_TESTING_VERSION', value: env.GIT_BASE_COMMIT),
-    string(name: 'BUILD_OPTS', value: buildOpts),
+    string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
     string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
-    booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: false)],
+    booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
     propagate: true,
     quietPeriod: 10,
     wait: true)

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -50,7 +50,7 @@ import groovy.transform.Field
 ]
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     REPO="git@github.com:elastic/apm-integration-testing.git"
@@ -81,7 +81,6 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'master || immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -108,10 +107,7 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests"){
-      agent { label 'linux && immutable' }
-      options { skipDefaultCheckout() }
       when {
-        beforeAgent true
         expression { return params.agent_integration_test != 'All' }
       }
       steps {
@@ -137,9 +133,7 @@ pipeline {
       }
     }
     stage("All") {
-      agent { label 'linux && immutable' }
       when {
-        beforeAgent true
         expression { return params.agent_integration_test == 'All' }
       }
       environment {

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@v1.0.9') _
+@Library('apm@current') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field
@@ -19,6 +19,7 @@ import groovy.transform.Field
   'nodejs': 'tests/versions/nodejs.yml',
   'python': 'tests/versions/python.yml',
   'ruby': 'tests/versions/ruby.yml',
+  'rum': 'tests/versions/rum.yml',
   'server': 'tests/versions/apm_server.yml'
 ]
 
@@ -31,6 +32,7 @@ import groovy.transform.Field
   'nodejs': 'NODEJS_AGENT',
   'python': 'PYTHON_AGENT',
   'ruby': 'RUBY_AGENT',
+  'rum': 'RUM_AGENT',
   'server': 'APM_SERVER'
 ]
 
@@ -43,6 +45,7 @@ import groovy.transform.Field
   'Node.js': 'nodejs',
   'Python': 'python',
   'Ruby': 'ruby',
+  'RUM': 'rum',
   'All': 'all'
 ]
 
@@ -198,6 +201,7 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
     'nodejs': 'APM_AGENT_NODEJS_VERSION',
     'python': 'APM_AGENT_PYTHON_VERSION',
     'ruby': 'APM_AGENT_RUBY_VERSION',
+    'rum': 'APM_AGENT_RUM_VERSION',
     'server': 'APM_SERVER_BRANCH'
   ]
 

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -59,7 +59,7 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '100', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '300', artifactNumToKeepStr: '300', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()
@@ -152,7 +152,7 @@ pipeline {
       }
       post {
         always {
-          wrappingup('-all')
+          wrappingup('all')
         }
       }
     }
@@ -255,16 +255,14 @@ def runScript(Map params = [:]){
 
 def wrappingup(label){
   dir("${BASE_DIR}"){
-    def stepName = "-" + label.replace(";","_")
-      .replace("#","_")
-      .replace(":","_")
-      .replace("-","_")
+    def stepName = label.replace(";","/")
+      .replace("--","_")
       .replace(".","_")
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
     sh('make stop-env || echo 0')
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info*/**',
+        artifacts: 'docker-info/**',
         defaultExcludes: false)
     junit(
       allowEmptyResults: false,

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -260,7 +260,7 @@ def wrappingup(label){
     sh('make stop-env || echo 0')
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info/**',
+        artifacts: 'docker-info/**,**/tests/results/data-*.json',
         defaultExcludes: false)
     junit(
       allowEmptyResults: false,

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -78,7 +78,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'master || (linux && immutable)' }
+      agent { label 'master || immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -105,7 +105,7 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests"){
-      agent { label 'master || (linux && immutable)' }
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -70,7 +70,7 @@ pipeline {
   }
   parameters {
     choice(name: 'agent_integration_test', choices: ['Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
-    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "6.6 --release", description: "Elastic Stack Git branch/tag to use")
+    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "master", description: "Integration testing Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
     string(name: 'UPSTREAM_BUILD', defaultValue: "", description: "upstream build info to show in the description.")

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ docker-test-%:
 
 dockerized-test:
 	@echo waiting for services to be healthy
-	docker-compose-wait || (./scripts/docker-summary.sh && exit 1)
-	sleep 30
+	docker-compose-wait || (./scripts/docker-summary.sh; echo "Failed waiting for all containers are healthy"; exit 1)
+
 	./scripts/docker-summary.sh
 	
 	@echo running make $(TARGET) inside a container

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ docker-test-%:
 
 dockerized-test:
 	@echo waiting for services to be healthy
-	docker-compose-wait || (./scripts/docker-summary.sh; echo "Failed waiting for all containers are healthy"; exit 1)
+	docker-compose-wait || (./scripts/docker-summary.sh; echo "[ERROR] Failed waiting for all containers are healthy"; exit 1)
 
 	./scripts/docker-summary.sh
 	

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ docker-test-%:
 dockerized-test:
 	@echo waiting for services to be healthy
 	docker-compose-wait || (./scripts/docker-summary.sh && exit 1)
-	
+	sleep 30
 	./scripts/docker-summary.sh
 	
 	@echo running make $(TARGET) inside a container

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-helps:
 	$(foreach subcommand,$(SUBCOMMANDS), $(PYTHON) scripts/compose.py $(subcommand) --help >/dev/null || exit 1;)
 
 test-all: venv test-compose lint test-helps
-	pytest -v --ignore=tests/agent/test_python.py -s $(JUNIT_OPT)/all-junit.xml
+	pytest -v -s $(JUNIT_OPT)/all-junit.xml
 
 docker-test-%:
 	TARGET=test-$* $(MAKE) dockerized-test

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import pytest
+import json
 from tests.fixtures.transactions import minimal
 from tests.fixtures.apm_server import apm_server
 from tests.fixtures.es import es
@@ -11,3 +12,12 @@ from tests.fixtures.agents import rails
 from tests.fixtures.agents import go_nethttp
 from tests.fixtures.agents import java_spring
 from tests.fixtures.agents import rum
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item, nextitem):
+    """Called after pytest_runtest_call."""
+    outcome = yield
+    rs = es().es.search(index="apm-*")
+    with open(f'/app/tests/results/data-{item.name}.json', 'w') as outFile:
+        json.dump(rs, outFile, sort_keys=True, indent=4, ensure_ascii=False)

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -4,15 +4,16 @@ ARG RUM_AGENT_BRANCH
 ARG RUM_AGENT_REPO
 ARG APM_SERVER_URL
 
-RUN apt-get -qq update && apt-get -qq install -yq libgconf-2-4 \
-    && apt-get -qq install -y wget git --no-install-recommends \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN apt-get -qq update \
+    && apt-get -qq install -yq libgconf-2-4 \
+    && apt-get -qq install -y curl git --no-install-recommends \
+    && curl -L https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get -qq update \
     && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get -qq purge --auto-remove -y curl \
+    && apt-get -qq purge --auto-remove -y \
     && rm -rf /src/*.deb
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.

--- a/scripts/ci/all.sh
+++ b/scripts/ci/all.sh
@@ -5,6 +5,8 @@ srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.
 . ${srcdir}/common.sh
 
+# FIXME Temporarily disabled python tests
+#--with-agent-python-django --with-agent-python-flask 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-all docker-test-all

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -27,11 +27,11 @@ if [ -n "${APM_SERVER_BRANCH}" ]; then
  fi
 fi
 
-if [ -z "${DISABLE_BUILD_PARALLEL}" ]; then
+if [ -z "${DISABLE_BUILD_PARALLEL}" || "${DISABLE_BUILD_PARALLEL}" == "false" ]; then
  BUILD_OPTS="${BUILD_OPTS} --build-parallel"
 fi
 
-ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION:-'master'}
+ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION:-'7.0.0'}
 
 # assume we're under CI if BUILD_NUMBER is set
 if [ -n "${BUILD_NUMBER}" ]; then

--- a/scripts/ci/rum.sh
+++ b/scripts/ci/rum.sh
@@ -13,6 +13,6 @@ if [ -n "${APM_AGENT_RUM_VERSION}" ]; then
 fi
 
 #--with-agent-python-django 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-rumjs --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-rum docker-test-agent-rum

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -937,7 +937,7 @@ class AgentRUMJS(Service):
                 "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL)
             },
             depends_on=self.depends_on,
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, "rum", path="/run_integration_test"),
+            healthcheck=curl_healthcheck(self.SERVICE_PORT, "rum", path="/"),
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
 

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1210,7 +1210,7 @@ class AgentJavaSpring(Service):
                 "ELASTIC_APM_API_REQUEST_TIME": "3s",
                 "ELASTIC_APM_SERVICE_NAME": "springapp",
             },
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, "javaspring", path="/"),
+            healthcheck=curl_healthcheck(self.SERVICE_PORT, "javaspring"),
             depends_on=self.depends_on,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -941,6 +941,7 @@ class AgentRUMJS(Service):
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
 
+
 class AgentGoNetHttp(Service):
     SERVICE_PORT = 8080
     DEFAULT_AGENT_VERSION = "master"

--- a/scripts/docker-get-logs.sh
+++ b/scripts/docker-get-logs.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 STEP=${1:-""}
 
-mkdir -p docker-info/${STEP}
-cd docker-info/${STEP}
+DOCKR_INFO_DIR="docker-info/${STEP}"
+mkdir -p ${DOCKR_INFO_DIR}
+cp docker-compose.yml ${DOCKR_INFO_DIR}
+cd ${DOCKR_INFO_DIR}
 
 docker ps -a &> docker-containers.txt
 

--- a/scripts/docker-get-logs.sh
+++ b/scripts/docker-get-logs.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 STEP=${1:-""}
 
-mkdir -p docker-info${STEP}
-cd docker-info${STEP}
+mkdir -p docker-info/${STEP}
+cd docker-info/${STEP}
 
 docker ps -a &> docker-containers.txt
 

--- a/scripts/docker-summary.sh
+++ b/scripts/docker-summary.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "***************Docker Containers Summary***************"
-docker ps -a
-
 DOCKER_IDS=$(docker ps -aq)
 
 for id in ${DOCKER_IDS}
 do
+  echo "***********************************************************"
   echo "***************Docker Container ${id}***************"
+  echo "***********************************************************"
   docker ps -af id=${id} --no-trunc
+  echo "----"
   docker logs ${id} | tail -n 10 || echo "It is not possible to grab the logs of ${id}"
 done
+
 echo "*******************************************************"
+echo "***************Docker Containers Summary***************"
+echo "*******************************************************"
+docker ps -a

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -133,7 +133,7 @@ class OpbeansServiceTest(ServiceTest):
                         condition: service_healthy
                     healthcheck:
                       test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-java:3000/"]
-                      interval: 5s
+                      interval: 10s
                       retries: 36""")  # noqa: 501
         )
 
@@ -183,7 +183,7 @@ class OpbeansServiceTest(ServiceTest):
                             condition: service_healthy
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-node:3000/"]
-                        interval: 5s
+                        interval: 10s
                         retries: 12
                     volumes:
                         - ./docker/opbeans/node/sourcemaps:/sourcemaps""")  # noqa: 501
@@ -235,7 +235,7 @@ class OpbeansServiceTest(ServiceTest):
                             condition: service_healthy
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
-                        interval: 5s
+                        interval: 10s
                         retries: 12
             """)  # noqa: 501
         )
@@ -306,8 +306,8 @@ class OpbeansServiceTest(ServiceTest):
                         condition: service_healthy
                     healthcheck:
                       test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-ruby:3000/"]
-                      interval: 5s
-                      retries: 100""")  # noqa: 501
+                      interval: 10s
+                      retries: 50""")  # noqa: 501
 
         )
 
@@ -336,7 +336,7 @@ class OpbeansServiceTest(ServiceTest):
                              condition: service_healthy
                      healthcheck:
                          test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://localhost:9222/"]
-                         interval: 5s
+                         interval: 10s
                          retries: 12""")  # noqa: 501
         )
 
@@ -461,7 +461,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
                 healthcheck:
-                    interval: 5s
+                    interval: 10s
                     retries: 12
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:6.2.10-SNAPSHOT
@@ -494,7 +494,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                 environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
                 healthcheck:
-                    interval: 5s
+                    interval: 10s
                     retries: 20
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana-x-pack:6.2.10-SNAPSHOT
@@ -538,7 +538,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
                 healthcheck:
-                    interval: 5s
+                    interval: 10s
                     retries: 12
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
                 image: docker.elastic.co/apm/apm-server:6.3.10-SNAPSHOT
@@ -571,7 +571,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                 environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
-                    interval: 5s
+                    interval: 10s
                     retries: 20
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana:6.3.10-SNAPSHOT
@@ -618,7 +618,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
                 healthcheck:
-                    interval: 5s
+                    interval: 10s
                     retries: 12
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://localhost:8200/']
                 image: docker.elastic.co/apm/apm-server:7.0.10-alpha1-SNAPSHOT
@@ -651,7 +651,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                 environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
-                    interval: 5s
+                    interval: 10s
                     retries: 20
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana:7.0.10-alpha1-SNAPSHOT

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -38,7 +38,7 @@ class AgentServiceTest(ServiceTest):
                         ELASTIC_APM_SERVICE_NAME: gonethttpapp
                         ELASTIC_APM_TRANSACTION_IGNORE_NAMES: healthcheck
                     healthcheck:
-                        interval: 5s
+                        interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://gonethttpapp:8080/healthcheck"]
                     ports:
@@ -67,7 +67,7 @@ class AgentServiceTest(ServiceTest):
                         EXPRESS_SERVICE_NAME: expressapp
                         EXPRESS_PORT: "8010"
                     healthcheck:
-                        interval: 5s
+                        interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://expressapp:8010/healthcheck"]
                     ports:
@@ -100,7 +100,7 @@ class AgentServiceTest(ServiceTest):
                         DJANGO_SERVICE_NAME: djangoapp
                         DJANGO_PORT: 8003
                     healthcheck:
-                        interval: 5s
+                        interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://djangoapp:8003/healthcheck"]
                     ports:
@@ -129,7 +129,7 @@ class AgentServiceTest(ServiceTest):
                         FLASK_SERVICE_NAME: flaskapp
                         GUNICORN_CMD_ARGS: "-w 4 -b 0.0.0.0:8001"
                     healthcheck:
-                        interval: 5s
+                        interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://flaskapp:8001/healthcheck"]
                     ports:
@@ -194,7 +194,7 @@ class AgentServiceTest(ServiceTest):
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_SERVICE_NAME: springapp
                     healthcheck:
-                        interval: 5s
+                        interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output",
                         "/dev/null", "http://javaspring:8090/healthcheck"]
@@ -557,7 +557,7 @@ class KibanaServiceTest(ServiceTest):
                             max-file: '5'
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
-                        interval: 5s
+                        interval: 10s
                         retries: 20
                     depends_on:
                         elasticsearch:
@@ -587,7 +587,7 @@ class KibanaServiceTest(ServiceTest):
                             max-file: '5'
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
-                        interval: 5s
+                        interval: 10s
                         retries: 20
                     depends_on:
                         elasticsearch:
@@ -618,7 +618,7 @@ class LogstashServiceTest(ServiceTest):
             environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200'}
             healthcheck:
                 test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://logstash:9600/"]
-                interval: 5s
+                interval: 10s
                 retries: 12
             image: docker.elastic.co/logstash/logstash:6.3.0
             labels: [co.elatic.apm.stack-version=6.3.0]

--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -105,7 +105,7 @@ class Concurrent:
         self.logger.debug("Starting tornado I/O loop")
         ioloop.IOLoop.instance().start()
 
-    def check_counts(self, it, max_wait=60, backoff=.5):
+    def check_counts(self, it, max_wait=60, backoff=1):
         err = "queried for {}, expected {}, got {}"
 
         def assert_count(terms, expected):

--- a/tests/agent/test_multiple_agents.py
+++ b/tests/agent/test_multiple_agents.py
@@ -2,7 +2,7 @@ from tests.agent.concurrent_requests import Concurrent
 
 
 def test_conc_req_all_agents(es, apm_server, flask, django, express, rails, go_nethttp, java_spring):
-    # FIXME Temporarily disabled python tests
+    # FIXME Temporarily disabled python tests
     # flask_f = Concurrent.Endpoint(flask.foo.url,
     #                               flask.app_name,
     #                               ["app.foo"],
@@ -65,7 +65,7 @@ def test_conc_req_all_agents(es, apm_server, flask, django, express, rails, go_n
                                         events_no=500)
 
     Concurrent(es, [
-        # FIXME Temporarily disabled python tests
+        # FIXME Temporarily disabled python tests
         # flask_f, flask_b,
         # django_f, django_b,
         express_f, express_b,

--- a/tests/agent/test_multiple_agents.py
+++ b/tests/agent/test_multiple_agents.py
@@ -2,6 +2,7 @@ from tests.agent.concurrent_requests import Concurrent
 
 
 def test_conc_req_all_agents(es, apm_server, flask, django, express, rails, go_nethttp, java_spring):
+    # FIXME Temporarily disabled python tests
     # flask_f = Concurrent.Endpoint(flask.foo.url,
     #                               flask.app_name,
     #                               ["app.foo"],
@@ -64,6 +65,7 @@ def test_conc_req_all_agents(es, apm_server, flask, django, express, rails, go_n
                                         events_no=500)
 
     Concurrent(es, [
+        # FIXME Temporarily disabled python tests
         # flask_f, flask_b,
         # django_f, django_b,
         express_f, express_b,

--- a/tests/agent/test_python.py
+++ b/tests/agent/test_python.py
@@ -3,15 +3,17 @@ import pytest
 from tests import utils
 from tests.agent.concurrent_requests import Concurrent
 
-
+# FIXME Temporarily disabled python tests
 @pytest.mark.version
 @pytest.mark.flask
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_req_flask(flask):
     utils.check_agent_transaction(flask.foo, flask.apm_server.elasticsearch)
 
 
 @pytest.mark.version
 @pytest.mark.flask
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_flask_error(flask):
     # one from exception handler, one from logging handler
     utils.check_agent_error(flask.oof, flask.apm_server.elasticsearch, ct=2)
@@ -19,6 +21,7 @@ def test_flask_error(flask):
 
 @pytest.mark.version
 @pytest.mark.flask
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_concurrent_req_flask(flask):
     foo = Concurrent.Endpoint(flask.foo.url,
                               flask.app_name,
@@ -29,6 +32,7 @@ def test_concurrent_req_flask(flask):
 
 @pytest.mark.version
 @pytest.mark.flask
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_concurrent_req_flask_foobar(flask):
     foo = Concurrent.Endpoint(flask.foo.url,
                               flask.app_name,
@@ -44,18 +48,21 @@ def test_concurrent_req_flask_foobar(flask):
 
 @pytest.mark.version
 @pytest.mark.django
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_req_django(django):
     utils.check_agent_transaction(django.foo, django.apm_server.elasticsearch)
 
 
 @pytest.mark.version
 @pytest.mark.django
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_django_error(django):
     utils.check_agent_error(django.oof, django.apm_server.elasticsearch)
 
 
 @pytest.mark.version
 @pytest.mark.django
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_concurrent_req_django(django):
     foo = Concurrent.Endpoint(django.foo.url,
                               django.app_name,
@@ -66,6 +73,7 @@ def test_concurrent_req_django(django):
 
 @pytest.mark.version
 @pytest.mark.django
+@pytest.mark.skip(reason="Temporarily disabled")
 def test_concurrent_req_django_foobar(django):
     foo = Concurrent.Endpoint(django.foo.url,
                               django.app_name,

--- a/tests/agent/test_python.py
+++ b/tests/agent/test_python.py
@@ -3,7 +3,8 @@ import pytest
 from tests import utils
 from tests.agent.concurrent_requests import Concurrent
 
-# FIXME Temporarily disabled python tests
+
+# FIXME Temporarily disabled python tests
 @pytest.mark.version
 @pytest.mark.flask
 @pytest.mark.skip(reason="Temporarily disabled")

--- a/tests/versions/rum.yml
+++ b/tests/versions/rum.yml
@@ -1,5 +1,6 @@
 RUM_AGENT:
   - 'github;1.x'
+  - 'github;master'
 
 exclude:
 

--- a/tests/versions/rum.yml
+++ b/tests/versions/rum.yml
@@ -1,5 +1,4 @@
 RUM_AGENT:
-  - 'github;1.x'
   - 'github;master'
 
 exclude:


### PR DESCRIPTION
* copy docker-compose file to the docker info folder
* show a message when it fails on docker-compose-wait
* review health check parameters
* make docker-compose quieter
* put the docker summary at the end of the log
* wait 1 second between check document count
* use immutable Jenkins agents for most of the things
* RUM Docker container health check
* RUM test stage
* use current shared library version
* reorganized the Jenkinsfile
* store Elasticsearch indices data in JSON files
* editor config rules for all file types