### PR TITLE
feat: support to build apm server from a particular commit or branch

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -12,7 +12,8 @@ ENV SRC=/go/src/github.com/elastic/apm-server
 
 # Git clone and checkout given either the branch, commit or both.
 RUN git clone ${apm_server_repo} ${SRC} \
-    && cd ${SRC} && git reset --hard ${apm_server_branch_or_commit}
+    && cd ${SRC} && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+    && git checkout ${apm_server_branch_or_commit}
 
 RUN cd ${SRC} && git rev-parse HEAD && echo ${apm_server_branch_or_commit}
 

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -6,15 +6,18 @@ FROM golang:${go_version} AS build
 # install make update prerequisites
 RUN apt-get -qq update && apt-get -qq install -y python-virtualenv
 
-ARG apm_server_branch_or_commit=master
+ARG apm_server_branch=master
+ARG apm_server_commit=
 ARG apm_server_repo=https://github.com/elastic/apm-server.git
 ENV SRC=/go/src/github.com/elastic/apm-server
 
 # Git clone and checkout given either the branch, commit or both.
-RUN git clone ${apm_server_repo} ${SRC} \
-    && cd ${SRC} && git reset --hard ${apm_server_branch_or_commit}
+RUN [ -z "${apm_server_commit}" ] \
+      && (echo 'cloning from branch' && git clone -b $apm_server_branch ${apm_server_repo} ${SRC}) \
+      || (echo 'cloning from commit' && git clone ${apm_server_repo} ${SRC} \
+          && cd ${SRC} && git reset --hard ${apm_server_commit})
 
-RUN cd ${SRC} && git rev-parse HEAD && echo ${apm_server_branch_or_commit}
+RUN cd ${SRC} && git rev-parse HEAD
 
 RUN make -C ${SRC} && update apm-server \
 	  && sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' ${SRC}/apm-server.yml \

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -7,14 +7,24 @@ FROM golang:${go_version} AS build
 RUN apt-get -qq update && apt-get -qq install -y python-virtualenv
 
 ARG apm_server_branch=master
+ARG apm_server_commit=
 ARG apm_server_repo=https://github.com/elastic/apm-server.git
-RUN git clone -b $apm_server_branch ${apm_server_repo} /go/src/github.com/elastic/apm-server && \
-	make -C /go/src/github.com/elastic/apm-server update apm-server && \
-	sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' /go/src/github.com/elastic/apm-server/apm-server.yml && \
-	chmod go+r /go/src/github.com/elastic/apm-server/apm-server.yml
+ENV SRC=/go/src/github.com/elastic/apm-server
+
+# Git clone and checkout given either the branch, commit or both.
+RUN [ -z "${apm_server_commit}" ] \
+      && (echo 'cloning from branch' && git clone -b $apm_server_branch ${apm_server_repo} ${SRC}) \
+      || (echo 'cloning from commit' && git clone ${apm_server_repo} ${SRC} \
+          && cd ${SRC} && git reset --hard ${apm_server_commit})
+
+RUN cd ${SRC} && git rev-parse HEAD
+
+RUN make -C ${SRC} && update apm-server \
+	  && sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' ${SRC}/apm-server.yml \
+	  && chmod go+r ${SRC}/apm-server.yml
 
 FROM ${apm_server_base_image}
 
-COPY --from=build /go/src/github.com/elastic/apm-server/apm-server /usr/share/apm-server/apm-server
-COPY --from=build /go/src/github.com/elastic/apm-server/apm-server.yml /usr/share/apm-server/apm-server.yml
-COPY --from=build /go/src/github.com/elastic/apm-server/fields.yml /usr/share/apm-server/fields.yml
+COPY --from=build ${SRC}/apm-server /usr/share/apm-server/apm-server
+COPY --from=build ${SRC}/apm-server.yml /usr/share/apm-server/apm-server.yml
+COPY --from=build ${SRC}/fields.yml /usr/share/apm-server/fields.yml

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -6,18 +6,15 @@ FROM golang:${go_version} AS build
 # install make update prerequisites
 RUN apt-get -qq update && apt-get -qq install -y python-virtualenv
 
