### PR TITLE
[APM-CI][Integration Tests][.Net] Fix building issues

### DIFF
--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=
-ENV OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
-ENV OPBEANS_DOTNET_BRANCH=master
 WORKDIR /src
 COPY . /src
 RUN ./run.sh

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -15,6 +15,9 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
   DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}
+else
+  ### Otherwise: The default NuGet.Config will fail as it's required
+  mkdir /src/local-packages
 fi
 
 cd /src/aspnetcore

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -11,7 +11,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/aspnetcore
-  mv ../NuGet.Config .
+  mv /src/NuGet.Config .
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
   DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -11,7 +11,7 @@ ARG DOTNET_AGENT_VERSION=
 ENV OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
 ENV OPBEANS_DOTNET_BRANCH=master
 WORKDIR /src
-COPY run.sh /src
+COPY . /src
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -12,10 +12,13 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet
-  mv ../NuGet.Config .
+  mv /src/NuGet.Config .
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
   DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}
+else
+  ### Otherwise: The default NuGet.Config will fail as it's required
+  mkdir /src/local-packages
 fi
 
 cd /src/opbeans-dotnet/opbeans-dotnet

--- a/tests/versions/dotnet.yml
+++ b/tests/versions/dotnet.yml
@@ -1,3 +1,2 @@
 DOTNET_AGENT:
   - 'github;master'
-  - 'release;0.0.2-alpha'


### PR DESCRIPTION
This is a leftover when merging https://github.com/elastic/apm-integration-testing/pull/424

## Highlights
- `0.0.2-alpha` release does not contain the fix for the concurrent reqs. (Refers to https://github.com/elastic/apm-agent-dotnet/pull/219)
- It does fix the below error

```
[2019-05-20T08:04:04.428Z] + dotnet restore
[2019-05-20T08:04:05.815Z] /usr/share/dotnet/sdk/2.2.204/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/aspnetcore/TestAspNetCoreApp.sln]
[2019-05-20T08:04:05.815Z] + dotnet publish -c Release -o build
[2019-05-20T08:04:06.077Z] Microsoft (R) Build Engine version 16.0.450+ga8dc7f1d34 for .NET Core
[2019-05-20T08:04:06.077Z] Copyright (C) Microsoft Corporation. All rights reserved.
[2019-05-20T08:04:07.464Z] /usr/share/dotnet/sdk/2.2.204/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/aspnetcore/TestAspNetCoreApp.sln]
[2019-05-20T08:04:07.723Z] Service 'agent-dotnet' failed to build: The command '/bin/sh -c ./run.sh' returned a non-zero code: 1
```

##  How to reproduce
```
python scripts/compose.py start 7.0.0 --build-parallel --dotnet-agent-release=0.0.2-alpha --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-dotnet --force-build
```