### PR TITLE
[APM-CI][Integration Tests] Enable Dot NET choice parameter

### DIFF
--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -69,7 +69,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    choice(name: 'agent_integration_test', choices: ['Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
+    choice(name: 'agent_integration_test', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "6.6 --release", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "6.x", description: "Integration testing Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")


### PR DESCRIPTION
This is a fix to be able to reuse the same Jenkins job (pipeline) with the default choice parameter between different ITs branches. Otherwise, the choice parameter will contain a subset of what's used in the master branch.

This is caused since https://github.com/elastic/apm-integration-testing/pull/424 was merged in the master branch but was not cherry-picked to other branches. @kuisathaverat , what's the best strategy in this case?