### PR TITLE
quick fix for new paths to build candidate docker images

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -319,13 +319,16 @@ class StackService(object):
         image = self.docker_name
         if self.oss:
             image += "-oss"
+        base_url = "https://staging.elastic.co"
         if self.bc_old:
-            return "https://staging.elastic.co/{version}-{sha}/docker/{image}-{version}.tar.gz".format(
+            return "{base_url}/{version}-{sha}/docker/{image}-{version}.tar.gz".format(
+                base_url=base_url,
                 sha=self.bc,
                 image=image,
                 version=version,
             )
-        return "https://staging.elastic.co/{version}-{sha}/downloads/{service}/{image}-{version}-docker-image.tar.gz".format(
+        return "{base_url}/{version}-{sha}/downloads/{service}/{image}-{version}-docker-image.tar.gz".format(
+            base_url=base_url,
             sha=self.bc,
             image=image,
             service=self.docker_name,

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -203,6 +203,7 @@ class Service(object):
 
         # bc depends on version for resolution
         self._bc = resolve_bc(self._version, options.get(self.option_name() + "_bc") or options.get("bc"))
+        self.bc_old = options.get("bc_old")
 
     @property
     def bc(self):
@@ -318,9 +319,16 @@ class StackService(object):
         image = self.docker_name
         if self.oss:
             image += "-oss"
-        return "https://staging.elastic.co/{version}-{sha}/docker/{image}-{version}.tar.gz".format(
+        if self.bc_old:
+            return "https://staging.elastic.co/{version}-{sha}/docker/{image}-{version}.tar.gz".format(
+                sha=self.bc,
+                image=image,
+                version=version,
+            )
+        return "https://staging.elastic.co/{version}-{sha}/downloads/{service}/{image}-{version}-docker-image.tar.gz".format(
             sha=self.bc,
             image=image,
+            service=self.docker_name,
             version=version,
         )
 
@@ -1828,6 +1836,13 @@ class LocalSetup(object):
             dest='release',
             help='use snapshot version',
             default='',
+        )
+
+        # Add option to use the old bc format
+        parser.add_argument(
+            '--bc-old',
+            action='store_true',
+            help='use the older build candidate path.  option to be removed soon.'
         )
 
         # Add option to skip image downloads

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -836,9 +836,9 @@ class LocalTest(unittest.TestCase):
         self.assertEqual("docker.elastic.co/kibana/kibana:{}".format(version), services["kibana"]["image"])
         mock_load_images.assert_called_once_with(
             {
-                'https://staging.elastic.co/6.9.5-abcd1234/docker/apm-server-6.9.5.tar.gz',
-                'https://staging.elastic.co/6.9.5-abcd1234/docker/elasticsearch-6.9.5.tar.gz',
-                'https://staging.elastic.co/6.9.5-abcd1234/docker/kibana-6.9.5.tar.gz'
+                'https://staging.elastic.co/6.9.5-abcd1234/downloads/apm-server/apm-server-6.9.5-docker-image.tar.gz',
+                'https://staging.elastic.co/6.9.5-abcd1234/downloads/elasticsearch/elasticsearch-6.9.5-docker-image.tar.gz',
+                'https://staging.elastic.co/6.9.5-abcd1234/downloads/kibana/kibana-6.9.5-docker-image.tar.gz'
             },
             image_cache_dir)\
 
@@ -864,8 +864,8 @@ class LocalTest(unittest.TestCase):
         )
         mock_load_images.assert_called_once_with(
             {
-                'https://staging.elastic.co/6.9.5-abcd1234/docker/elasticsearch-6.9.5.tar.gz',
-                'https://staging.elastic.co/6.9.5-abcd1234/docker/kibana-6.9.5.tar.gz'
+                'https://staging.elastic.co/6.9.5-abcd1234/downloads/elasticsearch/elasticsearch-6.9.5-docker-image.tar.gz',
+                'https://staging.elastic.co/6.9.5-abcd1234/downloads/kibana/kibana-6.9.5-docker-image.tar.gz'
             },
             image_cache_dir)
 
@@ -874,10 +874,28 @@ class LocalTest(unittest.TestCase):
         common_args = (("image_cache_dir", ".images"),)
         cases = [
             # post-6.3
-            Case(Elasticsearch, "https://staging.elastic.co/6.3.10-be84d930/docker/elasticsearch-6.3.10.tar.gz",
+            Case(Elasticsearch, "https://staging.elastic.co/6.3.10-be84d930/downloads/elasticsearch/elasticsearch-6.3.10-docker-image.tar.gz",
                  dict(bc="be84d930", version="6.3.10")),
-            Case(Elasticsearch, "https://staging.elastic.co/6.3.10-be84d930/docker/elasticsearch-oss-6.3.10.tar.gz",
+            Case(Elasticsearch, "https://staging.elastic.co/6.3.10-be84d930/downloads/elasticsearch/elasticsearch-oss-6.3.10-docker-image.tar.gz",
                  dict(bc="be84d930", oss=True, version="6.3.10")),
+        ]
+        for case in cases:
+            args = dict(common_args)
+            if case.args:
+                args.update(case.args)
+            service = case.service(**args)
+            got = service.image_download_url()
+            self.assertEqual(case.expected, got)
+
+    def test_docker_download_old_image_url(self):
+        Case = collections.namedtuple("Case", ("service", "expected", "args"))
+        common_args = (("image_cache_dir", ".images"),)
+        cases = [
+            # post-6.3
+            Case(Elasticsearch, "https://staging.elastic.co/6.3.10-be84d930/docker/elasticsearch-6.3.10.tar.gz",
+                 dict(bc="be84d930", version="6.3.10", bc_old=True)),
+            Case(Elasticsearch, "https://staging.elastic.co/6.3.10-be84d930/docker/elasticsearch-oss-6.3.10.tar.gz",
+                 dict(bc="be84d930", oss=True, version="6.3.10", bc_old=True)),
         ]
         for case in cases:
             args = dict(common_args)


### PR DESCRIPTION
to be followed up with fix that uses the manifest to find images for a given service