### PR TITLE
feat: support apm ruby agent with either branches or sha1s

### DIFF
--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -3,7 +3,22 @@ FROM ruby:latest
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
     build-essential \
-    nodejs 
+    nodejs
+
+## Whether the reference is a branch or a git commit to be used within the Gemfile
+ARG RUBY_AGENT_REPO=elastic/apm-agent-ruby
+ARG RUBY_AGENT_VERSION=master
+ENV RUBY_AGENT_REPO=$RUBY_AGENT_REPO
+ENV RUBY_AGENT_VERSION=$RUBY_AGENT_VERSION
+
+RUN git clone https://github.com/${RUBY_AGENT_REPO}.git /agent/apm-agent-ruby
+RUN cd /agent/apm-agent-ruby \
+  && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+  && git checkout ${RUBY_AGENT_VERSION}
+
+RUN cd /agent/apm-agent-ruby \
+    && ( git show-ref --verify refs/heads/${RUBY_AGENT_VERSION} \
+          && echo 'export RUBY_AGENT_TYPE=branch' >> /tmp/branch || true )
 
 RUN mkdir -p /app
 

--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /agent/apm-agent-ruby \
 
 RUN cd /agent/apm-agent-ruby \
     && ( git show-ref --verify refs/heads/${RUBY_AGENT_VERSION} \
-          && echo 'export RUBY_AGENT_TYPE=branch' >> /tmp/branch || true )
+          && touch /tmp/branch || true )
 
 RUN mkdir -p /app
 

--- a/docker/ruby/rails/testapp/Gemfile
+++ b/docker/ruby/rails/testapp/Gemfile
@@ -28,5 +28,9 @@ if ENV['RUBY_AGENT_VERSION_STATE']=='release'
     gem 'elastic-apm', "~> #{ENV['RUBY_AGENT_VERSION']}"
   end
 else
-  gem 'elastic-apm', git: "https://github.com/#{ENV['RUBY_AGENT_REPO']}.git", branch: ENV['RUBY_AGENT_VERSION']
+  if File.exist?('/tmp/branch')
+    gem 'elastic-apm', git: "https://github.com/#{ENV['RUBY_AGENT_REPO']}.git", branch: ENV['RUBY_AGENT_VERSION']
+  else
+    gem 'elastic-apm', git: "https://github.com/#{ENV['RUBY_AGENT_REPO']}.git", ref: ENV['RUBY_AGENT_VERSION']
+  end
 end


### PR DESCRIPTION
## Highlights
- This is required to customize whether to use either a branch or a commit for the specific apm-agent-ruby.
- Unfortunately, it's required to checkout the code to know whether the given variable, `RUBY_AGENT_VERSION` it's either a branch or a commit.
- Env variables have to be set with the build arguments to be able to run the container `locally`. At the moment this is managed by the docker compose script.