### PR TITLE
feat: dotnet agent uses Elastic.Apm.NetCoreAll and enable --opbeans-dotnet-version

### DIFF
--- a/docker/dotnet/aspnetcore/Startup.cs
+++ b/docker/dotnet/aspnetcore/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Elastic.Apm;
-using Elastic.Apm.All;
+using Elastic.Apm.NetCoreAll;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -17,10 +17,10 @@ namespace TestAspNetCoreApp
 
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
-			// /healthcheck is mapped before app.UseElasticApm -> as specified in the spec, it won't be traced.
+			// /healthcheck is mapped before app.UseAllElasticApm -> as specified in the spec, it won't be traced.
 			app.Map("/healthcheck", HealthCheck);
 
-			app.UseElasticApm(_configuration);
+			app.UseAllElasticApm(_configuration);
 
 			app.Map("/bar", Bar);
 			app.Map("/foo", Foo);

--- a/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
+++ b/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Apm.All" Version="0.0.2-alpha" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0-beta1" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     </ItemGroup>

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -2,6 +2,10 @@
 set -x
 
 CSPROJ="TestAspNetCoreApp.csproj"
+
+PACKAGE=Elastic.Apm.NetCoreAll
+CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
 
   git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent
@@ -18,8 +22,9 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   cd /src/aspnetcore
   mv /src/NuGet.Config .
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
-  dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}
+
+  DOTNET_AGENT_VERSION=$(cat ${CSPROJ_VERSION} | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+  dotnet add package ${PACKAGE} -v ${DOTNET_AGENT_VERSION}
 else
   ### Otherwise: The default NuGet.Config will fail as it's required
   mkdir /src/local-packages
@@ -27,6 +32,6 @@ fi
 
 cd /src/aspnetcore
 # This is the way to manipulate the csproj with the version of the dotnet agent to be used
-sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.All\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" ${CSPROJ}
+sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.NetCoreAll\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" ${CSPROJ}
 dotnet restore
 dotnet publish -c Release -o build

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -3,6 +3,9 @@ set -x
 git clone https://github.com/${OPBEANS_DOTNET_REPO}.git /src/opbeans-dotnet -b ${OPBEANS_DOTNET_BRANCH}
 CSPROJ="opbeans-dotnet.csproj"
 
+PACKAGE=Elastic.Apm.NetCoreAll
+CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent -b ${DOTNET_AGENT_BRANCH}
   cd /src/dotnet-agent
@@ -14,8 +17,8 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   cd /src/opbeans-dotnet/opbeans-dotnet
   mv /src/NuGet.Config .
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
-  dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}
+  DOTNET_AGENT_VERSION=$(cat ${CSPROJ_VERSION} | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+  dotnet add package ${PACKAGE} -v ${DOTNET_AGENT_VERSION}
 else
   ### Otherwise: The default NuGet.Config will fail as it's required
   mkdir /src/local-packages
@@ -23,6 +26,6 @@ fi
 
 cd /src/opbeans-dotnet/opbeans-dotnet
 # This is the way to manipulate the csproj with the version of the dotnet agent to be used
-sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.All\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" ${CSPROJ}
+sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.NetCoreAll\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" ${CSPROJ}
 dotnet restore
 dotnet publish -c Release -o build

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1689,6 +1689,18 @@ class OpbeansDotnet(OpbeansService):
     DEFAULT_SERVICE_NAME = "opbeans-dotnet"
     DEFAULT_AGENT_VERSION = ""
 
+    @classmethod
+    def add_arguments(cls, parser):
+        super(OpbeansDotnet, cls).add_arguments(parser)
+        parser.add_argument(
+            '--opbeans-dotnet-version',
+            default=cls.DEFAULT_AGENT_VERSION,
+        )
+
+    def __init__(self, **options):
+        super(OpbeansDotnet, self).__init__(**options)
+        self.agent_version = options.get('opbeans_dotnet_version')
+
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN")
     ])
