### PR TITLE
filter concurrent checks on service name

### DIFF
--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -41,13 +41,13 @@ class Concurrent:
             }
             if app_name in ("flaskapp", "djangoapp"):
                 self.agent = "python"
-            elif app_name in ("expressapp"):
+            elif app_name in ("expressapp",):
                 self.agent = "nodejs"
-            elif self.app_name in ("railsapp"):
+            elif self.app_name in ("railsapp",):
                 self.agent = "ruby"
-            elif self.app_name in ("gonethttpapp"):
+            elif self.app_name in ("gonethttpapp",):
                 self.agent = "go"
-            elif self.app_name in ("springapp"):
+            elif self.app_name in ("springapp",):
                 self.agent = "java"
             else:
                 raise Exception(

--- a/tests/fixtures/es.py
+++ b/tests/fixtures/es.py
@@ -18,12 +18,15 @@ def es():
             self.es.indices.delete(self.index)
             self.es.indices.refresh()
 
-        def term_q(self, terms):
-            t = []
-            for idx in range(len(terms)):
-                for k in terms[idx]:
-                    t.append({"term": {k: {"value": terms[idx][k]}}})
-            return {"query": {"bool": {"must": t}}}
+        def term_q(self, filters):
+            clauses = []
+            for field, value in filters:
+                if isinstance(value, list):
+                    clause = {"terms": {field: value}}
+                else:
+                    clause = {"term": {field: {"value": value}}}
+                clauses.append(clause)
+            return {"query": {"bool": {"must": clauses}}}
 
         @timeout_decorator.timeout(10)
         def count(self, q):


### PR DESCRIPTION
Per @beniwohli's suggestion, make it possible to run tests while other services are running, particularly for when apm-server self-instrumentation isn't disabled.