### PR TITLE
Update path for APM plugin in repo

### DIFF
--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
@@ -5,5 +5,5 @@ echo "Cloning Kibana: $OWNER:$BRANCH"
 
 cd ./tmp
 git clone --depth 1 -b $BRANCH https://github.com/$OWNER/kibana.git
-mv ./kibana/x-pack/plugins/apm/typings/es_schemas ./apm-ui-interfaces
+mv ./kibana/x-pack/legacy/plugins/apm/typings/es_schemas ./apm-ui-interfaces
 rm -rf kibana


### PR DESCRIPTION
The current x-pack plugins, including APM, got moved into a new folder (see https://github.com/elastic/kibana/pull/39204). This breaks the `validate-ts-interfaces-against-apm-server-sample-docs` script.

This change updates the `clone-kibana` script with the new path.