### PR TITLE
close #482 feat(jenkins): Pipeline test selector

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    JOB_GIT_CREDENTIALS = '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
     PIPELINE_LOG_LEVEL='INFO'
   }
   triggers {
@@ -27,10 +26,7 @@ pipeline {
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
-    string(name: 'BUILD_OPTS', defaultValue: "", description: "Additional build options to passing compose.py")
-    string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
-    string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
-    string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }
   stages{
@@ -40,7 +36,6 @@ pipeline {
     stage('Checkout'){
       agent { label 'master || immutable' }
       steps {
-        githubCheckNotify('PENDING')
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
@@ -82,7 +77,6 @@ pipeline {
   }
   post {
     always {
-      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
       notifyBuildResult()
     }
   }
@@ -107,17 +101,4 @@ def runJob(agentName, buildOpts = ''){
     propagate: true,
     quietPeriod: 10,
     wait: true)
-}
-
-/**
- Notify the GitHub check of the parent stream
-**/
-def githubCheckNotify(String status) {
-  if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
-    githubNotify context: "${params.GITHUB_CHECK_NAME}",
-                 description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",
-                 status: "${status}",
-                 targetUrl: "${env.RUN_DISPLAY_URL}",
-                 sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
-  }
 }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -1,0 +1,191 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+import groovy.transform.Field
+
+/**
+  translate from human agent name to its app name .
+*/
+@Field Map mapAgentsApps = [
+  '.NET': 'dotnet',
+  'Go': 'go-net-http',
+  'Java': 'java-spring',
+  'Node.js': 'nodejs-express',
+  'Python': 'python-django',
+  'Ruby': 'ruby-rails',
+  'RUM': 'rumjs',
+  'All': 'all',
+  'UI': 'ui'
+]
+
+/**
+  translate from human agent name to an ID.
+*/
+@Field Map mapAgentsIDs = [
+  '.NET': 'dotnet',
+  'Go': 'go',
+  'Java': 'java',
+  'Node.js': 'nodejs',
+  'Python': 'python',
+  'Ruby': 'ruby',
+  'RUM': 'rum',
+  'All': 'all',
+  'UI': 'ui'
+]
+
+pipeline {
+  agent { label 'linux && immutable && docker' }
+  environment {
+    BASE_DIR="src/github.com/elastic/apm-integration-testing"
+    NOTIFY_TO = credentials('notify-to')
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GIT_CREDENTIALS = '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
+    PIPELINE_LOG_LEVEL = 'INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '300', artifactNumToKeepStr: '300', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  parameters {
+    choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
+    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
+    string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
+    string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
+  }
+  stages{
+    /**
+     Checkout the code and stash it, to use it on other stages.
+    */
+    stage('Checkout'){
+      agent { label 'master || immutable' }
+      steps {
+        githubCheckNotify('PENDING')
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}")
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        script{
+          currentBuild.displayName = "apm-agent-${params.AGENT_INTEGRATION_TEST} - ${currentBuild.displayName}"
+        }
+      }
+    }
+    /**
+      launch integration tests.
+    */
+    stage("Integration Tests"){
+      when {
+        expression {
+          return (params.AGENT_INTEGRATION_TEST != 'All')
+        }
+      }
+      steps {
+        deleteDir()
+        unstash "source"
+        dir("${BASE_DIR}"){
+          script {
+            def agentName = mapAgentsIDs[params.AGENT_INTEGRATION_TEST]
+            def agentApp = mapAgentsApps[params.AGENT_INTEGRATION_TEST]
+            withEnv(env){
+              sh """#!/bin/bash
+              export TMPDIR="${WORKSPACE}"
+              .ci/scripts/agent.sh ${agentName} ${agentApp}
+              """
+            }
+          }
+        }
+      }
+      post {
+        always {
+          wrappingup()
+        }
+      }
+    }
+    stage("All") {
+      when {
+        expression { return params.AGENT_INTEGRATION_TEST == 'All' }
+      }
+      environment {
+        TMPDIR = "${WORKSPACE}"
+        REUSE_CONTAINERS = "true"
+      }
+      steps {
+        deleteDir()
+        unstash "source"
+        dir("${BASE_DIR}"){
+          sh ".ci/scripts/all.sh"
+        }
+      }
+      post {
+        always {
+          wrappingup()
+        }
+      }
+    }
+    stage("UI") {
+      when {
+        expression { return params.AGENT_INTEGRATION_TEST == 'UI' }
+      }
+      environment {
+        TMPDIR = "${WORKSPACE}/${BASE_DIR}"
+        HOME = "${WORKSPACE}/${BASE_DIR}"
+      }
+      steps {
+        deleteDir()
+        unstash "source"
+        dir("${BASE_DIR}"){
+          script {
+            docker.image('node:11').inside() {
+              sh(label: "Check Schema", script: ".ci/scripts/ui.sh")
+            }
+          }
+        }
+      }
+      post {
+        always {
+          wrappingup()
+        }
+      }
+    }
+  }
+  post {
+    always {
+      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
+      notifyBuildResult()
+    }
+  }
+}
+
+def wrappingup(){
+  dir("${BASE_DIR}"){
+    def stepName = mapAgentsIDs[params.AGENT_INTEGRATION_TEST]
+    sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
+    sh('make stop-env || echo 0')
+    archiveArtifacts(
+        allowEmptyArchive: true,
+        artifacts: 'docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
+        defaultExcludes: false)
+    junit(
+      allowEmptyResults: false,
+      keepLongStdio: true,
+      testResults: "**/tests/results/*-junit*.xml")
+  }
+}
+
+
+/**
+ Notify the GitHub check of the parent stream
+**/
+def githubCheckNotify(String status) {
+  if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
+    githubNotify context: "${params.GITHUB_CHECK_NAME}",
+                 description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",
+                 status: "${status}",
+                 targetUrl: "${env.RUN_DISPLAY_URL}",
+                 sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
+  }
+}

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: apm-integration-tests-selector-mbp
+    display-name: APM Integration Test MBP Selector
+    description: APM Integration Test Selector Multi Branch Pipeline
+    project-type: multibranch
+    number-to-keep: '5'
+    days-to-keep: '1'
+    script-path: .ci/integrationTestSelector.grrovy
+    scm:
+    - github:
+        branch-discovery: all
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        repo: apm-integration-testing
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -23,9 +23,7 @@
         - tags:
             ignore-tags-older-than: -1
             ignore-tags-newer-than: -1
-        - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
+        - regular-branches: false
         clean:
           after: true
           before: true

--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
+
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+. ${srcdir}/common.sh
+
+AGENT=$1
+APP=$2
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --with-agent-${APP} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --force-build"
+export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
+runTests env-agent-${AGENT} docker-test-agent-${AGENT}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    JOB_GIT_CREDENTIALS = '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
     PIPELINE_LOG_LEVEL='INFO'
   }
   triggers {
@@ -27,10 +26,7 @@ pipeline {
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.0.0", description: "Elastic Stack Git branch/tag to use")
-    string(name: 'BUILD_OPTS', defaultValue: "", description: "Additional build options to passing compose.py")
-    string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
-    string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
-    string(name: 'GITHUB_CHECK_SHA1', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')
+    string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }
   stages{
@@ -40,7 +36,6 @@ pipeline {
     stage('Checkout'){
       agent { label 'master || immutable' }
       steps {
-        githubCheckNotify('PENDING')
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
@@ -82,7 +77,6 @@ pipeline {
   }
   post {
     always {
-      githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
       notifyBuildResult()
     }
   }
@@ -100,17 +94,4 @@ def runJob(agentName, buildOpts = ''){
     propagate: true,
     quietPeriod: 10,
     wait: true)
-}
-
-/**
- Notify the GitHub check of the parent stream
-**/
-def githubCheckNotify(String status) {
-  if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
-    githubNotify context: "${params.GITHUB_CHECK_NAME}",
-                 description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",
-                 status: "${status}",
-                 targetUrl: "${env.RUN_DISPLAY_URL}",
-                 sha: params.GITHUB_CHECK_SHA1, account: 'elastic', repo: params.GITHUB_CHECK_REPO, credentialsId: env.JOB_GIT_CREDENTIALS
-  }
 }


### PR DESCRIPTION
Relates to #41 and Closes #482

## Highlights
- Enable a Multibranch Pipeline test selector to be able to orchestrate ITs per agent and being able to pass the `branch` and `repo` to be used.
- Revert #470 as it's managed with this new Pipeline 

## Reason
- The current pipelines either run all the ITs or the agent compatibility matrix. 
- This particular pipeline will allow running a specific ITs per agent which will help to notify the PRs for the apm-* repos with the right status.