### PR TITLE
feat: Expose repo flags for Go, Ruby, Java and .Net apm agents

### DIFF
--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -3,8 +3,13 @@ set -x
 
 CSPROJ="TestAspNetCoreApp.csproj"
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-  git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent -b ${DOTNET_AGENT_BRANCH}
+
+  git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent
   cd /src/dotnet-agent
+  git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+  git checkout ${DOTNET_AGENT_BRANCH}
+  git rev-parse HEAD
+
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
   dotnet restore

--- a/docker/ruby/rails/testapp/Gemfile
+++ b/docker/ruby/rails/testapp/Gemfile
@@ -22,11 +22,11 @@ group :development do
 end
 
 if ENV['RUBY_AGENT_VERSION_STATE']=='release'
-  if ENV['RUBY_AGENT_VERSION'] == 'latest' 
+  if ENV['RUBY_AGENT_VERSION'] == 'latest'
     gem 'elastic-apm'
-  else 
+  else
     gem 'elastic-apm', "~> #{ENV['RUBY_AGENT_VERSION']}"
   end
 else
-  gem 'elastic-apm', git: 'https://github.com/elastic/apm-agent-ruby.git', branch: ENV['RUBY_AGENT_VERSION']
+  gem 'elastic-apm', git: "https://github.com/#{ENV['RUBY_AGENT_REPO']}.git", branch: ENV['RUBY_AGENT_VERSION']
 end

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get -qq update \
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
-RUN git clone -b $RUM_AGENT_BRANCH --single-branch https://github.com/$RUM_AGENT_REPO.git --depth 1 rumjs-integration-test
+RUN git clone https://github.com/${RUM_AGENT_REPO}.git /rumjs-integration-test
+RUN (cd /rumjs-integration-test \
+  && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+  && git checkout ${RUM_AGENT_BRANCH})
 
 WORKDIR /rumjs-integration-test
 

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1482,6 +1482,7 @@ class AgentJavaSpring(Service):
     SERVICE_PORT = 8090
     DEFAULT_AGENT_VERSION = "master"
     DEFAULT_AGENT_RELEASE = ""
+    DEFAULT_AGENT_REPO = "elastic/apm-agent-java"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1496,11 +1497,17 @@ class AgentJavaSpring(Service):
             default=cls.DEFAULT_AGENT_RELEASE,
             help='Use Java agent release version (1.6.0, 0.6.2, ...)',
         )