-ARG apm_server_branch=master
-ARG apm_server_commit=
+ARG apm_server_branch_or_commit=master
 ARG apm_server_repo=https://github.com/elastic/apm-server.git
 ENV SRC=/go/src/github.com/elastic/apm-server
 
 # Git clone and checkout given either the branch, commit or both.
-RUN [ -z "${apm_server_commit}" ] \
-      && (echo 'cloning from branch' && git clone -b $apm_server_branch ${apm_server_repo} ${SRC}) \
-      || (echo 'cloning from commit' && git clone ${apm_server_repo} ${SRC} \
-          && cd ${SRC} && git reset --hard ${apm_server_commit})
+RUN git clone ${apm_server_repo} ${SRC} \
+    && cd ${SRC} && git reset --hard ${apm_server_branch_or_commit}
 
-RUN cd ${SRC} && git rev-parse HEAD
+RUN cd ${SRC} && git rev-parse HEAD && echo ${apm_server_branch_or_commit}
 
 RUN make -C ${SRC} && update apm-server \
 	  && sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' ${SRC}/apm-server.yml \

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -508,7 +508,7 @@ class ApmServer(StackService, Service):
             '--apm-server-build',
             const="https://github.com/elastic/apm-server.git",
             nargs="?",
-            help='build apm-server from a git repo[@branch], eg https://github.com/elastic/apm-server.git@v2'
+            help='build apm-server from a git repo[@branch|#sha], eg https://github.com/elastic/apm-server.git@v2'
         )
         parser.add_argument(
             "--apm-server-ilm-disable",
@@ -653,14 +653,25 @@ class ApmServer(StackService, Service):
 
         if self.build:
             build_spec_parts = self.build.split("@", 1)
+            commit_spec_parts = self.build.split("#", 1)
             repo = build_spec_parts[0]
-            branch = build_spec_parts[1] if len(build_spec_parts) > 1 else "master"
+            if len(build_spec_parts) > 1:
+                branch = build_spec_parts[1]
+                commit = ""
+            elif len(commit_spec_parts) > 1:
+                branch = ""
+                commit = commit_spec_parts[1]
+                repo = commit_spec_parts[0]
+            else:
+                branch = "master"
+                commit = ""
             content.update({
                 "build": {
                     "context": "docker/apm-server",
                     "args": {
                         "apm_server_base_image": self.default_image(),
                         "apm_server_branch": branch,
+                        "apm_server_commit": commit,
                         "apm_server_repo": repo,
                     }
                 },

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -508,7 +508,7 @@ class ApmServer(StackService, Service):
             '--apm-server-build',
             const="https://github.com/elastic/apm-server.git",
             nargs="?",
-            help='build apm-server from a git repo[@branch|#sha], eg https://github.com/elastic/apm-server.git@v2'
+            help='build apm-server from a git repo[@branch|sha], eg https://github.com/elastic/apm-server.git@v2'
         )
         parser.add_argument(
             "--apm-server-ilm-disable",
@@ -653,25 +653,14 @@ class ApmServer(StackService, Service):
 
         if self.build:
             build_spec_parts = self.build.split("@", 1)
-            commit_spec_parts = self.build.split("#", 1)
             repo = build_spec_parts[0]
-            if len(build_spec_parts) > 1:
-                branch = build_spec_parts[1]
-                commit = ""
-            elif len(commit_spec_parts) > 1:
-                branch = ""
-                commit = commit_spec_parts[1]
-                repo = commit_spec_parts[0]
-            else:
-                branch = "master"
-                commit = ""
+            branch = build_spec_parts[1] if len(build_spec_parts) > 1 else "master"
             content.update({
                 "build": {
                     "context": "docker/apm-server",
                     "args": {
                         "apm_server_base_image": self.default_image(),
-                        "apm_server_branch": branch,
-                        "apm_server_commit": commit,
+                        "apm_server_branch_or_commit": branch,
                         "apm_server_repo": repo,
                     }
                 },

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -508,7 +508,7 @@ class ApmServer(StackService, Service):
             '--apm-server-build',
             const="https://github.com/elastic/apm-server.git",
             nargs="?",
-            help='build apm-server from a git repo[@branch|sha], eg https://github.com/elastic/apm-server.git@v2'
+            help='build apm-server from a git repo[@branch|#sha], eg https://github.com/elastic/apm-server.git@v2'
         )
         parser.add_argument(
             "--apm-server-ilm-disable",
@@ -653,14 +653,25 @@ class ApmServer(StackService, Service):
 
         if self.build:
             build_spec_parts = self.build.split("@", 1)
+            commit_spec_parts = self.build.split("#", 1)
             repo = build_spec_parts[0]
-            branch = build_spec_parts[1] if len(build_spec_parts) > 1 else "master"
+            if len(build_spec_parts) > 1:
+                branch = build_spec_parts[1]
+                commit = ""
+            elif len(commit_spec_parts) > 1:
+                branch = ""
+                commit = commit_spec_parts[1]
+                repo = commit_spec_parts[0]
+            else:
+                branch = "master"
+                commit = ""
             content.update({
                 "build": {
                     "context": "docker/apm-server",
                     "args": {
                         "apm_server_base_image": self.default_image(),
-                        "apm_server_branch_or_commit": branch,
+                        "apm_server_branch": branch,
+                        "apm_server_commit": commit,
                         "apm_server_repo": repo,
                     }
                 },

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -426,18 +426,7 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
-                     'apm_server_branch': 'bar',
-                     'apm_server_commit': '',
-                     'apm_server_repo': 'foo.git'},
-            'context': 'docker/apm-server'})
-
-    def test_apm_server_build_with_commit(self):
-        apm_server = ApmServer(version="6.3.100", apm_server_build="foo.git#123", release=True).render()["apm-server"]
-        self.assertIsNone(apm_server.get("image"))
-        self.assertDictEqual(apm_server["build"], {
-            'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
-                     'apm_server_branch': '',
-                     'apm_server_commit': '123',
+                     'apm_server_branch_or_commit': 'bar',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 
@@ -446,8 +435,7 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
-                     'apm_server_branch': 'master',
-                     'apm_server_commit': '',
+                     'apm_server_branch_or_commit': 'master',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -426,7 +426,18 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
-                     'apm_server_branch_or_commit': 'bar',
+                     'apm_server_branch': 'bar',
+                     'apm_server_commit': '',
+                     'apm_server_repo': 'foo.git'},
+            'context': 'docker/apm-server'})
+
+    def test_apm_server_build_with_commit(self):
+        apm_server = ApmServer(version="6.3.100", apm_server_build="foo.git#123", release=True).render()["apm-server"]
+        self.assertIsNone(apm_server.get("image"))
+        self.assertDictEqual(apm_server["build"], {
+            'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
+                     'apm_server_branch': '',
+                     'apm_server_commit': '123',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 
@@ -435,7 +446,8 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
-                     'apm_server_branch_or_commit': 'master',
+                     'apm_server_branch': 'master',
+                     'apm_server_commit': '',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -427,6 +427,17 @@ class ApmServerServiceTest(ServiceTest):
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
                      'apm_server_branch': 'bar',
+                     'apm_server_commit': '',
+                     'apm_server_repo': 'foo.git'},
+            'context': 'docker/apm-server'})
+
+    def test_apm_server_build_with_commit(self):
+        apm_server = ApmServer(version="6.3.100", apm_server_build="foo.git#123", release=True).render()["apm-server"]
+        self.assertIsNone(apm_server.get("image"))
+        self.assertDictEqual(apm_server["build"], {
+            'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
+                     'apm_server_branch': '',
+                     'apm_server_commit': '123',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 
@@ -436,6 +447,7 @@ class ApmServerServiceTest(ServiceTest):
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
                      'apm_server_branch': 'master',
+                     'apm_server_commit': '',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 


### PR DESCRIPTION
Relates to https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- Support build the apm server either from a particular branch or a particular sha.
- This will help to have some reproducibility when running a particular build from another build as using the sha will ensure the apm-server is created for a particular commit, which cannot be overridden as it might happen when using a branch instead.