### PR TITLE
(#464) Add support for MBP and JJBB

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
 def runJob(agentName, buildOpts = ''){
   def job = build(job: 'apm-integration-test-axis-pipeline',
     parameters: [
-    string(name: 'agent_integration_test', value: agentName),
+    string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
     string(name: 'INTEGRATION_TESTING_VERSION', value: env.GIT_BASE_COMMIT),
     string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -95,7 +95,13 @@ pipeline {
 }
 
 def runJob(agentName, buildOpts = ''){
-  def job = build(job: 'apm-integration-test-axis-pipeline',
+  def branch = env.BRANCH_NAME
+
+  if (env.CHANGE_ID) {
+    branch = env.CHANGE_TARGET
+  }
+
+  def job = build(job: 'apm-integration-test-axis-pipeline-mbp/job/${branch}',
     parameters: [
     string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -106,6 +106,7 @@ def runJob(agentName, buildOpts = ''){
     string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
     string(name: 'INTEGRATION_TESTING_VERSION', value: env.GIT_BASE_COMMIT),
+    string(name: 'MERGE_TARGET', value: "${branch}"),
     string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
     string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
     booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -73,7 +73,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    choice(name: 'agent_integration_test', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
+    choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "master", description: "Integration testing Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
@@ -102,8 +102,8 @@ pipeline {
         }
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{
-          currentBuild.displayName = "apm-agent-${params.agent_integration_test} - ${currentBuild.displayName}"
-          currentBuild.description = "Agent ${params.agent_integration_test} - ${params.UPSTREAM_BUILD}"
+          currentBuild.displayName = "apm-agent-${params.AGENT_INTEGRATION_TEST} - ${currentBuild.displayName}"
+          currentBuild.description = "Agent ${params.AGENT_INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
         }
       }
     }
@@ -113,8 +113,8 @@ pipeline {
     stage("Integration Tests"){
       when {
         expression {
-          return (params.agent_integration_test != 'All'
-            && params.agent_integration_test != 'UI')
+          return (params.AGENT_INTEGRATION_TEST != 'All'
+            && params.AGENT_INTEGRATION_TEST != 'UI')
         }
       }
       steps {
@@ -122,7 +122,7 @@ pipeline {
         unstash "source"
         dir("${BASE_DIR}"){
           script {
-            def agentTests = mapAgentsIDs[params.agent_integration_test]
+            def agentTests = mapAgentsIDs[params.AGENT_INTEGRATION_TEST]
             integrationTestsGen = new IntegrationTestingParallelTaskGenerator(
               xKey: agentYamlVar[agentTests],
               yKey: agentYamlVar['server'],
@@ -130,7 +130,7 @@ pipeline {
               yFile: ymlFiles['server'],
               exclusionFile: ymlFiles[agentTests],
               tag: agentTests,
-              name: params.agent_integration_test,
+              name: params.AGENT_INTEGRATION_TEST,
               steps: this
               )
             def mapPatallelTasks = integrationTestsGen.generateParallelTests()
@@ -141,7 +141,7 @@ pipeline {
     }
     stage("All") {
       when {
-        expression { return params.agent_integration_test == 'All' }
+        expression { return params.AGENT_INTEGRATION_TEST == 'All' }
       }
       environment {
         TMPDIR = "${WORKSPACE}"
@@ -162,7 +162,7 @@ pipeline {
     }
     stage("UI") {
       when {
-        expression { return params.agent_integration_test == 'UI' }
+        expression { return params.AGENT_INTEGRATION_TEST == 'UI' }
       }
       environment {
         TMPDIR = "${WORKSPACE}/${BASE_DIR}"
@@ -186,7 +186,7 @@ pipeline {
       script{
         if(integrationTestsGen?.results){
           writeJSON(file: 'results.json', json: toJSON(integrationTestsGen.results), pretty: 2)
-          def mapResults = ["${params.agent_integration_test}": integrationTestsGen.results]
+          def mapResults = ["${params.AGENT_INTEGRATION_TEST}": integrationTestsGen.results]
           def processor = new ResultsProcessor()
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false

--- a/.ci/jobs/apm-integration-test-axis-pipeline-jjbb.yml
+++ b/.ci/jobs/apm-integration-test-axis-pipeline-jjbb.yml
@@ -1,0 +1,46 @@
+---
+- job:
+    name: apm-integration-test-axis-pipeline-mbp
+    display-name: APM Integration Test Downstream MBP
+    description: APM Integration Tests downstream job that runs an Agent version matrix
+      tests in a multibranch pipeline
+    project-type: multibranch
+    number-to-keep: '5'
+    days-to-keep: '1'
+    script-path: .ci/integrationTestDownstream.groovy
+    scm:
+    - github:
+        branch-discovery: all
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        repo: apm-integration-testing
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true

--- a/.ci/jobs/apm-integration-test-axis-pipeline-mbp-jjbb.yml
+++ b/.ci/jobs/apm-integration-test-axis-pipeline-mbp-jjbb.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: apm-integration-test-axis-pipeline-mbp
+    name: apm-integration-test-axis-pipeline-mbp-jjbb
     display-name: APM Integration Test Downstream MBP
     description: APM Integration Tests downstream job that runs an Agent version matrix
       tests in a multibranch pipeline

--- a/.ci/jobs/apm-integration-test-axis-pipeline-mbp-jjbb.yml
+++ b/.ci/jobs/apm-integration-test-axis-pipeline-mbp-jjbb.yml
@@ -14,7 +14,6 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        discover-tags: true
         repo: apm-integration-testing
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
@@ -25,8 +24,6 @@
             ignore-tags-older-than: -1
             ignore-tags-newer-than: -1
         - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
         clean:
           after: true
           before: true

--- a/.ci/jobs/apm-integration-tests-mbp-jjbb.yml
+++ b/.ci/jobs/apm-integration-tests-mbp-jjbb.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: apm-integration-tests-mbp
+    display-name: APM Integration Test MBP
+    description: APM Integration Test Multi Branch Pipeline
+    project-type: multibranch
+    number-to-keep: '5'
+    days-to-keep: '1'
+    script-path: .ci/Jenkinsfile
+    scm:
+    - github:
+        branch-discovery: all
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        repo: apm-integration-testing
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true

--- a/.ci/jobs/apm-integration-tests-mbp-jjbb.yml
+++ b/.ci/jobs/apm-integration-tests-mbp-jjbb.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: apm-integration-tests-mbp
+    name: apm-integration-tests-mbp-jjbb
     display-name: APM Integration Test MBP
     description: APM Integration Test Multi Branch Pipeline
     project-type: multibranch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
 def runJob(agentName, buildOpts = ''){
   def job = build(job: 'apm-integration-test-axis-pipeline',
     parameters: [
-    string(name: 'agent_integration_test', value: agentName),
+    string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
     string(name: 'INTEGRATION_TESTING_VERSION', value: env.GIT_BASE_COMMIT),
     string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),

--- a/JenkinsfileAxis
+++ b/JenkinsfileAxis
@@ -73,7 +73,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    choice(name: 'agent_integration_test', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
+    choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "master", description: "Integration testing Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
@@ -102,8 +102,8 @@ pipeline {
         }
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{
-          currentBuild.displayName = "apm-agent-${params.agent_integration_test} - ${currentBuild.displayName}"
-          currentBuild.description = "Agent ${params.agent_integration_test} - ${params.UPSTREAM_BUILD}"
+          currentBuild.displayName = "apm-agent-${params.AGENT_INTEGRATION_TEST} - ${currentBuild.displayName}"
+          currentBuild.description = "Agent ${params.AGENT_INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
         }
       }
     }
@@ -113,8 +113,8 @@ pipeline {
     stage("Integration Tests"){
       when {
         expression {
-          return (params.agent_integration_test != 'All'
-            && params.agent_integration_test != 'UI')
+          return (params.AGENT_INTEGRATION_TEST != 'All'
+            && params.AGENT_INTEGRATION_TEST != 'UI')
         }
       }
       steps {
@@ -122,7 +122,7 @@ pipeline {
         unstash "source"
         dir("${BASE_DIR}"){
           script {
-            def agentTests = mapAgentsIDs[params.agent_integration_test]
+            def agentTests = mapAgentsIDs[params.AGENT_INTEGRATION_TEST]
             integrationTestsGen = new IntegrationTestingParallelTaskGenerator(
               xKey: agentYamlVar[agentTests],
               yKey: agentYamlVar['server'],
@@ -130,7 +130,7 @@ pipeline {
               yFile: ymlFiles['server'],
               exclusionFile: ymlFiles[agentTests],
               tag: agentTests,
-              name: params.agent_integration_test,
+              name: params.AGENT_INTEGRATION_TEST,
               steps: this
               )
             def mapPatallelTasks = integrationTestsGen.generateParallelTests()
@@ -141,7 +141,7 @@ pipeline {
     }
     stage("All") {
       when {
-        expression { return params.agent_integration_test == 'All' }
+        expression { return params.AGENT_INTEGRATION_TEST == 'All' }
       }
       environment {
         TMPDIR = "${WORKSPACE}"
@@ -162,7 +162,7 @@ pipeline {
     }
     stage("UI") {
       when {
-        expression { return params.agent_integration_test == 'UI' }
+        expression { return params.AGENT_INTEGRATION_TEST == 'UI' }
       }
       environment {
         TMPDIR = "${WORKSPACE}/${BASE_DIR}"
@@ -186,7 +186,7 @@ pipeline {
       script{
         if(integrationTestsGen?.results){
           writeJSON(file: 'results.json', json: toJSON(integrationTestsGen.results), pretty: 2)
-          def mapResults = ["${params.agent_integration_test}": integrationTestsGen.results]
+          def mapResults = ["${params.AGENT_INTEGRATION_TEST}": integrationTestsGen.results]
           def processor = new ResultsProcessor()
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false


### PR DESCRIPTION
This is a work-in-progress PR for the MBP support

## What does this PR do?
It adds support for MBP in the JJBB jobs, adding two new builds to the existing ones. We are adding those two builds instead of replacing them in order to maintain the old ones after we have enough confidence in the new builds.

## Why is this PR important?
It adds consistency in the way we create jobs on CI infra, alongside allowing testing different branches of the project with different builds for it.

