### PR TITLE
enable apm-server ILM by default in 7.2+

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -417,6 +417,9 @@ class ApmServer(StackService, Service):
             "enable_elasticsearch", True) else {}
         self.build = self.options.get("apm_server_build")
 
+        if self.at_least_version("7.2") and not self.oss and not self.options.get("apm_server_ilm_disable"):
+            self.apm_server_command_args.append(("apm-server.ilm.enabled", "true"))
+
         if self.options.get("enable_kibana", True):
             self.depends_on["kibana"] = {"condition": "service_healthy"}
             if options.get("apm_server_dashboards", True) and not self.at_least_version("7.0") \
@@ -506,6 +509,11 @@ class ApmServer(StackService, Service):
             const="https://github.com/elastic/apm-server.git",
             nargs="?",
             help='build apm-server from a git repo[@branch], eg https://github.com/elastic/apm-server.git@v2'
+        )
+        parser.add_argument(
+            "--apm-server-ilm-disable",
+            action="store_true",
+            help='disable ILM (enabled by default in 7.2+)'
         )
         parser.add_argument(
             '--apm-server-output',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -300,6 +300,18 @@ class ApmServerServiceTest(ServiceTest):
                             "{} not set while output=elasticsearch and overrides set: ".format(o) + " ".join(
                                 apm_server["command"]))
 
+    def test_ilm_default(self):
+        """enable ILM by default in 7.2+"""
+        apm_server = ApmServer(version="6.3.100").render()["apm-server"]
+        self.assertFalse("apm-server.ilm.enabled=true" in apm_server["command"], "ILM enabled by default in < 7.2")
+
+        apm_server = ApmServer(version="7.2.0").render()["apm-server"]
+        self.assertTrue("apm-server.ilm.enabled=true" in apm_server["command"], "ILM not enabled by default in >= 7.2")
+
+    def test_ilm_disabled(self):
+        apm_server = ApmServer(version="7.2.0", apm_server_ilm_disable=True).render()["apm-server"]
+        self.assertFalse("apm-server.ilm.enabled=true" in apm_server["command"], "ILM enabled but should not be")
+
     def test_logstash_output(self):
         apm_server = ApmServer(version="6.3.100", apm_server_output="logstash").render()["apm-server"]
         options = [


### PR DESCRIPTION
adds `--apm-server-ilm-disable` option