### PR TITLE
fix: rum-js docker image cannot be built

### DIFF
--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /rumjs-integration-test
 
 RUN npm install
 
-RUN npx lerna run build && npx lerna run build:e2e
+RUN npx lerna run --scope=@elastic/apm-rum build && npx lerna run build:e2e
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \


### PR DESCRIPTION
fixes https://github.com/elastic/apm-integration-testing/issues/525

## Highlights
- Since https://github.com/elastic/apm-agent-rum-js/pull/265 was merged the app in the ITs started to fail.
- @jahtalab suggested adding the flag `lerna run --scope=@elastic/apm-rum build`

## How to test it out?
- Check out this PR
- Run the infra
```
python scripts/compose.py start 8.0.0 \
   --apm-server-build https://github.com/elastic/apm-server.git@master \
   --rum-agent-branch='master' \
   --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --no-kibana \
   --with-agent-rumjs \
   --force-build
```
- Run the tests
```
make docker-test-agent-rum
```

## Test output
```
tests/agent/test_rum.py::test_rum PASSED                                 [100%]

---------- generated xml file: /app/tests/results/agent-rum-junit.xml ----------
=========================== 1 passed in 4.14 seconds ===========================
```