### PR TITLE
ci(jenkins): create upgrade tests pipeline using JJBB

### DIFF
--- a/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
@@ -1,0 +1,39 @@
+---
+- job:
+    name: apm-integration-tests-upgrade-mbp
+    display-name: APM Integration Test Upgrade MBP
+    description: APM Integration Test Upgrade Multi Branch Pipeline
+    project-type: multibranch
+    script-path: .ci/integrationTestUpgrade.groovy
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
+        repo: apm-integration-testing
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true


### PR DESCRIPTION
This is caused by https://github.com/elastic/apm-integration-testing/pull/518

It will create the pipeline using the JJBB.  Therefore only those branches with the file `.ci/integrationTestUpgrade.groovy` will have a pipeline.