### PR TITLE
docker/opbeans/go: CGO_ENABLED=0

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -4,6 +4,7 @@
 # repo and branch (or commit) to use.
 FROM golang:latest
 ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 WORKDIR /src/opbeans-go
 RUN git clone https://github.com/elastic/opbeans-go.git .
 RUN rm -fr vendor/go.elastic.co/apm


### PR DESCRIPTION
Fix opbeans-go by disabling cgo.

There appears to be an incompatibility between
the glibc used by gcr.io/distroless/base and
golang:latest. We don't need cgo in integration
testing, since we use PostgreSQL and not SQLite.