### PR TITLE
[APM-CI][Integration test] Artifacts name has changed

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -934,15 +934,26 @@ class BeatMixin(object):
         )
         try:
             if key not in self.bc["projects"]["beats"]["packages"]:
+                # This is the old standard based on the format:
+                # ${name}-${version}-${os}-${architecture}-${classifier}.${extension}
                 key = "{image}-{version}-linux-amd64-docker-image.tar.gz".format(
                     image=image,
                     version=version,
                 )
             return self.bc["projects"]["beats"]["packages"][key]
         except KeyError:
-            # help debug manifest issues
-            print(json.dumps(self.bc))
-            raise
+            try:
+                # This is the new standard based on the format:
+                # ${name}-${version}-${classifier}-${os}-${architecture}.${extension}
+                key = "{image}-{version}-docker-image-linux-amd64.tar.gz".format(
+                        image=image,
+                        version=version,
+                )
+                return self.bc["projects"]["beats"]["packages"][key]
+            except KeyError:
+                # help debug manifest issues
+                print(json.dumps(self.bc))
+                raise
 
 
 class Filebeat(BeatMixin, StackService, Service):


### PR DESCRIPTION
Closes https://github.com/elastic/apm-integration-testing/issues/455

## Test cases
```
python3 compose.py start 7.2.0 \
               --with-opbeans-java --with-opbeans-go \
               --with-filebeat --with-metricbeat \
               --bc 54d878d8
```

```
 python3 compose.py start 7.2.0 --with-opbeans-java --with-opbeans-go --with-filebeat --with-metricbeat --bc 54d878d8
downloading https://staging.elastic.co/7.2.0-54d878d8/downloads/kibana/kibana-7.2.0-docker-image.tar.gz
downloading https://staging.elastic.co/7.2.0-54d878d8/downloads/apm-server/apm-server-7.2.0-docker-image.tar.gz
downloading https://staging.elastic.co/7.2.0-54d878d8/downloads/beats/metricbeat/metricbeat-7.2.0-docker-image-linux-amd64.tar.gz
downloading https://staging.elastic.co/7.2.0-54d878d8/downloads/elasticsearch/elasticsearch-7.2.0-docker-image.tar.gz
....
Successfully tagged apm-integration-testing_opbeans-go:latest
Pulling postgres               ... done
Pulling redis                  ... done
Pulling opbeans-load-generator ... done
Creating network "apm-integration-testing" with the default driver
Creating localtesting_7.2.0_postgres      ... done
Creating localtesting_7.2.0_redis         ... done
Creating localtesting_7.2.0_elasticsearch ... done
Creating localtesting_7.2.0_kibana        ... done
Creating localtesting_7.2.0_filebeat      ... done
Creating localtesting_7.2.0_apm-server    ... done
Creating localtesting_7.2.0_metricbeat    ... done
Creating localtesting_7.2.0_opbeans-java  ... done
Creating localtesting_7.2.0_opbeans-go    ... done
Creating localtesting_7.2.0_opbeans-load-generator ... done
```