### PR TITLE
fall back to native realm with security enabled

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -777,8 +777,11 @@ class Elasticsearch(StackService, Service):
                 self.environment.append("xpack.security.authc.anonymous.roles=remote_monitoring_collector")
                 if self.at_least_version("7.0"):
                     self.environment.append("xpack.security.authc.realms.file.file1.order=0")
+                    self.environment.append("xpack.security.authc.realms.native.native1.order=1")
                 else:
                     self.environment.append("xpack.security.authc.realms.file1.type=file")
+                    self.environment.append("xpack.security.authc.realms.native1.type=native")
+                    self.environment.append("xpack.security.authc.realms.native1.order=1")
             self.environment.append("xpack.security.enabled=" + xpack_security_enabled)
             self.environment.append("xpack.license.self_generated.type=trial")
             if self.at_least_version("6.3"):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -729,6 +729,8 @@ class LocalTest(unittest.TestCase):
         self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
         ## file based realm
         self.assertIn("xpack.security.authc.realms.file1.type=file", es_env)
+        ## native realm
+        self.assertIn("xpack.security.authc.realms.native1.type=native", es_env)
         # kibana should use user/pass -> es
         kibana_env = got["services"]["kibana"]["environment"]
         self.assertIn("ELASTICSEARCH_PASSWORD", kibana_env)
@@ -757,6 +759,8 @@ class LocalTest(unittest.TestCase):
         self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
         ## file based realm
         self.assertIn("xpack.security.authc.realms.file.file1.order=0", es_env)
+        ## native realm
+        self.assertIn("xpack.security.authc.realms.native.native1.order=1", es_env)
         # kibana should use user/pass -> es
         kibana_env = got["services"]["kibana"]["environment"]
         self.assertIn("ELASTICSEARCH_PASSWORD", kibana_env)


### PR DESCRIPTION
Users added via kibana / apis don't make into the file auth - this adds native auth to the chain to enable those users.

fixes #454