### PR TITLE
feat: change BUILD_OPTS precedence

### DIFF
--- a/.ci/scripts/dotnet.sh
+++ b/.ci/scripts/dotnet.sh
@@ -9,7 +9,7 @@ if [ -n "${APM_AGENT_DOTNET_VERSION}" ]; then
   EXTRA_OPTS=${APM_AGENT_DOTNET_VERSION/'github;'/'--dotnet-agent-version='}
   EXTRA_OPTS=${EXTRA_OPTS/'release;'/'--dotnet-agent-release='}
   EXTRA_OPTS=${EXTRA_OPTS/'commit;'/'--dotnet-agent-version='}
-  BUILD_OPTS="${BUILD_OPTS} ${EXTRA_OPTS}"
+  BUILD_OPTS="${EXTRA_OPTS} ${BUILD_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-dotnet --force-build"

--- a/.ci/scripts/go.sh
+++ b/.ci/scripts/go.sh
@@ -9,7 +9,7 @@ if [ -n "${APM_AGENT_GO_VERSION}" ]; then
   APM_AGENT_GO_VERSION=${APM_AGENT_GO_VERSION/'github;'/''}
   APM_AGENT_GO_VERSION=${APM_AGENT_GO_VERSION/'release;'/''}
   APM_AGENT_GO_VERSION=${APM_AGENT_GO_VERSION/'commit;'/''}
-  BUILD_OPTS="${BUILD_OPTS} --go-agent-version='${APM_AGENT_GO_VERSION}'"
+  BUILD_OPTS="--go-agent-version='${APM_AGENT_GO_VERSION}' ${BUILD_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-go-net-http --force-build"

--- a/.ci/scripts/java.sh
+++ b/.ci/scripts/java.sh
@@ -9,7 +9,7 @@ if [ -n "${APM_AGENT_JAVA_VERSION}" ]; then
   EXTRA_OPTS=${APM_AGENT_JAVA_VERSION/'github;'/'--java-agent-version='}
   EXTRA_OPTS=${EXTRA_OPTS/'release;'/'--java-agent-release='}
   EXTRA_OPTS=${EXTRA_OPTS/'commit;'/'--java-agent-version='}
-  BUILD_OPTS="${BUILD_OPTS} ${EXTRA_OPTS}"
+  BUILD_OPTS="${EXTRA_OPTS} ${BUILD_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-java-spring --force-build"

--- a/.ci/scripts/nodejs.sh
+++ b/.ci/scripts/nodejs.sh
@@ -8,7 +8,7 @@ test -z "$srcdir" && srcdir=.
 if [ -n "${APM_AGENT_NODEJS_VERSION}" ]; then
   APM_AGENT_NODEJS_VERSION=${APM_AGENT_NODEJS_VERSION/'github;'/'elastic/apm-agent-nodejs#'}
   APM_AGENT_NODEJS_VERSION=${APM_AGENT_NODEJS_VERSION/'release;'/'elastic-apm-node@'}
-  BUILD_OPTS="${BUILD_OPTS} --nodejs-agent-package='${APM_AGENT_NODEJS_VERSION}'"
+  BUILD_OPTS="--nodejs-agent-package='${APM_AGENT_NODEJS_VERSION}' ${BUILD_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-nodejs-express --force-build"

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -11,7 +11,7 @@ if [ -n "${APM_AGENT_PYTHON_VERSION}" ]; then
   if [ "${APM_AGENT_PYTHON_VERSION}" = "elastic-apm==latest" ]; then
     APM_AGENT_PYTHON_VERSION="elastic-apm"
   fi
-  BUILD_OPTS="${BUILD_OPTS} --python-agent-package='${APM_AGENT_PYTHON_VERSION}'"
+  BUILD_OPTS="--python-agent-package='${APM_AGENT_PYTHON_VERSION}' ${BUILD_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-python-django --with-agent-python-flask --force-build"

--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -6,7 +6,7 @@ test -z "$srcdir" && srcdir=.
 . ${srcdir}/common.sh
 
 if [ -n "${APM_AGENT_RUBY_VERSION}" ]; then
-  BUILD_OPTS="${BUILD_OPTS} --ruby-agent-version='${APM_AGENT_RUBY_VERSION#*;}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}'"
+  BUILD_OPTS="--ruby-agent-version='${APM_AGENT_RUBY_VERSION#*;}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}' ${BUILD_OPTS}"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-ruby-rails --force-build"

--- a/.ci/scripts/rum.sh
+++ b/.ci/scripts/rum.sh
@@ -9,10 +9,10 @@ if [ -n "${APM_AGENT_RUM_VERSION}" ]; then
   APM_AGENT_RUM_VERSION=${APM_AGENT_RUM_VERSION/'github;'/''}
   APM_AGENT_RUM_VERSION=${APM_AGENT_RUM_VERSION/'release;'/''}
   APM_AGENT_RUM_VERSION=${APM_AGENT_RUM_VERSION/'commit;'/''}
-  BUILD_OPTS="${BUILD_OPTS} --rum-agent-branch='${APM_AGENT_RUM_VERSION}'"
+  BUILD_OPTS="--rum-agent-branch='${APM_AGENT_RUM_VERSION}' ${BUILD_OPTS}"
 fi
 
-#--with-agent-python-django 
+#--with-agent-python-django
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-rumjs --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-rum docker-test-agent-rum


### PR DESCRIPTION
This is caused when BUILD_OPTS and any other env variables are affecting the same flag, so, then BUILD_OPTS got less precedence.

For instance:
- The build for https://github.com/elastic/apm-agent-dotnet/pull/294 was triggered with the values `'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"` and the ITs were launched with the below setup:


```
python scripts/compose.py start 7.0.0 \
--dotnet-agent-version 83c7570b0eaf1e79852915fa3346c254cbfaa5b4  \
--apm-server-build https://github.com/elastic/apm-server.git@master \
--build-parallel \
--dotnet-agent-version=master \
--no-apm-server-dashboards \
--no-apm-server-self-instrument \
--no-kibana \
--with-agent-dotnet \
--force-build
```

As you can see `--dotnet-agent-version 83c7570b0eaf1e79852915fa3346c254cbfaa5b4` and `--dotnet-agent-version=master` are duplicated and therefore the latest one is the one which it's finally used in this case.

This particular change will change the precedence in the other way around.