### PR TITLE
Remove asserts for stacktrace_frame optional properties

### DIFF
--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -281,9 +281,7 @@ class Concurrent:
                         "number of frames not expected, got {}, but this assertion might be too strict".format(
                             len(stacktrace))
 
-                    fns = [frame['function'] for frame in stacktrace]
-                    assert all(fns), fns
-                    for attr in ['abs_path', 'line', 'filename']:
+                    for attr in ['filename']:
                         assert all(
                             frame.get(attr) for frame in stacktrace), stacktrace[0].keys()
 


### PR DESCRIPTION
Remove asserts expecting `function`, `abs_path` and `line` properties in `stacktrace_frame` because according to https://github.com/elastic/apm-server/blob/master/docs/spec/stacktrace_frame.json `filename` is the only required `stacktrace_frame` property.