### PR TITLE
filebeat decode messages in place

### DIFF
--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -46,6 +46,16 @@ filebeat.autodiscover:
                   target: "filebeat"
       - condition:
           contains:
+            docker.container.image: "heartbeat"
+        config:
+          - type: docker
+            containers.ids:
+              - "${data.docker.container.id}"
+            processors:
+              - decode_json_fields:
+                  fields: ["message"]
+      - condition:
+          contains:
             docker.container.image: "kibana"
         config:
           - type: docker
@@ -105,6 +115,9 @@ filebeat.autodiscover:
             - not:
                 contains:
                   docker.container.image: "filebeat"
+            - not:
+                contains:
+                  docker.container.image: "heartbeat"
             - not:
                 contains:
                   docker.container.image: "kibana"

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -29,10 +29,11 @@ filebeat.autodiscover:
           - type: docker
             containers.ids:
               - "${data.docker.container.id}"
-            processors:
-              - decode_json_fields:
-                  fields: ["message"]
-                  target: "apm-server"
+            fields_under_root: true
+            json.keys_under_root: true
+            json.overwrite_keys: true
+            json.add_error_key: true
+            json.message_key: message
       - condition:
           contains:
             docker.container.image: "filebeat"
@@ -40,10 +41,11 @@ filebeat.autodiscover:
           - type: docker
             containers.ids:
               - "${data.docker.container.id}"
-            processors:
-              - decode_json_fields:
-                  fields: ["message"]
-                  target: "filebeat"
+            fields_under_root: true
+            json.keys_under_root: true
+            json.overwrite_keys: true
+            json.add_error_key: true
+            json.message_key: message
       - condition:
           contains:
             docker.container.image: "heartbeat"
@@ -51,9 +53,11 @@ filebeat.autodiscover:
           - type: docker
             containers.ids:
               - "${data.docker.container.id}"
-            processors:
-              - decode_json_fields:
-                  fields: ["message"]
+            fields_under_root: true
+            json.keys_under_root: true
+            json.overwrite_keys: true
+            json.add_error_key: true
+            json.message_key: message
       - condition:
           contains:
             docker.container.image: "kibana"
@@ -61,10 +65,11 @@ filebeat.autodiscover:
           - type: docker
             containers.ids:
               - "${data.docker.container.id}"
-            processors:
-              - decode_json_fields:
-                  fields: ["message"]
-                  target: "kibana"
+            fields_under_root: true
+            json.keys_under_root: true
+            json.overwrite_keys: true
+            json.add_error_key: true
+            json.message_key: message
       - condition:
           contains:
             docker.container.image: "metricbeat"
@@ -72,10 +77,11 @@ filebeat.autodiscover:
           - type: docker
             containers.ids:
               - "${data.docker.container.id}"
-            processors:
-              - decode_json_fields:
-                  fields: ["message"]
-                  target: "metricbeat"
+            fields_under_root: true
+            json.keys_under_root: true
+            json.overwrite_keys: true
+            json.add_error_key: true
+            json.message_key: message
       - condition:
           contains:
             docker.container.image: "opbeans-node"
@@ -93,10 +99,11 @@ filebeat.autodiscover:
           - type: docker
             containers.ids:
               - "${data.docker.container.id}"
-            processors:
-              - decode_json_fields:
-                  fields: ["message"]
-                  target: "opbeans-go"
+            fields_under_root: true
+            json.keys_under_root: true
+            json.overwrite_keys: true
+            json.add_error_key: true
+            json.message_key: message
       - condition:
           contains:
             docker.container.image: "postgres"


### PR DESCRIPTION
Parse message from docker logs before indexing:

eg before:
```
"message": "{\"type\":\"response\",\"@timestamp\":\"2019-05-20T16:52:19Z\",\"tags\":[],\"pid\":1,\"method\":\"get\",\"statusCode\":200,\"req\":{\"url\":\"/ui/favicons/favicon.ico\",\"method\":\"get\",\"headers\":{\"host\":\"localhost:5601\",\"connection\":\"keep-alive\",\"pragma\":\"no-cache\",\"cache-control\":\"no-cache\",\"user-agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36\",\"accept\":\"image/webp,image/apng,image/*,*/*;q=0.8\",\"referer\":\"http://localhost:5601/app/kibana\",\"accept-encoding\":\"gzip, deflate, br\",\"accept-language\":\"en-US,en;q=0.9\"},\"remoteAddress\":\"172.31.0.1\",\"userAgent\":\"172.31.0.1\",\"referer\":\"http://localhost:5601/app/kibana\"},\"res\":{\"statusCode\":200,\"responseTime\":14,\"contentLength\":9},\"message\":\"GET /ui/favicons/favicon.ico 200 14ms - 9.0B\"}",
```

after this change each of the fields in `message` become top-level keys
