### PR TITLE
fix(rum): build e2e bundles before running tests

### DIFF
--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -29,7 +29,7 @@ RUN npm install -g npm@latest
 RUN rm package-lock.json
 RUN npm install
 
-RUN npx lerna run build && npx lerna run buildE2eBundles
+RUN npx lerna run build && npx lerna run build:e2e
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \


### PR DESCRIPTION
+ Our recent refactor of the test scripts caused this to fail. 

The bundle was unavailable which raised this error
```
@elastic/apm-rum: Page Logs: Failed to load resource: the server responded with a status of 404 (Not Found)
```