### PR TITLE
fix: allow to set --no-kibana with the --all option

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -996,6 +996,7 @@ class Heartbeat(BeatMixin, StackService, Service):
     docker_path = "beats"
 
     def __init__(self, **options):
+        options['enable_kibana'] = False
         super(Heartbeat, self).__init__(**options)
         config = "heartbeat.yml"
         self.heartbeat_config_path = os.path.join(".", "docker", "heartbeat", config)

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -996,7 +996,6 @@ class Heartbeat(BeatMixin, StackService, Service):
     docker_path = "beats"
 
     def __init__(self, **options):
-        del options['enable_kibana']
         super(Heartbeat, self).__init__(**options)
         config = "heartbeat.yml"
         self.heartbeat_config_path = os.path.join(".", "docker", "heartbeat", config)


### PR DESCRIPTION
it is not possible to execute `scripts/compose.py start master --all --no-kibana` it fails with the error `ERROR: Service 'heartbeat' depends on service 'kibana' which is undefined.` if you add `--no-heartbeat` it does not have an effect and the docker compose file contains heartbeat, checking the compose.py I've found that the enable_kibana option is removed on the init method, I do not understand why and it works if I remove this line, seems some kind leftover from a test.