+        parser.add_argument(
+            "--java-agent-repo",
+            default=cls.DEFAULT_AGENT_REPO,
+            help='GitHub repo to be used. Default: elastic/apm-agent-java',
+        )
 
     def __init__(self, **options):
         super(AgentJavaSpring, self).__init__(**options)
         self.agent_version = options.get("java_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_release = options.get("java_agent_release", self.DEFAULT_AGENT_RELEASE)
+        self.agent_repo = options.get("java_agent_repo", self.DEFAULT_AGENT_REPO)
         self.depends_on = {
             "apm-server": {"condition": "service_healthy"},
         }
@@ -1517,6 +1524,7 @@ class AgentJavaSpring(Service):
                 "args": {
                     "JAVA_AGENT_BRANCH": self.agent_version,
                     "JAVA_AGENT_BUILT_VERSION": self.agent_release,
+                    "JAVA_AGENT_REPO": self.agent_repo,
                 }
             },
             container_name="javaspring",

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1204,6 +1204,7 @@ class AgentRUMJS(Service):
         parser.add_argument(
             '--rum-agent-repo',
             default=cls.DEFAULT_AGENT_REPO,
+            help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
         parser.add_argument(
             '--rum-agent-branch',
@@ -1251,6 +1252,7 @@ class AgentGoNetHttp(Service):
         parser.add_argument(
             '--go-agent-repo',
             default=cls.DEFAULT_AGENT_REPO,
+            help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
 
     def __init__(self, **options):
@@ -1437,7 +1439,7 @@ class AgentRubyRails(Service):
         parser.add_argument(
             "--ruby-agent-repo",
             default=cls.DEFAULT_AGENT_REPO,
-            help='GitHub repo to be used. Default: elastic/apm-agent-ruby',
+            help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
 
     def __init__(self, **options):
@@ -1500,7 +1502,7 @@ class AgentJavaSpring(Service):
         parser.add_argument(
             "--java-agent-repo",
             default=cls.DEFAULT_AGENT_REPO,
-            help='GitHub repo to be used. Default: elastic/apm-agent-java',
+            help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
 
     def __init__(self, **options):
@@ -1563,7 +1565,7 @@ class AgentDotnet(Service):
         parser.add_argument(
             "--dotnet-agent-repo",
             default=cls.DEFAULT_AGENT_REPO,
-            help='GitHub repo to be used. Default: elastic/apm-agent-dotnet',
+            help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
 
     def __init__(self, **options):

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1238,6 +1238,7 @@ class AgentRUMJS(Service):
 class AgentGoNetHttp(Service):
     SERVICE_PORT = 8080
     DEFAULT_AGENT_VERSION = "master"
+    DEFAULT_AGENT_REPO = "elastic/apm-agent-go"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1247,10 +1248,15 @@ class AgentGoNetHttp(Service):
             default=cls.DEFAULT_AGENT_VERSION,
             help='Use Go agent version (master, 0.5, v0.5.2, ...)',
         )
+        parser.add_argument(
+            '--go-agent-repo',
+            default=cls.DEFAULT_AGENT_REPO,
+        )
 
     def __init__(self, **options):
         super(AgentGoNetHttp, self).__init__(**options)
         self.agent_version = options.get("go_agent_version", self.DEFAULT_AGENT_VERSION)
+        self.agent_repo = options.get("go_agent_repo", self.DEFAULT_AGENT_REPO)
         self.depends_on = {
             "apm-server": {"condition": "service_healthy"},
         }
@@ -1266,6 +1272,7 @@ class AgentGoNetHttp(Service):
                 "dockerfile": "Dockerfile",
                 "args": {
                     "GO_AGENT_BRANCH": self.agent_version,
+                    "GO_AGENT_REPO": self.agent_repo,
                 },
             },
             container_name="gonethttpapp",

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1416,6 +1416,7 @@ class AgentPythonFlask(AgentPython):
 
 
 class AgentRubyRails(Service):
+    DEFAULT_AGENT_REPO = "elastic/apm-agent-ruby"
     DEFAULT_AGENT_VERSION = "latest"
     DEFAULT_AGENT_VERSION_STATE = "release"
     SERVICE_PORT = 8020
@@ -1433,11 +1434,17 @@ class AgentRubyRails(Service):
             default=cls.DEFAULT_AGENT_VERSION_STATE,
             help='Use Ruby agent version state (github or release)',
         )
+        parser.add_argument(
+            "--ruby-agent-repo",
+            default=cls.DEFAULT_AGENT_REPO,
+            help='GitHub repo to be used. Default: elastic/apm-agent-ruby',
+        )
 
     def __init__(self, **options):
         super(AgentRubyRails, self).__init__(**options)
         self.agent_version = options.get("ruby_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_version_state = options.get("ruby_agent_version_state", self.DEFAULT_AGENT_VERSION_STATE)
+        self.agent_repo = options.get("ruby_agent_repo", self.DEFAULT_AGENT_REPO)
         self.depends_on = {
             "apm-server": {"condition": "service_healthy"},
         }
@@ -1460,6 +1467,7 @@ class AgentRubyRails(Service):
                 "RAILS_SERVICE_NAME": "railsapp",
                 "RUBY_AGENT_VERSION_STATE": self.agent_version_state,
                 "RUBY_AGENT_VERSION": self.agent_version,
+                "RUBY_AGENT_REPO": self.agent_repo,
             },
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "railsapp", retries=60),
             depends_on=self.depends_on,

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1545,6 +1545,7 @@ class AgentDotnet(Service):
     SERVICE_PORT = 8100
     DEFAULT_AGENT_VERSION = "master"
     DEFAULT_AGENT_RELEASE = ""
+    DEFAULT_AGENT_REPO = "elastic/apm-agent-dotnet"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1559,11 +1560,17 @@ class AgentDotnet(Service):
             default=cls.DEFAULT_AGENT_RELEASE,
             help='Use .NET agent release version (0.0.1-alpha, 0.0.2-alpha, ...)',
         )
+        parser.add_argument(
+            "--dotnet-agent-repo",
+            default=cls.DEFAULT_AGENT_REPO,
+            help='GitHub repo to be used. Default: elastic/apm-agent-dotnet',
+        )
 
     def __init__(self, **options):
         super(AgentDotnet, self).__init__(**options)
         self.agent_version = options.get("dotnet_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_release = options.get("dotnet_agent_release", self.DEFAULT_AGENT_RELEASE)
+        self.agent_repo = options.get("dotnet_agent_repo", self.DEFAULT_AGENT_REPO)
         self.depends_on = {
             "apm-server": {"condition": "service_healthy"},
         }
@@ -1580,6 +1587,7 @@ class AgentDotnet(Service):
                 "args": {
                     "DOTNET_AGENT_BRANCH": self.agent_version,
                     "DOTNET_AGENT_VERSION": self.agent_release,
+                    "DOTNET_AGENT_REPO": self.agent_repo,
                 },
             },
             container_name="dotnetapp",

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -26,6 +26,7 @@ class AgentServiceTest(ServiceTest):
                     build:
                         args:
                             GO_AGENT_BRANCH: master
+                            GO_AGENT_REPO: elastic/apm-agent-go
                         dockerfile: Dockerfile
                         context: docker/go/nethttp
                     container_name: gonethttpapp

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -164,6 +164,7 @@ class AgentServiceTest(ServiceTest):
                         RAILS_PORT: 8020
                         RUBY_AGENT_VERSION: latest
                         RUBY_AGENT_VERSION_STATE: release
+                        RUBY_AGENT_REPO: elastic/apm-agent-ruby
                     healthcheck:
                         interval: 10s
                         retries: 60

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -220,6 +220,7 @@ class AgentServiceTest(ServiceTest):
                         args:
                             DOTNET_AGENT_BRANCH: master
                             DOTNET_AGENT_VERSION: ""
+                            DOTNET_AGENT_REPO: elastic/apm-agent-dotnet
                         dockerfile: Dockerfile
                         context: docker/dotnet
                     container_name: dotnetapp

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -187,6 +187,7 @@ class AgentServiceTest(ServiceTest):
                         args:
                             JAVA_AGENT_BRANCH: master
                             JAVA_AGENT_BUILT_VERSION: ""
+                            JAVA_AGENT_REPO: elastic/apm-agent-java
                         dockerfile: Dockerfile
                         context: docker/java/spring
                     container_name: javaspring


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- Expose the below arguments/flags
  - `--go-agent-repo`
  - `--ruby-agent-repo`
  - `--java-agent-repo`
  - `--dotnet-agent-repo`
- Checkout either a branch or a commit
- Neither python nor nodejs support those flags at the moment.
