### PR TITLE
fix(jenkins): withEnv causes ClassCastException in the Pipeline

### DIFF
--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -90,12 +90,10 @@ pipeline {
           script {
             def agentName = mapAgentsIDs[params.AGENT_INTEGRATION_TEST]
             def agentApp = mapAgentsApps[params.AGENT_INTEGRATION_TEST]
-            withEnv(env){
-              sh """#!/bin/bash
-              export TMPDIR="${WORKSPACE}"
-              .ci/scripts/agent.sh ${agentName} ${agentApp}
-              """
-            }
+            sh """#!/bin/bash
+            export TMPDIR="${WORKSPACE}"
+            .ci/scripts/agent.sh ${agentName} ${agentApp}
+            """
           }
         }
       }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -34,7 +34,7 @@ import groovy.transform.Field
 ]
 
 pipeline {
-  agent { label 'linux && immutable && docker' }
+  agent none
   environment {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')
@@ -49,6 +49,7 @@ pipeline {
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   parameters {
     choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')


### PR DESCRIPTION
## Highlights
- withEnv is not required when running the script.
- withEnv causes some issues when using the `@Field` annotations.
- Tuned the pipeline to use the same strategy as: https://github.com/elastic/apm-integration-testing/blob/master/.ci/Jenkinsfile