### PR TITLE
Improve output of Opbeans Node.js entrypoint script

### DIFF
--- a/docker/opbeans/node/entrypoint.sh
+++ b/docker/opbeans/node/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+
+set -x
+
 if [[ -f /local-install/package.json ]]; then
     echo "Installing from local folder"
     # copy to folder inside container to ensure were not poluting the local folder


### PR DESCRIPTION
When installing from the local folder, it currently seems like nothing is happening because there isn't much output. This improves the experience for when you tail the logs so you can actually see which commands are being run.