### PR TITLE
ci: enable pre-commit stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -42,25 +42,49 @@ pipeline {
       }
     }
 
-    /**
-      Validate UTs and lint the app
-    */
-    stage('Unit Tests'){
-      agent { label 'linux && immutable && docker' }
-      steps {
-        withGithubNotify(context: 'Unit Tests', tab: 'tests') {
-          deleteDir()
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            sh '.ci/scripts/unit-tests.sh'
+    stage('Tests'){
+      parallel {
+        /**
+          Validate UTs and lint the app
+        */
+        stage('Unit Tests'){
+          agent { label 'linux && immutable && docker' }
+          steps {
+            withGithubNotify(context: 'Unit Tests', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh '.ci/scripts/unit-tests.sh'
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true,
+                keepLongStdio: true,
+                testResults: "${BASE_DIR}/**/*junit.xml")
+            }
           }
         }
-      }
-      post {
-        always {
-          junit(allowEmptyResults: true,
-            keepLongStdio: true,
-            testResults: "${BASE_DIR}/**/*junit.xml")
+        stage('Check pre-commit') {
+          agent { label 'linux && immutable && docker' }
+          environment {
+            PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
+            HOME = "${env.WORKSPACE}"
+          }
+          steps {
+            withGithubNotify(context: 'Check pre-commit') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh '''
+                  env | sort
+                  curl https://pre-commit.com/install-local.py | python -
+                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                '''
+              }
+            }
+          }
         }
       }
     }

--- a/.ci/scripts/shellcheck
+++ b/.ci/scripts/shellcheck
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable "$@"

--- a/.ci/scripts/validate.sh
+++ b/.ci/scripts/validate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [ -z "${JENKINS_URL}" ] ; then
+  JENKINS_URL=http://0.0.0.0:18080
+else
+  # See https://jenkins.io/doc/book/pipeline/development/#linter
+  JENKINS_CRUMB=$(curl --silent "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)")
+fi
+
+## Validate whether the URL is reachable before running anything else
+curl --silent ${JENKINS_URL}/ > /dev/null
+
+## Iterate for each file without failing fast.
+set +e
+for file in "$@"; do
+  if curl --silent -X POST -H "${JENKINS_CRUMB}" -F "jenkinsfile=<${file}" ${JENKINS_URL}/pipeline-model-converter/validate | grep -i -v successfully ; then
+    echo "ERROR: jenkinslint failed for the file '${file}'"
+    exit_status=1
+  fi
+done
+
+exit $exit_status

--- a/.ci/scripts/yamllint
+++ b/.ci/scripts/yamllint
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+docker run --rm -v "$PWD:/yaml" sdesbure/yamllint yamllint "$@"


### PR DESCRIPTION
## Highlights
- Enable pre-commit stage to validate the [.pre-comit-config.yaml](https://github.com/elastic/apm-integration-testing/blob/master/.pre-commit-config.yaml) rules.
- Run in parallel with the UTs.

