### PR TITLE
ci(jenkins): notify github check of the parent stream, if any

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -115,7 +115,7 @@ def githubCheckNotify() {
   if (params.GITHUB_CHECK_NAME?.trim && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim() ) {
     String statusSuffix =
     String status =
-    githubNotify context: params.GITHUB_CHECK_NAME,
+    githubNotify context: "${params.GITHUB_CHECK_NAME}",
                  description: "${params.GITHUB_CHECK_NAME} ${currentBuild.currentResult == 'FAILURE' ? 'failed' : 'passed'}",
                  status: "${(currentBuild.currentResult == 'SUCCESS') ?: 'FAILED'}",
                  targetUrl: "${env.RUN_DISPLAY_URL}",

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
   }
   post {
     always {
-      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILED')
+      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
       notifyBuildResult()
     }
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -112,12 +112,11 @@ def runJob(agentName, buildOpts = ''){
  Notify the GitHub check of the parent stream
 **/
 def githubCheckNotify() {
-  if (params.GITHUB_CHECK_NAME?.trim && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim() ) {
-    String statusSuffix =
-    String status =
+  if (params.GITHUB_CHECK_NAME?.trim && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
+    def status = currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILED'
     githubNotify context: "${params.GITHUB_CHECK_NAME}",
-                 description: "${params.GITHUB_CHECK_NAME} ${currentBuild.currentResult == 'FAILURE' ? 'failed' : 'passed'}",
-                 status: "${(currentBuild.currentResult == 'SUCCESS') ? 'SUCCESS' : 'FAILED'}",
+                 description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",
+                 status: "${status}",
                  targetUrl: "${env.RUN_DISPLAY_URL}",
                  sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GIT_CREDENTIALS = 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
     PIPELINE_LOG_LEVEL='INFO'
   }
   triggers {
@@ -26,7 +27,10 @@ pipeline {
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
-    string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
+    string(name: 'BUILD_OPTS', defaultValue: "", description: "Additional build options to passing compose.py")
+    string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }
   stages{
@@ -77,6 +81,7 @@ pipeline {
   }
   post {
     always {
+      githubCheckNotify()
       notifyBuildResult()
     }
   }
@@ -101,4 +106,19 @@ def runJob(agentName, buildOpts = ''){
     propagate: true,
     quietPeriod: 10,
     wait: true)
+}
+
+/**
+ Notify the GitHub check of the parent stream
+**/
+def githubCheckNotify() {
+  if (params.GITHUB_CHECK_NAME?.trim && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim() ) {
+    String statusSuffix =
+    String status =
+    githubNotify context: params.GITHUB_CHECK_NAME,
+                 description: "${params.GITHUB_CHECK_NAME} ${currentBuild.currentResult == 'FAILURE' ? 'failed' : 'passed'}",
+                 status: "${(currentBuild.currentResult == 'SUCCESS') ?: 'FAILED'}",
+                 targetUrl: "${env.RUN_DISPLAY_URL}",
+                 sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
+  }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -112,7 +112,7 @@ def runJob(agentName, buildOpts = ''){
  Notify the GitHub check of the parent stream
 **/
 def githubCheckNotify() {
-  if (params.GITHUB_CHECK_NAME?.trim && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
+  if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
     def status = currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILED'
     githubNotify context: "${params.GITHUB_CHECK_NAME}",
                  description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
     stage('Checkout'){
       agent { label 'master || immutable' }
       steps {
+        githubCheckNotify('PENDING')
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
@@ -81,7 +82,7 @@ pipeline {
   }
   post {
     always {
-      githubCheckNotify()
+      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILED')
       notifyBuildResult()
     }
   }
@@ -111,9 +112,8 @@ def runJob(agentName, buildOpts = ''){
 /**
  Notify the GitHub check of the parent stream
 **/
-def githubCheckNotify() {
+def githubCheckNotify(String status) {
   if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
-    def status = currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILED'
     githubNotify context: "${params.GITHUB_CHECK_NAME}",
                  description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",
                  status: "${status}",

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    JOB_GIT_CREDENTIALS = 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+    JOB_GIT_CREDENTIALS = '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
     PIPELINE_LOG_LEVEL='INFO'
   }
   triggers {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -117,7 +117,7 @@ def githubCheckNotify() {
     String status =
     githubNotify context: "${params.GITHUB_CHECK_NAME}",
                  description: "${params.GITHUB_CHECK_NAME} ${currentBuild.currentResult == 'FAILURE' ? 'failed' : 'passed'}",
-                 status: "${(currentBuild.currentResult == 'SUCCESS') ?: 'FAILED'}",
+                 status: "${(currentBuild.currentResult == 'SUCCESS') ? 'SUCCESS' : 'FAILED'}",
                  targetUrl: "${env.RUN_DISPLAY_URL}",
                  sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    JOB_GIT_CREDENTIALS = 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+    JOB_GIT_CREDENTIALS = '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
     PIPELINE_LOG_LEVEL='INFO'
   }
   triggers {
@@ -82,7 +82,7 @@ pipeline {
   }
   post {
     always {
-      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILED')
+      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
       notifyBuildResult()
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GIT_CREDENTIALS = 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
     PIPELINE_LOG_LEVEL='INFO'
   }
   triggers {
@@ -26,7 +27,10 @@ pipeline {
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
-    string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
+    string(name: 'BUILD_OPTS', defaultValue: "", description: "Additional build options to passing compose.py")
+    string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }
   stages{
@@ -77,8 +81,24 @@ pipeline {
   }
   post {
     always {
+      githubCheckNotify()
       notifyBuildResult()
     }
+  }
+}
+
+/**
+ Notify the GitHub check of the parent stream
+**/
+def githubCheckNotify() {
+  if (params.GITHUB_CHECK_NAME?.trim && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim() ) {
+    String statusSuffix =
+    String status =
+    githubNotify context: params.GITHUB_CHECK_NAME,
+                 description: "${params.GITHUB_CHECK_NAME} ${currentBuild.currentResult == 'FAILURE' ? 'failed' : 'passed'}",
+                 status: "${(currentBuild.currentResult == 'SUCCESS') ?: 'FAILED'}",
+                 targetUrl: "${env.RUN_DISPLAY_URL}",
+                 sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- Enable to report the build status to the GitHub check of the parent stream if any
- It should report either `failed` or `success` and a link to the build URL.
- This feature will enable to trigger and notify status between different Pipelines.