### PR TITLE
use newest version of agent in integration tests

### DIFF
--- a/scripts/ci/versions_python.sh
+++ b/scripts/ci/versions_python.sh
@@ -14,10 +14,10 @@ stack_args=${2//;/ }
 
 # use release version by default
 python_pkg="elastic-apm==${version}"
-if [[ ${version_type} == github ]]; then
+if [[ ${version_type} == "github" ]]; then
   python_pkg="git+https://github.com/elastic/apm-agent-python.git@${version}"
 else
-  if [[ ${version} == latest ]]; then
+  if [[ ${version} == "latest" ]]; then
     python_pkg="elastic-apm"
   fi
 fi

--- a/tests/versions/python.yml
+++ b/tests/versions/python.yml
@@ -4,4 +4,4 @@ PYTHON_AGENT:
   # release;release -> pip install elastic-apm==version
   - 'github;master'
   - 'release;latest'
-  - 'release;4.0'
+  - 'release;4.2'


### PR DESCRIPTION
also, maybe possibly fixed "latest". It currently fails with

    [2019-03-20T15:46:32.843Z]   Could not find a version that satisfies the requirement elastic-apm==latest (from versions: 1.0.0.dev0, 1.0.0.dev1, 1.0.0.dev2, 1.0.0.dev3, 1.0.0, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.2.0, 2.2.1, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 4.0.0, 4.0.1, 4.0.2, 4.0.3, 4.1.0, 4.2.0)
    
    [2019-03-20T15:46:32.843Z] No matching distribution found for elastic-apm==latest
