### PR TITLE
[APM-CI][Integration Tests] Fix Java integration tests

### DIFF
--- a/.ci/scripts/java.sh
+++ b/.ci/scripts/java.sh
@@ -6,10 +6,10 @@ test -z "$srcdir" && srcdir=.
 . ${srcdir}/common.sh
 
 if [ -n "${APM_AGENT_JAVA_VERSION}" ]; then
-  APM_AGENT_JAVA_VERSION=${APM_AGENT_JAVA_VERSION/'github;'/''}
-  APM_AGENT_JAVA_VERSION=${APM_AGENT_JAVA_VERSION/'release;'/''}
-  APM_AGENT_JAVA_VERSION=${APM_AGENT_JAVA_VERSION/'commit;'/''}
-  BUILD_OPTS="${BUILD_OPTS} --java-agent-version='${APM_AGENT_JAVA_VERSION}'"
+  EXTRA_OPTS=${APM_AGENT_JAVA_VERSION/'github;'/'--java-agent-version='}
+  EXTRA_OPTS=${APM_AGENT_JAVA_VERSION/'release;'/'--java-agent-release='}
+  EXTRA_OPTS=${APM_AGENT_JAVA_VERSION/'commit;'/'--java-agent-version='}
+  BUILD_OPTS="${BUILD_OPTS} ${EXTRA_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-java-spring --force-build"

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -16,38 +16,16 @@ RUN cd /agent/apm-agent-java \
   && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
   && git checkout ${JAVA_AGENT_BRANCH}
 
-## If the JAVA_AGENT_BUILT_VERSION is set then download the release artifact from maven.org
-RUN [ -n "${JAVA_AGENT_BUILT_VERSION}" ] && (curl -s https://search.maven.org/remotecontent?filepath=co/elastic/apm/elastic-apm-agent/${JAVA_AGENT_BUILT_VERSION}/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar -o /agent/apm-agent.jar \
-    && mvn -q --batch-mode install:install-file \
-      -Dfile=/agent/apm-agent.jar \
-      -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
-      -Dpackaging=jar \
-      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn) || echo true
-
-## If the JAVA_AGENT_BUILT_VERSION is not set then build from the source code
-RUN [ -z "${JAVA_AGENT_BUILT_VERSION}" ] && (cd /agent/apm-agent-java \
-    && mvn -q --batch-mode package -DskipTests \
-      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-    && export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
-    && mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar \
-    && mvn -q --batch-mode install:install-file \
-      -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar \
-      -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
-      -Dpackaging=jar \
-      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn) || echo true
-
-RUN cd /app \
-    && mvn -q --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
-      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-      package
+COPY maven-package.sh /agent
+RUN ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"
 
 FROM openjdk:10-jre-slim
 COPY --from=0 /app /app
-COPY --from=0 /agent/apm-agent.jar  /app
+COPY --from=0 /agent/apm-agent.jar /app
 RUN apt-get -qq update \
   && apt-get -qq install -y curl \
   && apt-get -qq clean \
