### PR TITLE
update to latest apm-server build

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
-ARG apm_server_base_image=docker.elastic.co/apm/apm-server:7.0.0-alpha1-SNAPSHOT
-ARG go_version=1.11
+ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
+ARG go_version=1.12
 
 FROM golang:${go_version} AS build
 


### PR DESCRIPTION
master is now 8.0.0 and uses go 1.12.  We probably need a 7.x branch in this repo akin to 6.x and 6.x-v1, or some other approach for the version differences.