### PR TITLE
enable xpack security with beats

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -1,4 +1,24 @@
 apm_server:
   indices:
-    - names: [ 'apm-*' ]
-      privileges: [ 'all' ]
+    - names: ['apm-*']
+      privileges: ['all']
+beats:
+  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  indices:
+    - names: ['filebeat-*','shrink-filebeat-*']
+      privileges: ['all']
+filebeat:
+  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  indices:
+    - names: ['filebeat-*','shrink-filebeat-*']
+      privileges: ['all']
+heartbeat:
+  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  indices:
+    - names: ['heartbeat-*','shrink-heartbeat-*']
+      privileges: ['all']
+metricbeat:
+  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  indices:
+    - names: ['metricbeat-*','shrink-metricbeat-*']
+      privileges: ['all']

--- a/docker/elasticsearch/users
+++ b/docker/elasticsearch/users
@@ -1,4 +1,8 @@
 admin:$2a$10$xiY0ZzOKmDDN1p3if4t4muUBwh2.bFHADoMRAWQgSClm4ZJ4132Y.
 apm_server_user:$2a$10$iTy29qZaCSVn4FXlIjertuO8YfYVLCbvoUAJ3idaXfLRclg9GXdGG
 apm_user_ro:$2a$10$hQfy2o2u33SapUClsx8NCuRMpQyHP9b2l4t3QqrBA.5xXN2S.nT4u
+beats_user:$2a$10$LRpKi4/Q3Qo4oIbiu26rH.FNIL4aOH4aj2Kwi58FkMo1z9FgJONn2
+filebeat_user:$2a$10$sFxIEX8tKyOYgsbJLbUhTup76ssvSD3L4T0H6Raaxg4ewuNr.lUFC
+heartbeat_user:$2a$10$nKUGDr/V5ClfliglJhfy8.oEkjrDtklGQfhd9r9NoFqQeoNxr7uUK
 kibana_system_user:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
+metricbeat_user:$2a$10$5PyTd121U2ZXnFk9NyqxPuLxdptKbB8nK5egt6M5/4xrKUkk.GReG

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -1,7 +1,12 @@
 apm_server:apm_server_user
 apm_system:apm_server_user
 apm_user:apm_user_ro
+beats:beats_user
+beats_system:beats_user,filebeat_user,heartbeat_user,metricbeat_user
+filebeat:filebeat_user
+heartbeat:heartbeat_user
 ingest_admin:apm_server_user
 kibana_system:kibana_system_user
-kibana_user:apm_user_ro
+kibana_user:apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
+metricbeat:metricbeat_user
 superuser:admin

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -7,7 +7,9 @@ setup.kibana:
   host: "kibana:5601"
 
 output.elasticsearch:
-  hosts: ["elasticsearch:9200"]
+  hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'
+  username: '${ELASTICSEARCH_USERNAME:}'
+  password: '${ELASTICSEARCH_PASSWORD:}'
 
 logging.json: true
 logging.metrics.enabled: false

--- a/docker/metricbeat/metricbeat.yml
+++ b/docker/metricbeat/metricbeat.yml
@@ -7,7 +7,9 @@ setup.kibana:
   host: "kibana:5601"
 
 output.elasticsearch:
-  hosts: ["elasticsearch:9200"]
+  hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'
+  username: '${ELASTICSEARCH_USERNAME:}'
+  password: '${ELASTICSEARCH_PASSWORD:}'
 
 logging.json: true
 logging.metrics.enabled: false

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -754,6 +754,10 @@ class BeatMixin(object):
         if options.get("enable_kibana", True):
             self.command += " -E setup.dashboards.enabled=true"
             self.depends_on["kibana"] = {"condition": "service_healthy"}
+        self.environment = {}
+        if options.get("xpack_secure"):
+            self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
+            self.environment["ELASTICSEARCH_USERNAME"] = "{}_user".format(self.name())
         super(BeatMixin, self).__init__(**options)
 
     def build_candidate_manifest(self):
@@ -792,6 +796,7 @@ class Filebeat(BeatMixin, StackService, Service):
         return dict(
             command=self.command,
             depends_on=self.depends_on,
+            environment=self.environment,
             labels=None,
             user="root",
             volumes=[
@@ -816,6 +821,7 @@ class Heartbeat(BeatMixin, StackService, Service):
         return dict(
             command=self.command,
             depends_on=self.depends_on,
+            environment=self.environment,
             labels=None,
             user="root",
             volumes=[
@@ -892,6 +898,7 @@ class Metricbeat(BeatMixin, StackService, Service):
         return dict(
             command=self.command,
             depends_on=self.depends_on,
+            environment=self.environment,
             labels=None,
             user="root",
             volumes=[

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -460,6 +460,7 @@ class FilebeatServiceTest(ServiceTest):
                     container_name: localtesting_6.0.4_filebeat
                     user: root
                     command: filebeat -e --strict.perms=false -E setup.dashboards.enabled=true
+                    environment: {}
                     logging:
                         driver: 'json-file'
                         options:
@@ -485,6 +486,7 @@ class FilebeatServiceTest(ServiceTest):
                     container_name: localtesting_6.1.1_filebeat
                     user: root
                     command: filebeat -e --strict.perms=false -E setup.dashboards.enabled=true
+                    environment: {}
                     logging:
                         driver: 'json-file'
                         options:
@@ -628,6 +630,7 @@ class MetricbeatServiceTest(ServiceTest):
                     container_name: localtesting_6.2.4_metricbeat
                     user: root
                     command: metricbeat -e --strict.perms=false -E setup.dashboards.enabled=true
+                    environment: {}
                     logging:
                         driver: 'json-file'
                         options:


### PR DESCRIPTION
bringing the full configuration to:
```
$ docker-compose exec elasticsearch bin/elasticsearch-users list | sort
admin          : superuser
apm_server_user: apm_server,apm_system,ingest_admin
apm_user_ro    : apm_user,kibana_user
beats_user     : beats,beats_system,kibana_user
filebeat_user  : beats_system,filebeat,kibana_user
heartbeat_user : beats_system,heartbeat,kibana_user
kibana_system_user: kibana_system
metricbeat_user: beats_system,kibana_user,metricbeat
```