### PR TITLE
feat: enable build args for the ruby agent

### DIFF
--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -11,14 +11,9 @@ ARG RUBY_AGENT_VERSION=master
 ENV RUBY_AGENT_REPO=$RUBY_AGENT_REPO
 ENV RUBY_AGENT_VERSION=$RUBY_AGENT_VERSION
 
-RUN git clone https://github.com/${RUBY_AGENT_REPO}.git /agent/apm-agent-ruby
-RUN cd /agent/apm-agent-ruby \
-  && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
-  && git checkout ${RUBY_AGENT_VERSION}
-
-RUN cd /agent/apm-agent-ruby \
-    && ( git show-ref --verify refs/heads/${RUBY_AGENT_VERSION} \
-          && touch /tmp/branch || true )
+WORKDIR /src
+COPY . /src
+RUN ./run.sh
 
 RUN mkdir -p /app
 

--- a/docker/ruby/rails/run.sh
+++ b/docker/ruby/rails/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -x
+
+# Latest is not a branch but the latest released version, so it's not required to
+if [ "${RUBY_AGENT_VERSION}" = "latest" ] ; then
+  echo "Let's use the latest release."
+else
+  echo "Let's checkout from the source code and see whether the version is a branch or a sha1."
+  git clone https://github.com/${RUBY_AGENT_REPO}.git /agent/apm-agent-ruby
+  cd /agent/apm-agent-ruby
+  git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+  git checkout ${RUBY_AGENT_VERSION}
+  git show-ref --verify refs/heads/${RUBY_AGENT_VERSION} && touch /tmp/branch || true
+fi

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1456,7 +1456,14 @@ class AgentRubyRails(Service):
     ])
     def _content(self):
         return dict(
-            build={"context": "docker/ruby/rails", "dockerfile": "Dockerfile"},
+            build={
+                "context": "docker/ruby/rails",
+                "dockerfile": "Dockerfile",
+                "args": {
+                    "RUBY_AGENT_VERSION": self.agent_version,
+                    "RUBY_AGENT_REPO": self.agent_repo,
+                }
+            },
             command="bash -c \"bundle install && RAILS_ENV=production bundle exec rails s -b 0.0.0.0 -p {}\"".format(
                 self.SERVICE_PORT),
             container_name="railsapp",

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -156,6 +156,9 @@ class AgentServiceTest(ServiceTest):
             agent, yaml.load("""
                 agent-ruby-rails:
                     build:
+                        args:
+                            RUBY_AGENT_VERSION: latest
+                            RUBY_AGENT_REPO: elastic/apm-agent-ruby
                         dockerfile: Dockerfile
                         context: docker/ruby/rails
                     container_name: railsapp


### PR DESCRIPTION
https://github.com/elastic/apm-integration-testing/pull/497 enabled to pass the build arguments, but the compose.py didn't have those flags enabled when building the docker image for the apm-agent-ruby.

## Highlights
- Enable build arguments to be passed to the docker compose
- Move Dockerfile logic to a script to be able to distinguish whether the version is latest then nothing else is required or something else which will require to identify whether it's a sha or a branch.


## Notes

Why didn't I see this behavior previously? Because I ran the docker build locally rather than triggering the `scripts/compose.py` script :(
