### PR TITLE
fix: test_opbeans_loadgen failed as the dict is not ordered

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -9,6 +9,7 @@ from abc import abstractmethod
 import argparse
 import codecs
 import collections
+from collections import OrderedDict
 import datetime
 import functools
 import glob
@@ -2059,7 +2060,7 @@ class OpbeansLoadGenerator(Service):
     def __init__(self, **options):
         super(OpbeansLoadGenerator, self).__init__(**options)
         self.loadgen_services = []
-        self.loadgen_rpms = {}
+        self.loadgen_rpms = OrderedDict()
         # create load for opbeans services
         run_all_opbeans = options.get('run_all_opbeans')
         excluded = ('opbeans_load_generator', 'opbeans_rum', 'opbeans_node')


### PR DESCRIPTION
# Highlights
- This is the fix to avoid discrepancies when running the UTs as the dict is not ordered by definition.

# Fixes

```
def test_opbeans_loadgen(self):
...
E         -                                             'OPBEANS_RPMS=opbeans-ruby:10,opbeans-python:50'],

E         ?                                                                   ^^^  ^          ^ ---- ^

E         +                                             'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:10'],

E         ?                                                                   ^ ++++ ^          ^^^  ^

```

The above error can be found [here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-tests-mbp%2FPR-493/detail/PR-493/6/tests/)