### PR TITLE
fix: dict is now ordered by key

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -52,7 +52,10 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh 'make docker-test-all'
+            sh """
+              python script/compose.py start ${params.ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana
+              TARGET="test-compose lint test-helps" make dockerized-test
+            """
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh "make test-compose lint"
+            sh 'make docker-test-all'
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -52,10 +52,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh """
-              python script/compose.py start ${params.ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana
-              TARGET="test-compose lint test-helps" make dockerized-test
-            """
+            sh '.ci/scripts/unit-tests.sh'
           }
         }
       }

--- a/.ci/scripts/unit-tests.sh
+++ b/.ci/scripts/unit-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+# for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
+
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+. ${srcdir}/common.sh
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana"
+export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
+runTests test-compose lint test-helps

--- a/.ci/scripts/unit-tests.sh
+++ b/.ci/scripts/unit-tests.sh
@@ -7,4 +7,4 @@ test -z "$srcdir" && srcdir=.
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
-runTests test-compose lint test-helps
+runTests env-server test-compose lint test-helps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,10 +51,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh """
-              python script/compose.py start ${params.ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana
-              TARGET="test-compose lint test-helps" make dockerized-test
-            """
+            sh '.ci/scripts/unit-tests.sh'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh "make test-compose lint"
+            sh 'make docker-test-all'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,10 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh 'make docker-test-all'
+            sh """
+              python script/compose.py start ${params.ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana
+              TARGET="test-compose lint test-helps" make dockerized-test
+            """
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ as it is itself generating load using a headless chrome instance.
 You can start Opbeans with an agent which is built from source from a specific branch or PR.
 This is currently only supported with the go and the Java agent.
 
-Example which builds the https://github.com/elastic/apm-agent-java/pull/588 branch from source and uses an APM server built from master: 
+Example which builds the https://github.com/elastic/apm-agent-java/pull/588 branch from source and uses an APM server built from master:
 
     ./scripts/compose.py start master --with-opbeans-java --opbeans-java-agent-branch=pr/588/head --apm-server-build https://github.com/elastic/apm-server.git@master
 
@@ -195,6 +195,7 @@ These are the scripts available to execute:
 * `python.sh:` runs Python agent tests, you can choose the versions to run see the [environment variables](environment-variables) configuration.
 * `ruby.sh:` runs Ruby agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `server.sh:` runs APM Server tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
+* `unit-tests.sh:` runs the unit tests for the apm-integration-testing app and validate the linting, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 
 #### Environment Variables
 

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -2083,13 +2083,12 @@ class OpbeansLoadGenerator(Service):
                         self.loadgen_rpms[service_name.replace('_', '-')] = rpm
 
     def _content(self):
-        keys_order_loadgen_rpms = OrderedDict(sorted(self.loadgen_rpms.items()))
         content = dict(
             image="opbeans/opbeans-loadgen:latest",
             depends_on={service: {'condition': 'service_healthy'} for service in self.loadgen_services},
             environment=[
                 "OPBEANS_URLS={}".format(','.join('{0}:http://{0}:3000'.format(s) for s in self.loadgen_services)),
-                "OPBEANS_RPMS={}".format(','.join('{}:{}'.format(k, v) for k, v in keys_order_loadgen_rpms.items()))
+                "OPBEANS_RPMS={}".format(','.join('{}:{}'.format(k, v) for k, v in sorted(self.loadgen_rpms.items())))
             ],
             labels=None,
         )

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -2083,12 +2083,13 @@ class OpbeansLoadGenerator(Service):
                         self.loadgen_rpms[service_name.replace('_', '-')] = rpm
 
     def _content(self):
+        keys_order_loadgen_rpms = OrderedDict(sorted(self.loadgen_rpms.items()))
         content = dict(
             image="opbeans/opbeans-loadgen:latest",
             depends_on={service: {'condition': 'service_healthy'} for service in self.loadgen_services},
             environment=[
                 "OPBEANS_URLS={}".format(','.join('{0}:http://{0}:3000'.format(s) for s in self.loadgen_services)),
-                "OPBEANS_RPMS={}".format(','.join('{}:{}'.format(k, v) for k, v in self.loadgen_rpms.items()))
+                "OPBEANS_RPMS={}".format(','.join('{}:{}'.format(k, v) for k, v in keys_order_loadgen_rpms.items()))
             ],
             labels=None,
         )

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -402,7 +402,7 @@ class OpbeansServiceTest(ServiceTest):
             enable_opbeans_node=True,
             no_opbeans_node_loadgen=True,
             opbeans_python_loadgen_rpm=50,
