### PR TITLE
update logstash configuration for 7.0 stack

### DIFF
--- a/docker/logstash/pipeline/apm.conf
+++ b/docker/logstash/pipeline/apm.conf
@@ -22,11 +22,21 @@ filter {
       add_field => { "[@metadata][index_suffix]" => "-%{[processor][event]}" }
     }
   }
+
+  if ![beat] {
+    mutate {
+      add_field => { "[@metadata][index_prefix]" => "%{[observer][version]}" }
+    }
+  } else {
+    mutate {
+      add_field => { "[@metadata][index_prefix]" => "%{[beat][version]}" }
+    }
+  }
 }
 
 output {
   elasticsearch {
     hosts => ["elasticsearch:9200"]
-    index => "apm-%{[beat][version]}%{[@metadata][index_suffix]}-%{+YYYY.MM.dd}"
+    index => "apm-%{[@metadata][index_prefix]}%{[@metadata][index_suffix]}-%{+YYYY.MM.dd}"
   }
 }

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -836,7 +836,7 @@ class Kafka(Service):
                 "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": 1,
                 "KAFKA_ZOOKEEPER_CONNECT": "zookeeper:2181",
             },
-            image="confluentinc/cp-kafka:4.1.0",
+            image="confluentinc/cp-kafka:4.1.3",
             labels=None,
             logging=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
@@ -855,7 +855,6 @@ class Postgres(Service):
             labels=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT, expose=True)],
             volumes=["./docker/opbeans/sql:/docker-entrypoint-initdb.d", "pgdata:/var/lib/postgresql/data"],
-
         )
 
 

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -521,7 +521,7 @@ class KafkaServiceTest(ServiceTest):
         self.assertEqual(
             kafka, yaml.load("""
                 kafka:
-                    image: confluentinc/cp-kafka:4.1.0
+                    image: confluentinc/cp-kafka:4.1.3
                     container_name: localtesting_6.2.4_kafka
                     depends_on:
                         - zookeeper


### PR DESCRIPTION
Update the config to work with 7.0 while retaining 6.x compatibility.  For users on 7.0, the configuration can be simplified greatly per https://www.elastic.co/guide/en/apm/server/7.0/logstash-output.html