### PR TITLE
ci(jenkins): add support to run Packetbeat to grab network traffic info during integration test

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -284,7 +284,7 @@ def wrappingup(label){
     sh('make stop-env || echo 0')
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info/**,**/tests/results/data-*.json',
+        artifacts: 'docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
         defaultExcludes: false)
     junit(
       allowEmptyResults: false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
 FROM python:3.7
 # install latest Google Chrome & Chromedriver
-RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get -yqq update && \
-    apt-get -yqq install google-chrome-unstable && \
-    rm -rf /var/lib/apt/lists/*
-RUN curl -SLO https://chromedriver.storage.googleapis.com/$(curl -o- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip && \
-    apt-get -yqq update && apt install -yqq --no-install-recommends unzip && \
-    unzip -d /usr/local/bin/ chromedriver_linux64.zip chromedriver && \
-    rm -rf /var/lib/apt/lists/*
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get -yqq update \
+    && apt-get -yqq --allow-unauthenticated install google-chrome-unstable
+
+RUN curl -SLO https://chromedriver.storage.googleapis.com/$(curl -o- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip \
+    && apt-get -yqq update \
+    && apt install -yqq --no-install-recommends unzip \
+    && unzip -d /usr/local/bin/ chromedriver_linux64.zip chromedriver
+
+#Install elasticdump
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
+    && apt-get -yqq update \
+    && apt-get install -yqq nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install elasticdump -g
 
 COPY requirements.txt requirements.txt
 RUN pip install -q -r requirements.txt

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -284,7 +284,7 @@ def wrappingup(label){
     sh('make stop-env || echo 0')
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info/**,**/tests/results/data-*.json',
+        artifacts: 'docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
         defaultExcludes: false)
     junit(
       allowEmptyResults: false,

--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ Tests should always eventually be run within a docker container to ensure a cons
 
 Prefix any of the `test-` targets with `docker-` to run them in a container eg: `make docker-test-server`.
 
+### Network issues diagnose
+
+It is possible to diagnose Network issues related with lost documents
+between APM Agent, APM server, or Elasticsearch,
+in order to do that, you have to add the `--with-packetbeat` argument
+to your command line.
+When you add this argument an additional Docker container running Packetbeat is
+attached to the APM Server Docker container,
+this container will grab information about the communication between APM Agent,
+APM server, and Elasticsearch that you can analyze in case of failure.
+When a test fails, data related to Packetbeat and APM is dumped
+with [elasticdump](https://www.npmjs.com/package/elasticdump) into a couple
+of files `/app/tests/results/data-NAME_OF_THE_TEST.json`
+and `/app/tests/results/packetbeat-NAME_OF_THE_TEST.json`
+
 ### Continuous Integration
 
 Jenkins runs the scripts from `.ci/scripts` and is viewable at https://apm-ci.elastic.co/.

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import pytest
 import json
+import subprocess
 from tests.fixtures.transactions import minimal
 from tests.fixtures.apm_server import apm_server
 from tests.fixtures.es import es
@@ -34,10 +35,13 @@ def pytest_collection_modifyitems(config, items):
 def pytest_runtest_logreport(report):
     yield
     if report.when == "call" and report.failed:
-        rs = es().es.search(index="apm-*", size=1000)
-        name = report.nodeid.split(":",2)[-1]
+        name = report.nodeid.split(":", 2)[-1]
         try:
-            with open("/app/tests/results/data-{}.json".format(name), 'w') as outFile:
-                json.dump(rs, outFile, sort_keys=True, indent=4, ensure_ascii=False)
+            subprocess.call(['elasticdump',
+                             '--input=http://elasticsearch:9200/apm-*',
+                             '--output=/app/tests/results/data-{}.json'.format(name)])
+            subprocess.call(['elasticdump',
+                             '--input=http://elasticsearch:9200/packetbeat-*',
+                             '--output=/app/tests/results/packetbeat-{}.json'.format(name)])
         except IOError:
             pass

--- a/docker/packetbeat/packetbeat.yml
+++ b/docker/packetbeat/packetbeat.yml
@@ -1,0 +1,39 @@
+packetbeat.interfaces.snaplen: 1514
+packetbeat.interfaces.type: af_packet
+packetbeat.interfaces.buffer_size_mb: 250
+packetbeat.protocols:
+- type: dns
+  ports: [53]
+  include_authorities: true
+  include_additionals: true
+- type: http
+  ports: [8080,80,8000,5000,3000,8200,9200,5601]
+  tags: ["http"]
+  send_headers: true
+  send_all_headers: true
+  split_cookie: true
+  send_request: true
+  send_response: true
+- type: mysql
+  ports: [3306]
+- type: icmp
+  enabled: true
+packetbeat.flows:
+  timeout: 30s
+  period: 10s
+packetbeat.procs:
+  enabled: true
+  system.hostfs: "/hostfs/proc"
+fields: { interface: "${INTERFACE:eth0}" }
+processors:
+  - add_docker_metadata:
+      host: "unix:///var/run/docker.sock"
+  - add_host_metadata:
+      #extremely verbose if enabled
+      netinfo.enabled: false
+xpack.monitoring.enabled: true
+queue.mem:
+  events: 20000
+setup.kibana.host: '${KIBANA_HOST:kibana}:${KIBANA_PORT:5601}'
+setup.kibana.username: '${KIBANA_USERNAME:}'
+setup.kibana.password: '${KIBANA_PASSWORD:}'

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -948,6 +948,29 @@ class Metricbeat(BeatMixin, StackService, Service):
         )
 
 
+class Packetbeat(BeatMixin, StackService, Service):
+    """Stars a Packetbeat container to grab the network traffic."""
+
+    DEFAULT_COMMAND = "packetbeat -e --strict.perms=false -E packetbeat.interfaces.device=eth0"
+    docker_path = "beats"
+
+    def _content(self):
+        return dict(
+            command=self.command,
+            depends_on=self.depends_on,
+            environment=self.environment,
+            labels=None,
+            user="root",
+            privileged="true",
+            cap_add=["NET_ADMIN", "NET_RAW"],
+            network_mode="service:apm-server",
+            volumes=[
+                "./docker/packetbeat/packetbeat.yml:/usr/share/packetbeat/packetbeat.yml",
+                "/var/run/docker.sock:/var/run/docker.sock",
+            ]
+        )
+
+
 #
 # Supporting Services
 #


### PR DESCRIPTION
* new --with-packetbeat argument, it would run a Docket container executing Packetbeat, this container is attached to the APM Server Docker container network drive.
* use [elasticdump](https://www.npmjs.com/package/elasticdump) to grab documents from Elasticsearch on a test failure.