-  && rm -fr /var/lib/apt/lists/* 
+  && rm -fr /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 8090
 ENV ELASTIC_APM_API_REQUEST_TIME 50ms

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.5.3-jdk-10
 
 ARG JAVA_AGENT_REPO=elastic/apm-agent-java
 ARG JAVA_AGENT_BRANCH=master
+ARG JAVA_AGENT_BUILT_VERSION=
 
 RUN mkdir /agent \
     && mkdir /app
@@ -15,7 +16,16 @@ RUN cd /agent/apm-agent-java \
   && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
   && git checkout ${JAVA_AGENT_BRANCH}
 
-RUN cd /agent/apm-agent-java \
+## If the JAVA_AGENT_BUILT_VERSION is set then download the release artifact from maven.org
+RUN [ -n "${JAVA_AGENT_BUILT_VERSION}" ] && (curl -s https://search.maven.org/remotecontent?filepath=co/elastic/apm/elastic-apm-agent/${JAVA_AGENT_BUILT_VERSION}/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar -o /agent/apm-agent.jar \
+    && mvn -q --batch-mode install:install-file \
+      -Dfile=/agent/apm-agent.jar \
+      -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
+      -Dpackaging=jar \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn) || echo true
+
+## If the JAVA_AGENT_BUILT_VERSION is not set then build from the source code
+RUN [ -z "${JAVA_AGENT_BUILT_VERSION}" ] && (cd /agent/apm-agent-java \
     && mvn -q --batch-mode package -DskipTests \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     && export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
@@ -24,8 +34,9 @@ RUN cd /agent/apm-agent-java \
       -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar \
       -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
       -Dpackaging=jar \
-      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-    && cd /app \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn) || echo true
+
+RUN cd /app \
     && mvn -q --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       package

--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -x
+JAVA_AGENT_BUILT_VERSION=${1}
+
+if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
+  cd /agent/apm-agent-java
+  mvn -q --batch-mode package -DskipTests \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+  export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+  mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar
+  mvn -q --batch-mode install:install-file \
+      -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar \
+      -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
+      -Dpackaging=jar \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+fi
+
+cd /app
+mvn -q --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  package
+
+cp /root/.m2/repository/co/elastic/apm/apm-agent-api/${JAVA_AGENT_BUILT_VERSION}/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar

--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -4,16 +4,10 @@ JAVA_AGENT_BUILT_VERSION=${1}
 
 if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
   cd /agent/apm-agent-java
-  mvn -q --batch-mode package -DskipTests \
+  mvn -q --batch-mode install -DskipTests \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
   export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
-  mv elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar
-  mvn -q --batch-mode install:install-file \
-      -Dfile=apm-agent-api/target/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar \
-      -DgroupId=co.elastic.apm -DartifactId=apm-agent-api -Dversion=${JAVA_AGENT_BUILT_VERSION} \
-      -Dpackaging=jar \
-      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 fi
 
 cd /app

--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -2,12 +2,19 @@
 set -x
 JAVA_AGENT_BUILT_VERSION=${1}
 
+ARTIFACT_ID=elastic-apm-agent
+
 if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
   cd /agent/apm-agent-java
   mvn -q --batch-mode install -DskipTests \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
   export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+else
+  mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+      -DrepoUrl=http://repo1.maven.apache.org/maven2 \
+      -Dartifact=co.elastic.apm:${ARTIFACT_ID}:${JAVA_AGENT_BUILT_VERSION}
 fi
 
 cd /app
@@ -15,4 +22,4 @@ mvn -q --batch-mode -DAGENT_API_VERSION=${JAVA_AGENT_BUILT_VERSION} \
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
   package
 
-cp /root/.m2/repository/co/elastic/apm/apm-agent-api/${JAVA_AGENT_BUILT_VERSION}/apm-agent-api-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar
+cp /root/.m2/repository/co/elastic/apm/${ARTIFACT_ID}/${JAVA_AGENT_BUILT_VERSION}/${ARTIFACT_ID}-${JAVA_AGENT_BUILT_VERSION}.jar /agent/apm-agent.jar

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1299,6 +1299,7 @@ class AgentRubyRails(Service):
 class AgentJavaSpring(Service):
     SERVICE_PORT = 8090
     DEFAULT_AGENT_VERSION = "master"
+    DEFAULT_AGENT_RELEASE = ""
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1308,10 +1309,16 @@ class AgentJavaSpring(Service):
             default=cls.DEFAULT_AGENT_VERSION,
             help='Use Java agent version (master, 0.5, v.0.7.1, ...)',
         )
+        parser.add_argument(
+            "--java-agent-release",
+            default=cls.DEFAULT_AGENT_RELEASE,
+            help='Use Java agent release version (1.6.0, 0.6.2, ...)',
+        )
 
     def __init__(self, **options):
         super(AgentJavaSpring, self).__init__(**options)
         self.agent_version = options.get("java_agent_version", self.DEFAULT_AGENT_VERSION)
+        self.agent_release = options.get("java_agent_release", self.DEFAULT_AGENT_RELEASE)
         self.depends_on = {
             "apm-server": {"condition": "service_healthy"},
         }
@@ -1327,6 +1334,7 @@ class AgentJavaSpring(Service):
                 "dockerfile": "Dockerfile",
                 "args": {
                     "JAVA_AGENT_BRANCH": self.agent_version,
+                    "JAVA_AGENT_BUILT_VERSION": self.agent_release,
                 }
             },
             container_name="javaspring",

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -183,6 +183,7 @@ class AgentServiceTest(ServiceTest):
                     build:
                         args:
                             JAVA_AGENT_BRANCH: master
+                            JAVA_AGENT_BUILT_VERSION: ""
                         dockerfile: Dockerfile
                         context: docker/java/spring
                     container_name: javaspring

--- a/tests/versions/java.yml
+++ b/tests/versions/java.yml
@@ -1,6 +1,6 @@
 JAVA_AGENT:
   - 'github;master'
-  - 'github;v1.0.1'
-  - 'github;v1.1.0'
-  - 'github;v1.2.0'
-  - 'github;v1.3.0'
+  - 'release;1.0.1'
+  - 'release;1.1.0'
+  - 'release;1.2.0'
+  - 'release;1.3.0'


### PR DESCRIPTION
This particular PR solves the integration test failures for the java agent.

## Highlights
- Move the docker `RUN` logic to the `maven-package.sh`
- Support release versions from the maven repository
- Transform `github;X.Y.Z` to `release;X.Y.Z`