### PR TITLE
ci(jenkins): enable unit tests for the integration tests app

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
         always {
           junit(allowEmptyResults: true,
             keepLongStdio: true,
-            testResults: "${BASE_DIR}/**/junit-*.xml")
+            testResults: "${BASE_DIR}/**/*junit.xml")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,6 +41,29 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
+
+    /**
+      Validate UTs and lint the app
+    */
+    stage('Unit Tests'){
+      agent { label 'linux && immutable && docker' }
+      steps {
+        withGithubNotify(context: 'Unit Tests', tab: 'tests') {
+          deleteDir()
+          unstash 'source'
+          dir("${BASE_DIR}"){
+            sh "make test-compose lint"
+          }
+        }
+      }
+      post {
+        always {
+          junit(allowEmptyResults: true,
+            keepLongStdio: true,
+            testResults: "${BASE_DIR}/**/junit-*.xml")
+        }
+      }
+    }
     /**
       launch integration tests.
     */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,28 @@ pipeline {
       }
     }
     /**
+      Validate UTs and lint the app
+    */
+    stage('Unit Tests'){
+      agent { label 'linux && immutable && docker' }
+      steps {
+        withGithubNotify(context: 'Unit Tests', tab: 'tests') {
+          deleteDir()
+          unstash 'source'
+          dir("${BASE_DIR}"){
+            sh "make test-compose lint"
+          }
+        }
+      }
+      post {
+        always {
+          junit(allowEmptyResults: true,
+            keepLongStdio: true,
+            testResults: "${BASE_DIR}/**/junit-*.xml")
+        }
+      }
+    }
+    /**
       launch integration tests.
     */
     stage("Integration Tests") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
         always {
           junit(allowEmptyResults: true,
             keepLongStdio: true,
-            testResults: "${BASE_DIR}/**/junit-*.xml")
+            testResults: "${BASE_DIR}/**/*junit.xml")
         }
       }
     }


### PR DESCRIPTION
## Highlights
- Add a new stage in the pipeline to validate the UTs.
- Therefore it will fail fast if the UTs/Lints are broken rather than waiting for the ITs to fail.