-            opbeans_ruby_loadgen_rpm=10,
+            opbeans_ruby_loadgen_rpm=100,
         ).render()
         assert opbeans_load_gen == yaml.load("""
             opbeans-load-generator:
@@ -413,7 +413,7 @@ class OpbeansServiceTest(ServiceTest):
                     opbeans-ruby: {condition: service_healthy}
                 environment:
                  - 'OPBEANS_URLS=opbeans-python:http://opbeans-python:3000,opbeans-ruby:http://opbeans-ruby:3000'
-                 - 'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:10'
+                 - 'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:100'
                 logging:
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}""")

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -405,18 +405,19 @@ class OpbeansServiceTest(ServiceTest):
             opbeans_ruby_loadgen_rpm=10,
         ).render()["opbeans-load-generator"]
 
-        assert "opbeans/opbeans-loadgen:latest" == opbeans_load_gen["image"]
-        assert "localtesting_6.3.1_opbeans-load-generator" == opbeans_load_gen["container_name"]
-        assert "json-file" == opbeans_load_gen["logging"]["driver"]
-        assert {"opbeans-python", "opbeans-ruby"} == set(opbeans_load_gen["depends_on"].keys())
+        self.assertEqual("opbeans/opbeans-loadgen:latest", opbeans_load_gen["image"])
+        self.assertEqual("localtesting_6.3.1_opbeans-load-generator", opbeans_load_gen["container_name"])
 
         value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_URLS")]
         listOfValues = value[0].replace("OPBEANS_URLS=", "").split(",")
-        assert {"opbeans-python:http://opbeans-python:3000", "opbeans-ruby:http://opbeans-ruby:3000"} == set(listOfValues)
+        self.assertSetEqual({"opbeans-python:http://opbeans-python:3000", "opbeans-ruby:http://opbeans-ruby:3000"}, set(listOfValues))
 
         value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_RPMS")]
         listOfValues = value[0].replace("OPBEANS_RPMS=", "").split(",")
-        assert {"opbeans-python:50", "opbeans-ruby:10"} == set(listOfValues)
+        self.assertSetEqual({"opbeans-python:50", "opbeans-ruby:10"}, set(listOfValues))
+
+        self.assertSetEqual({"opbeans-python", "opbeans-ruby"}, set(opbeans_load_gen["depends_on"].keys()))
+        self.assertEqual("json-file", opbeans_load_gen["logging"]["driver"])
 
 class PostgresServiceTest(ServiceTest):
     def test_postgres(self):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -403,21 +403,21 @@ class OpbeansServiceTest(ServiceTest):
             no_opbeans_node_loadgen=True,
             opbeans_python_loadgen_rpm=50,
             opbeans_ruby_loadgen_rpm=10,
-        ).render()
-        assert opbeans_load_gen == yaml.load("""
-            opbeans-load-generator:
-                image: opbeans/opbeans-loadgen:latest
-                container_name: localtesting_6.3.1_opbeans-load-generator
-                depends_on:
-                    opbeans-python: {condition: service_healthy}
-                    opbeans-ruby: {condition: service_healthy}
-                environment:
-                 - 'OPBEANS_URLS=opbeans-python:http://opbeans-python:3000,opbeans-ruby:http://opbeans-ruby:3000'
-                 - 'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:10'
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}""")
+        ).render()["opbeans-load-generator"]
 
+        self.assertEqual("opbeans/opbeans-loadgen:latest", opbeans_load_gen["image"])
+        self.assertEqual("localtesting_6.3.1_opbeans-load-generator", opbeans_load_gen["container_name"])
+
+        value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_URLS")]
+        listOfValues = value[0].replace("OPBEANS_URLS=", "").split(",")
+        self.assertSetEqual({"opbeans-python:http://opbeans-python:3000", "opbeans-ruby:http://opbeans-ruby:3000"}, set(listOfValues))
+
+        value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_RPMS")]
+        listOfValues = value[0].replace("OPBEANS_RPMS=", "").split(",")
+        self.assertSetEqual({"opbeans-python:50", "opbeans-ruby:10"}, set(listOfValues))
+
+        self.assertSetEqual({"opbeans-python", "opbeans-ruby"}, set(opbeans_load_gen["depends_on"].keys()))
+        self.assertEqual("json-file", opbeans_load_gen["logging"]["driver"])
 
 class PostgresServiceTest(ServiceTest):
     def test_postgres(self):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -405,19 +405,18 @@ class OpbeansServiceTest(ServiceTest):
             opbeans_ruby_loadgen_rpm=10,
         ).render()["opbeans-load-generator"]
 
