### PR TITLE
add apm server disk queue and generic options arguments

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -474,6 +474,9 @@ class ApmServer(StackService, Service):
                     ("output.logstash.hosts", "[\"logstash:5044\"]"),
                 ])
 
+        for opt in options.get("apm_server_opt", []):
+            self.apm_server_command_args.append(opt.split("=", 1))
+
         self.apm_server_count = options.get("apm_server_count", 1)
         self.apm_server_tee = options.get("apm_server_tee", False)
 
@@ -541,6 +544,12 @@ class ApmServer(StackService, Service):
             default=False,
             help=argparse.SUPPRESS,
             # help="tee proxied traffic instead of load balancing.  Only for  7.0upgrade testing atm.",
+        )
+        parser.add_argument(
+            "--apm-server-opt",
+            action="append",
+            default=[],
+            help="arbitrary additional configuration to set for apm-server"
         )
 
     def build_candidate_manifest(self):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -309,6 +309,17 @@ class ApmServerServiceTest(ServiceTest):
         for o in kafka_options:
             self.assertTrue(o in apm_server["command"], "{} not set while output=kafka".format(o))
 
+    def test_opt(self):
+        apm_server = ApmServer(version="7.1.10", apm_server_opt=("an.opt=foo", "opt2=bar")).render()["apm-server"]
+        self.assertTrue(
+            any(e.startswith("an.opt") for e in apm_server["command"]),
+            "some.option should be set "
+        )
+        self.assertTrue(
+            any(e.startswith("opt2") for e in apm_server["command"]),
+            "some.option should be set "
+        )
+
     def test_pipeline(self):
         apm_server = ApmServer(version="6.5.10").render()["apm-server"]
         self.assertTrue(


### PR DESCRIPTION
adds:

```
--apm-server-opt
--apm-server-queue
--apm-server-queue-file-size
--apm-server-queue-file-page-size
--apm-server-queue-write-buffer-size
--apm-server-queue-write-codec
--apm-server-queue-write-flush-events
--apm-server-queue-write-flush-timeout
```

closes #194, though not setting disk queue by default quite yet