### PR TITLE
fix: signal internal Node.js workload script to disable

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1855,6 +1855,7 @@ class OpbeansNode(OpbeansService):
                 "ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES",
                 "WORKLOAD_ELASTIC_APM_APP_NAME=workload",
                 "WORKLOAD_ELASTIC_APM_SERVER_URL={}".format(self.apm_server_url),
+                "WORKLOAD_DISABLED={}".format(self.options.get("no_opbeans_node_loadgen", False)),
                 "OPBEANS_SERVER_PORT=3000",
                 "OPBEANS_SERVER_HOSTNAME=opbeans-node",
                 "NODE_ENV=production",

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -202,6 +202,7 @@ class OpbeansServiceTest(ServiceTest):
                         - ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES
                         - WORKLOAD_ELASTIC_APM_APP_NAME=workload
                         - WORKLOAD_ELASTIC_APM_SERVER_URL=http://apm-server:8200
+                        - WORKLOAD_DISABLED=False
                         - OPBEANS_SERVER_PORT=3000
                         - OPBEANS_SERVER_HOSTNAME=opbeans-node
                         - NODE_ENV=production
@@ -227,6 +228,11 @@ class OpbeansServiceTest(ServiceTest):
                     volumes:
                         - ./docker/opbeans/node/sourcemaps:/sourcemaps""")  # noqa: 501
         )
+
+    def test_opbeans_node_without_loadgen(self):
+        opbeans_node = OpbeansNode(no_opbeans_node_loadgen=True).render()["opbeans-node"]
+        value = [e for e in opbeans_node["environment"] if e.startswith("WORKLOAD_DISABLED")]
+        self.assertEqual(value, ["WORKLOAD_DISABLED=True"])
 
     def test_opbeans_python(self):
         opbeans_python = OpbeansPython(version="6.2.4").render()


### PR DESCRIPTION
Currently `--no-opbeans-node-loadgen` doesn't have any effect on opbeans-node as it's not using the regular loadgen container.

The idea of the PR is to repurpose this config option and instead use it to set an environment variable which the internal loadgen script can see and know if it should run or not.