### PR TITLE
Add `AllowUnknownProperties` helper to APM UI integration test

### DIFF
--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/download-sample-docs.ts
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/download-sample-docs.ts
@@ -44,7 +44,10 @@ async function writeConvertedFile({
   const { data } = await axios.get(url);
 
   const content = `import { ${interfaceName} } from '${interfacePath}';
-  export const ${name}:${interfaceName}[] = ${JSON.stringify(data.events)}`;
+  import { AllowUnknownProperties } from '../../scripts/helpers';
+  export const ${name}:AllowUnknownProperties<${interfaceName}>[] = ${JSON.stringify(
+    data.events
+  )}`;
 
   const formattedContent = prettier.format(content, {
     ...prettierRc,

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/helpers.ts
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/helpers.ts
@@ -1,0 +1,6 @@
+// Allow unknown properties in an object
+export type AllowUnknownProperties<T> = T extends object
+  ? { [P in keyof T]: AllowUnknownProperties<T[P]> } & {
+      [key: string]: unknown;
+    }
+  : T;

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/helpers.ts
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/helpers.ts
@@ -1,4 +1,29 @@
-// Allow unknown properties in an object
+// AllowUnknownProperties: Allow unknown properties in an object
+// Example: `type UserWithUnknown = AllowUnknownProperties<User>;`
+//
+// Converts:
+//
+//    interface User {
+//      name: string;
+//      age: number;
+//      address: {
+//        street: string;
+//        city: string;
+//      };
+//    }
+//
+// To this:
+//
+//    type UserWithUnknown = {
+//      name: string;
+//      age: number;
+//      [key: string]: unknown;
+//      address: {
+//        street: string;
+//        city: string;
+//        [key: string]: unknown;
+//      };
+//    };
 export type AllowUnknownProperties<T> = T extends object
   ? { [P in keyof T]: AllowUnknownProperties<T[P]> } & {
       [key: string]: unknown;


### PR DESCRIPTION
Background: https://github.com/elastic/kibana/issues/34061.

This adds a helper, `AllowUnknownProperties`, that automatically adds `[key: string]: unknown;` to an object interface recursively, so that it allows properties which are not defined in the interface.

This makes it possible for new properties to be added by APM Server without affecting this test.
This change is necessitated by a change in https://github.com/elastic/kibana/pull/34146.