### PR TITLE
Beats logstash output

### DIFF
--- a/docker/logstash/pipeline/apm.conf
+++ b/docker/logstash/pipeline/apm.conf
@@ -1,6 +1,5 @@
 input {
   beats {
-    id => "apm-server"
     port => 5044
   }
 
@@ -13,13 +12,21 @@ input {
 }
 
 filter {
-  if ![processor] {
+  # for older libbeat/apm-server - https://github.com/elastic/apm-server/issues/1792
+  if [@metadata][beat] == "apm-server" {
     mutate {
-      add_field => { "[@metadata][index_suffix]" => "" }
+      replace => { "[@metadata][beat]" => "apm" }
     }
-  } else {
+  }
+
+  if [@metadata][beat] == "apm" and [processor] {
     mutate {
       add_field => { "[@metadata][index_suffix]" => "-%{[processor][event]}" }
+    }
+  } else {
+    # onboarding events originally did not set processor.event - https://github.com/elastic/apm-server/pull/1159
+    mutate {
+      add_field => { "[@metadata][index_suffix]" => "" }
     }
   }
 }
@@ -27,6 +34,6 @@ filter {
 output {
   elasticsearch {
     hosts => ["elasticsearch:9200"]
-    index => "apm-%{[@metadata][version]}%{[@metadata][index_suffix]}-%{+YYYY.MM.dd}"
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}%{[@metadata][index_suffix]}-%{+YYYY.MM.dd}"
   }
 }

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -880,9 +880,6 @@ class BeatMixin(object):
             self.command.extend(["-E", "setup.dashboards.enabled=true"])
             self.depends_on["kibana"] = {"condition": "service_healthy"}
         self.environment = {}
-        if options.get("xpack_secure"):
-            self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
-            self.environment["ELASTICSEARCH_USERNAME"] = "{}_user".format(self.name())
 
         es_urls = options.get("{}_elasticsearch_urls".format(self.name()))
         if not es_urls:

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -847,7 +847,7 @@ class Elasticsearch(StackService, Service):
 
 class BeatMixin(object):
     DEFAULT_OUTPUT = "elasticsearch"
-    OUTPUTS = {"elasticsearch", "kafka", "logstash"}
+    OUTPUTS = {"elasticsearch", "logstash"}
 
     @classmethod
     def add_arguments(cls, parser):
@@ -907,16 +907,17 @@ class BeatMixin(object):
         else:
             command_args.extend([("output.elasticsearch.enabled", "false")])
             add_es_config(command_args, prefix="xpack.monitoring")
-            if beat_output == "kafka":
+            if beat_output == "logstash":
+                command_args.extend([
+                    ("output.logstash.enabled", "true"),
+                    ("output.logstash.hosts", "[\"logstash:5044\"]"),
+                ])
+            elif beat_output == "kafka":
+                # disabled via command line options for now
                 command_args.extend([
                     ("output.kafka.enabled", "true"),
                     ("output.kafka.hosts", "[\"kafka:9092\"]"),
                     ("output.kafka.topics", "[{default: '{}', topic: '{}'}]".format(self.name(), self.name())),
-                ])
-            elif beat_output == "logstash":
-                command_args.extend([
-                    ("output.logstash.enabled", "true"),
-                    ("output.logstash.hosts", "[\"logstash:5044\"]"),
                 ])
 
         for param, value in command_args:

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -873,7 +873,7 @@ class BeatMixin(object):
         )
 
     def __init__(self, **options):
-        self.command = self.DEFAULT_COMMAND
+        self.command = list(self.DEFAULT_COMMAND)
         self.depends_on = {"elasticsearch": {"condition": "service_healthy"}} if options.get(
             "enable_elasticsearch", True) else {}
         if options.get("enable_kibana", True):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -544,7 +544,7 @@ class FilebeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/filebeat:6.0.4
                     container_name: localtesting_6.0.4_filebeat
                     user: root
-                    command: filebeat -e --strict.perms=false -E setup.dashboards.enabled=true
+                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -570,7 +570,7 @@ class FilebeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/filebeat:6.1.1
                     container_name: localtesting_6.1.1_filebeat
                     user: root
-                    command: filebeat -e --strict.perms=false -E setup.dashboards.enabled=true
+                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -587,6 +587,17 @@ class FilebeatServiceTest(ServiceTest):
                         - /var/lib/docker/containers:/var/lib/docker/containers
                         - /var/run/docker.sock:/var/run/docker.sock""")
         )
+
+    def test_logstash_output(self):
+        beat = Filebeat(version="6.3.100", filebeat_output="logstash").render()["filebeat"]
+        options = [
+            "output.elasticsearch.enabled=false",
+            "output.logstash.enabled=true",
+            "output.logstash.hosts=[\"logstash:5044\"]",
+            "xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+        ]
+        for o in options:
+            self.assertTrue(o in beat["command"], "{} not set in {} while output=logstash".format(o, beat["command"]))
 
 
 class KafkaServiceTest(ServiceTest):
@@ -714,7 +725,7 @@ class MetricbeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/metricbeat:6.2.4
                     container_name: localtesting_6.2.4_metricbeat
                     user: root
-                    command: metricbeat -e --strict.perms=false -E setup.dashboards.enabled=true
+                    command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -730,6 +741,17 @@ class MetricbeatServiceTest(ServiceTest):
                         - ./docker/metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml
                         - /var/run/docker.sock:/var/run/docker.sock""")
         )
+
+    def test_logstash_output(self):
+        beat = Metricbeat(version="6.3.100", metricbeat_output="logstash").render()["metricbeat"]
+        options = [
+            "output.elasticsearch.enabled=false",
+            "output.logstash.enabled=true",
+            "output.logstash.hosts=[\"logstash:5044\"]",
+            "xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+        ]
+        for o in options:
+            self.assertTrue(o in beat["command"], "{} not set in {} while output=logstash".format(o, beat["command"]))
 
 
 class ZookeeperServiceTest(ServiceTest):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -544,7 +544,7 @@ class FilebeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/filebeat:6.0.4
                     container_name: localtesting_6.0.4_filebeat
                     user: root
-                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true"]
+                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -570,7 +570,7 @@ class FilebeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/filebeat:6.1.1
                     container_name: localtesting_6.1.1_filebeat
                     user: root
-                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true"]
+                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -725,7 +725,7 @@ class MetricbeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/metricbeat:6.2.4
                     container_name: localtesting_6.2.4_metricbeat
                     user: root
-                    command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true"]
+                    command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'


### PR DESCRIPTION
adds options:

```
--{file,heart,metric}beat-elasticsearch-url
--{file,heart,metric}beat-elasticsearch-username
--{file,heart,metric}beat-elasticsearch-password
--{file,heart,metric}beat-output
```

Intended for use debugging apm-server ~> filebeat -> logstash -> elasticsearch

closes #443