@@ -1706,7 +1718,7 @@ class OpbeansDotnet(OpbeansService):
                 args=[
                     "DOTNET_AGENT_BRANCH=" + (self.agent_branch or self.DEFAULT_AGENT_BRANCH),
                     "DOTNET_AGENT_REPO=" + (self.agent_repo or self.DEFAULT_AGENT_REPO),
-                    "DOTNET_AGENT_VERSION=" + (self.agent_repo or self.DEFAULT_AGENT_VERSION),
+                    "DOTNET_AGENT_VERSION=" + (self.agent_version or self.DEFAULT_AGENT_VERSION),
                 ]
             ),
             environment=[

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -83,6 +83,11 @@ class OpbeansServiceTest(ServiceTest):
                         retries: 36""")
         )
 
+    def test_opbeans_dotnet_version(self):
+        opbeans_node = OpbeansDotnet(opbeans_dotnet_version="1.0").render()["opbeans-dotnet"]
+        value = [e for e in opbeans_node["build"]["args"] if e.startswith("DOTNET_AGENT_VERSION")]
+        self.assertEqual(value, ["DOTNET_AGENT_VERSION=1.0"])
+
     def test_opbeans_go(self):
         opbeans_go = OpbeansGo(version="6.3.10").render()
         self.assertEqual(


### PR DESCRIPTION
This is caused by https://github.com/elastic/apm-agent-dotnet/pull/371

Depends on https://github.com/elastic/opbeans-dotnet/pull/11

## Highlight
- The csproj has been changed in the above PR, let's change in the opbeans and dotnet images to be able to parse the version with some backward compatibility.
- enable `--opbeans-dotnet-version` flag as it was not implemented though.

## How to test the opbeans locally?
- Check out this PR
- Edit `docker/opbeans/dotnet/Dockerfile`
- Change the below env variables
```
ENV OPBEANS_DOTNET_REPO=v1v/opbeans-dotnet
ENV OPBEANS_DOTNET_BRANCH=feature/rename
```
- Run the below docker commands
```
docker build --build-arg DOTNET_AGENT_REPO=gregkalapos/apm-agent-dotnet --build-arg DOTNET_AGENT_BRANCH=renaming --tag opbeans-dotnet-test docker/opbeans/dotnet/
docker run --rm -ti -p 28080:80 opbeans-dotnet-test
```
- Open http://localhost:28080

## How to test the dotnet app locally?
- Check out this PR
- Run the below docker commands
```
docker build --build-arg DOTNET_AGENT_REPO=gregkalapos/apm-agent-dotnet --build-arg DOTNET_AGENT_BRANCH=renaming --tag dotnet-test docker/dotnet
docker run --rm -ti -p 28100:8100 dotnet-test:latest
```
- Open http://localhost:28100

## How to run the ITs locally?
- Check out this PR
- Edit `docker/opbeans/dotnet/Dockerfile`
- Change the below env variables
```
ENV OPBEANS_DOTNET_REPO=v1v/opbeans-dotnet
ENV OPBEANS_DOTNET_BRANCH=feature/rename
```
- Run the below commands
```
./scripts/compose.py start master --with-opbeans-dotnet --with-agent-dotnet \
    --opbeans-dotnet-agent-branch renaming \
    --opbeans-dotnet-agent-repo gregkalapos/apm-agent-dotnet  \
    --dotnet-agent-repo gregkalapos/apm-agent-dotnet \
    --dotnet-agent-version renaming
 make docker-test-agent-dotnet
```
```
tests/agent/test_dotnet.py::test_concurrent_req_dotnet_foobar PASSED     [ 25%]
tests/agent/test_dotnet.py::test_dotnet_error PASSED                     [ 50%]
tests/agent/test_dotnet.py::test_req_dotnet PASSED                       [ 75%]
tests/agent/test_dotnet.py::test_concurrent_req_dotnet PASSED            [100%]
```