-        self.assertEqual("opbeans/opbeans-loadgen:latest", opbeans_load_gen["image"])
-        self.assertEqual("localtesting_6.3.1_opbeans-load-generator", opbeans_load_gen["container_name"])
+        assert "opbeans/opbeans-loadgen:latest" == opbeans_load_gen["image"]
+        assert "localtesting_6.3.1_opbeans-load-generator" == opbeans_load_gen["container_name"]
+        assert "json-file" == opbeans_load_gen["logging"]["driver"]
+        assert {"opbeans-python", "opbeans-ruby"} == set(opbeans_load_gen["depends_on"].keys())
 
         value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_URLS")]
         listOfValues = value[0].replace("OPBEANS_URLS=", "").split(",")
-        self.assertSetEqual({"opbeans-python:http://opbeans-python:3000", "opbeans-ruby:http://opbeans-ruby:3000"}, set(listOfValues))
+        assert {"opbeans-python:http://opbeans-python:3000", "opbeans-ruby:http://opbeans-ruby:3000"} == set(listOfValues)
 
         value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_RPMS")]
         listOfValues = value[0].replace("OPBEANS_RPMS=", "").split(",")
-        self.assertSetEqual({"opbeans-python:50", "opbeans-ruby:10"}, set(listOfValues))
-
-        self.assertSetEqual({"opbeans-python", "opbeans-ruby"}, set(opbeans_load_gen["depends_on"].keys()))
-        self.assertEqual("json-file", opbeans_load_gen["logging"]["driver"])
+        assert {"opbeans-python:50", "opbeans-ruby:10"} == set(listOfValues)
 
 class PostgresServiceTest(ServiceTest):
     def test_postgres(self):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -403,21 +403,21 @@ class OpbeansServiceTest(ServiceTest):
             no_opbeans_node_loadgen=True,
             opbeans_python_loadgen_rpm=50,
             opbeans_ruby_loadgen_rpm=10,
-        ).render()["opbeans-load-generator"]
+        ).render()
+        assert opbeans_load_gen == yaml.load("""
+            opbeans-load-generator:
+                image: opbeans/opbeans-loadgen:latest
+                container_name: localtesting_6.3.1_opbeans-load-generator
+                depends_on:
+                    opbeans-python: {condition: service_healthy}
+                    opbeans-ruby: {condition: service_healthy}
+                environment:
+                 - 'OPBEANS_URLS=opbeans-python:http://opbeans-python:3000,opbeans-ruby:http://opbeans-ruby:3000'
+                 - 'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:10'
+                logging:
+                    driver: json-file
+                    options: {max-file: '5', max-size: 2m}""")
 
-        self.assertEqual("opbeans/opbeans-loadgen:latest", opbeans_load_gen["image"])
-        self.assertEqual("localtesting_6.3.1_opbeans-load-generator", opbeans_load_gen["container_name"])
-
-        value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_URLS")]
-        listOfValues = value[0].replace("OPBEANS_URLS=", "").split(",")
-        self.assertSetEqual({"opbeans-python:http://opbeans-python:3000", "opbeans-ruby:http://opbeans-ruby:3000"}, set(listOfValues))
-
-        value = [e for e in opbeans_load_gen["environment"] if e.startswith("OPBEANS_RPMS")]
-        listOfValues = value[0].replace("OPBEANS_RPMS=", "").split(",")
-        self.assertSetEqual({"opbeans-python:50", "opbeans-ruby:10"}, set(listOfValues))
-
-        self.assertSetEqual({"opbeans-python", "opbeans-ruby"}, set(opbeans_load_gen["depends_on"].keys()))
-        self.assertEqual("json-file", opbeans_load_gen["logging"]["driver"])
 
 class PostgresServiceTest(ServiceTest):
     def test_postgres(self):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -402,7 +402,7 @@ class OpbeansServiceTest(ServiceTest):
             enable_opbeans_node=True,
             no_opbeans_node_loadgen=True,
             opbeans_python_loadgen_rpm=50,
-            opbeans_ruby_loadgen_rpm=100,
+            opbeans_ruby_loadgen_rpm=10,
         ).render()
         assert opbeans_load_gen == yaml.load("""
             opbeans-load-generator:
@@ -413,7 +413,7 @@ class OpbeansServiceTest(ServiceTest):
                     opbeans-ruby: {condition: service_healthy}
                 environment:
                  - 'OPBEANS_URLS=opbeans-python:http://opbeans-python:3000,opbeans-ruby:http://opbeans-ruby:3000'
-                 - 'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:100'
+                 - 'OPBEANS_RPMS=opbeans-python:50,opbeans-ruby:10'
                 logging:
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}""")


### PR DESCRIPTION
Some UTs are failing from time to time even though the dict was sorted:
- https://github.com/elastic/apm-integration-testing/pull/498

After a few iterations, I managed to find that the python in use was the one from the host rather than using the docker container which it's created when running the make goal `dockerized-test`. Therefore the problem was an environmental issue.

## Highlights
- Enable UTs using a script to encapsulate how to run it within the CI.
- Ensure the dict is ordered 