### PR TITLE
fix: SRC was not declared in the multistage build but in the parent one

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -22,7 +22,7 @@ RUN make -C ${SRC} update apm-server \
 	  && chmod go+r ${SRC}/apm-server.yml
 
 FROM ${apm_server_base_image}
-
+ENV SRC=/go/src/github.com/elastic/apm-server
 COPY --from=build ${SRC}/apm-server /usr/share/apm-server/apm-server
 COPY --from=build ${SRC}/apm-server.yml /usr/share/apm-server/apm-server.yml
 COPY --from=build ${SRC}/fields.yml /usr/share/apm-server/fields.yml


### PR DESCRIPTION
This is a regression caused when refactoring the SRC location in https://github.com/elastic/apm-integration-testing/pull/471