### PR TITLE
Implement --opbeans-java-agent-branch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ To disable load generation for a specific service, use the `--no-opbeans-XYZ-loa
 Opbeans RUM does not need a load generation service,
 as it is itself generating load using a headless chrome instance.
 
+#### Start Opbeans with a specific agent branch
+
+You can start Opbeans with an agent which is built from source from a specific branch or PR.
+This is currently only supported with the go and the Java agent.
+
+Example which builds the https://github.com/elastic/apm-agent-java/pull/588 branch from source and uses an APM server built from master: 
+
+    ./scripts/compose.py start master --with-opbeans-java --opbeans-java-agent-branch=pr/588/head --apm-server-build https://github.com/elastic/apm-server.git@master
+
+Note that it may take a while to build the agent from source.
+
 ### Uploading Sourcemaps
 
 The frontend app packaged with opbeans-node runs in a production build, which means the source code is minified. The APM server needs the corresponding sourcemap to unminify the code.

--- a/docker/opbeans/java/Dockerfile
+++ b/docker/opbeans/java/Dockerfile
@@ -13,7 +13,7 @@ RUN ./build-agent.sh "${JAVA_AGENT_REPO}" "${JAVA_AGENT_BRANCH}"
 
 FROM opbeans/opbeans-java:latest
 # replaces the /agent/elastc-apm-agent.jar if it has been built by build-agent.sh
-COPY --from=0 /agent/* /app
+COPY --from=0 /agent/* /app/
 COPY entrypoint.sh /app/entrypoint.sh
 CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=customdb\
                                         -Dserver.port=${OPBEANS_SERVER_PORT:-3002}\

--- a/docker/opbeans/java/Dockerfile
+++ b/docker/opbeans/java/Dockerfile
@@ -1,5 +1,19 @@
-FROM opbeans/opbeans-java:latest
+FROM maven:3.5.3-jdk-10
+# setting --build-arg JAVA_AGENT_BRANCH=<branch> causes the agent to be built from source
+# instead of using the agent which comes pre-built with opbeans-java:latest
+ARG JAVA_AGENT_REPO=elastic/apm-agent-java
+ARG JAVA_AGENT_BRANCH=
 
+RUN mkdir /agent \
+  # making sure there is at least one file to COPY (otherwise docker complains)
+  && touch /agent/ignore
+COPY build-agent.sh .
+# noop if JAVA_AGENT_BRANCH is not set
+RUN ./build-agent.sh "${JAVA_AGENT_REPO}" "${JAVA_AGENT_BRANCH}"
+
+FROM opbeans/opbeans-java:latest
+# replaces the /agent/elastc-apm-agent.jar if it has been built by build-agent.sh
+COPY --from=0 /agent/* /app
 COPY entrypoint.sh /app/entrypoint.sh
 CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=customdb\
                                         -Dserver.port=${OPBEANS_SERVER_PORT:-3002}\

--- a/docker/opbeans/java/build-agent.sh
+++ b/docker/opbeans/java/build-agent.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -x
+JAVA_AGENT_REPO=${1}
+JAVA_AGENT_BRANCH=${2}
+
+ARTIFACT_ID=elastic-apm-agent
+
+if [ -n "${JAVA_AGENT_BRANCH}" ] ; then
+  # build agent from source, install to ~/.m2 repo
+  git clone https://github.com/${JAVA_AGENT_REPO}.git /apm-agent-java
+  cd /apm-agent-java
+  git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+  git checkout ${JAVA_AGENT_BRANCH}
+
+  mvn -q --batch-mode clean install -DskipTests \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+  export VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+  cp /root/.m2/repository/co/elastic/apm/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}.jar /agent/elastic-apm-agent.jar
+fi

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1727,7 +1727,7 @@ class OpbeansGo(OpbeansService):
 
 class OpbeansJava(OpbeansService):
     SERVICE_PORT = 3002
-    DEFAULT_AGENT_BRANCH = ""
+    DEFAULT_AGENT_BRANCH = "master"
     DEFAULT_AGENT_REPO = "elastic/apm-agent-java"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = 'opbeans-java'

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1727,7 +1727,7 @@ class OpbeansGo(OpbeansService):
 
 class OpbeansJava(OpbeansService):
     SERVICE_PORT = 3002
-    DEFAULT_AGENT_BRANCH = "master"
+    DEFAULT_AGENT_BRANCH = ""
     DEFAULT_AGENT_REPO = "elastic/apm-agent-java"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = 'opbeans-java'

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -138,7 +138,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/java
                       args:
-                        - JAVA_AGENT_BRANCH=master
+                        - JAVA_AGENT_BRANCH=
                         - JAVA_AGENT_REPO=elastic/apm-agent-java
                     container_name: localtesting_6.3.10_opbeans-java
                     ports:


### PR DESCRIPTION
This lets you start Opbeans with a specific Java agent branch built from source

It adds very little overhead when not specifying a branch