### PR TITLE
feat: Allow run integration tests against any APM Server and Elasticsearch URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,18 @@ COMPOSE_ARGS ?=
 JUNIT_RESULTS_DIR=tests/results
 JUNIT_OPT=--junitxml $(JUNIT_RESULTS_DIR)
 
+APM_SERVER_URL ?= "http://apm-server:8200"
+ES_URL ?= "http://elasticsearch:9200"
+KIBANA_URL ?= http://kibana:5601
+DJANGO_URL ?= "http://djangoapp:8003"
+DOTNET_URL ?= "http://dotnetapp:8100"
+EXPRESS_URL ?= "http://expressapp:8010"
+FLASK_URL ?= "http://flaskapp:8001"
+GO_NETHTTP_URL ?= "http://gonethttpapp:8080"
+JAVA_SPRING_URL ?= "http://javaspring:8090"
+RAILS_URL ?= "http://railsapp:8020"
+RUM_URL ?= "http://rum:8000"
+
 # Make sure we run local versions of everything, particularly commands
 # installed into our virtualenv with pip eg. `docker-compose`.
 export PATH := ./bin:$(VENV)/bin:$(PATH)
@@ -94,17 +106,17 @@ dockerized-test:
 	  --name=apm-integration-testing \
 	  --network=apm-integration-testing \
 	  --security-opt seccomp=unconfined \
-	  -e APM_SERVER_URL=http://apm-server:8200 \
-	  -e ES_URL=http://elasticsearch:9200 \
-	  -e KIBANA_URL=http://kibana:5601 \
-	  -e DJANGO_URL="http://djangoapp:8003" \
-	  -e DOTNET_URL="http://dotnetapp:8100" \
-	  -e EXPRESS_URL="http://expressapp:8010" \
-	  -e FLASK_URL="http://flaskapp:8001" \
-	  -e GO_NETHTTP_URL="http://gonethttpapp:8080" \
-	  -e JAVA_SPRING_URL="http://javaspring:8090" \
-	  -e RAILS_URL="http://railsapp:8020" \
-	  -e RUM_URL="http://rum:8000" \
+	  -e APM_SERVER_URL=$(APM_SERVER_URL) \
+	  -e ES_URL=$(ES_URL) \
+	  -e KIBANA_URL=$(KIBANA_URL) \
+	  -e DJANGO_URL=$(DJANGO_URL) \
+	  -e DOTNET_URL=$(DOTNET_URL) \
+	  -e EXPRESS_URL=$(EXPRESS_URL) \
+	  -e FLASK_URL=$(FLASK_URL) \
+	  -e GO_NETHTTP_URL=$(GO_NETHTTP_URL) \
+	  -e JAVA_SPRING_URL=$(JAVA_SPRING_URL) \
+	  -e RAILS_URL=$(RAILS_URL) \
+	  -e RUM_URL=$(RUM_URL) \
 	  -e PYTHONDONTWRITEBYTECODE=1 \
 	  -v "$(PWD)/$(JUNIT_RESULTS_DIR)":"/app/$(JUNIT_RESULTS_DIR)" \
 	  --rm \

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ from tests.fixtures.agents import rails
 from tests.fixtures.agents import go_nethttp
 from tests.fixtures.agents import java_spring
 from tests.fixtures.agents import rum
-
+from tests.fixtures import default
 
 
 def pytest_addoption(parser):
@@ -38,11 +38,12 @@ def pytest_runtest_logreport(report):
     if report.when == "call" and report.failed:
         name = report.nodeid.split(":", 2)[-1]
         try:
+            es_url = default.from_env("ES_URL")
             subprocess.call(['elasticdump',
-                             '--input=http://elasticsearch:9200/apm-*',
+                             '--input={}/apm-*'.format(es_url),
                              '--output=/app/tests/results/data-{}.json'.format(name)])
             subprocess.call(['elasticdump',
-                             '--input=http://elasticsearch:9200/packetbeat-*',
+                             '--input={}/packetbeat-*'.format(es_url),
                              '--output=/app/tests/results/packetbeat-{}.json'.format(name)])
         except IOError:
             pass

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone ${apm_server_repo} ${SRC} \
 RUN cd ${SRC} && git rev-parse HEAD && echo ${apm_server_branch_or_commit}
 
 RUN make -C ${SRC} update apm-server \
-	  && sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' ${SRC}/apm-server.yml \
+	  && sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["\${ELASTICSEARCH_HOSTS:elasticsearch:9200}"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' ${SRC}/apm-server.yml \
 	  && chmod go+r ${SRC}/apm-server.yml
 
 FROM ${apm_server_base_image}

--- a/docker/filebeat/filebeat.simple.yml
+++ b/docker/filebeat/filebeat.simple.yml
@@ -4,10 +4,10 @@ setup.template.settings:
   index.number_of_replicas: 0
 
 setup.kibana:
-  host: "kibana:5601"
+  host: "${KIBANA_HOST:kibana:5601}"
 
 output.elasticsearch:
-  hosts: ["elasticsearch:9200"]
+  hosts: ["${ELASTICSEARCH_HOSTS:elasticsearch:9200}"]
 
 logging.json: true
 logging.metrics.enabled: false

--- a/docker/filebeat/filebeat.simple.yml
+++ b/docker/filebeat/filebeat.simple.yml
@@ -1,3 +1,4 @@
+---
 setup.template.settings:
   index.number_of_shards: 1
   index.codec: best_compression
@@ -15,7 +16,7 @@ logging.metrics.enabled: false
 filebeat.prospectors:
   - type: log
     paths:
-     - '/var/lib/docker/containers/*/*.log'
+      - '/var/lib/docker/containers/*/*.log'
     json.message_key: log
     json.overwrite_keys: true
     json.keys_under_root: false

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -1,3 +1,4 @@
+---
 setup.template.settings:
   index.number_of_shards: 1
   index.codec: best_compression
@@ -22,125 +23,125 @@ filebeat.autodiscover:
   providers:
     - type: docker
       templates:
-      - condition:
-          contains:
-            docker.container.image: "apm-server"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            fields_under_root: true
-            json.keys_under_root: true
-            json.overwrite_keys: true
-            json.add_error_key: true
-            json.message_key: message
-      - condition:
-          contains:
-            docker.container.image: "filebeat"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            fields_under_root: true
-            json.keys_under_root: true
-            json.overwrite_keys: true
-            json.add_error_key: true
-            json.message_key: message
-      - condition:
-          contains:
-            docker.container.image: "heartbeat"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            fields_under_root: true
-            json.keys_under_root: true
-            json.overwrite_keys: true
-            json.add_error_key: true
-            json.message_key: message
-      - condition:
-          contains:
-            docker.container.image: "kibana"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            fields_under_root: true
-            json.keys_under_root: true
-            json.overwrite_keys: true
-            json.add_error_key: true
-            json.message_key: message
-      - condition:
-          contains:
-            docker.container.image: "metricbeat"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            fields_under_root: true
-            json.keys_under_root: true
-            json.overwrite_keys: true
-            json.add_error_key: true
-            json.message_key: message
-      - condition:
-          contains:
-            docker.container.image: "opbeans-node"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            multiline.pattern: '^ '
-            multiline.negate: false
-            multiline.match: after
-      - condition:
-          contains:
-            docker.container.image: "opbeans-go"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            fields_under_root: true
-            json.keys_under_root: true
-            json.overwrite_keys: true
-            json.add_error_key: true
-            json.message_key: message
-      - condition:
-          contains:
-            docker.container.image: "postgres"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
-            multiline.pattern: '^\t'
-            multiline.negate: false
-            multiline.match: after
-      - condition:
-          and:
-            - not:
-                contains:
-                  docker.container.image: "apm-server"
-            - not:
-                contains:
-                  docker.container.image: "filebeat"
-            - not:
-                contains:
-                  docker.container.image: "heartbeat"
-            - not:
-                contains:
-                  docker.container.image: "kibana"
-            - not:
-                contains:
-                  docker.container.image: "metricbeat"
-            - not:
-                contains:
-                  docker.container.image: "opbeans-node"
-            - not:
-                contains:
-                  docker.container.image: "opbeans-go"
-            - not:
-                contains:
-                  docker.container.image: "postgres"
-        config:
-          - type: docker
-            containers.ids:
-              - "${data.docker.container.id}"
+        - condition:
+            contains:
+              docker.container.image: "apm-server"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              fields_under_root: true
+              json.keys_under_root: true
+              json.overwrite_keys: true
+              json.add_error_key: true
+              json.message_key: message
+        - condition:
+            contains:
+              docker.container.image: "filebeat"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              fields_under_root: true
+              json.keys_under_root: true
+              json.overwrite_keys: true
+              json.add_error_key: true
+              json.message_key: message
+        - condition:
+            contains:
+              docker.container.image: "heartbeat"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              fields_under_root: true
+              json.keys_under_root: true
+              json.overwrite_keys: true
+              json.add_error_key: true
+              json.message_key: message
+        - condition:
+            contains:
+              docker.container.image: "kibana"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              fields_under_root: true
+              json.keys_under_root: true
+              json.overwrite_keys: true
+              json.add_error_key: true
+              json.message_key: message
+        - condition:
+            contains:
+              docker.container.image: "metricbeat"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              fields_under_root: true
+              json.keys_under_root: true
+              json.overwrite_keys: true
+              json.add_error_key: true
+              json.message_key: message
+        - condition:
+            contains:
+              docker.container.image: "opbeans-node"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              multiline.pattern: '^ '
+              multiline.negate: false
+              multiline.match: after
+        - condition:
+            contains:
+              docker.container.image: "opbeans-go"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              fields_under_root: true
+              json.keys_under_root: true
+              json.overwrite_keys: true
+              json.add_error_key: true
+              json.message_key: message
+        - condition:
+            contains:
+              docker.container.image: "postgres"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"
+              multiline.pattern: '^\t'
+              multiline.negate: false
+              multiline.match: after
+        - condition:
+            and:
+              - not:
+                  contains:
+                    docker.container.image: "apm-server"
+              - not:
+                  contains:
+                    docker.container.image: "filebeat"
+              - not:
+                  contains:
+                    docker.container.image: "heartbeat"
+              - not:
+                  contains:
+                    docker.container.image: "kibana"
+              - not:
+                  contains:
+                    docker.container.image: "metricbeat"
+              - not:
+                  contains:
+                    docker.container.image: "opbeans-node"
+              - not:
+                  contains:
+                    docker.container.image: "opbeans-go"
+              - not:
+                  contains:
+                    docker.container.image: "postgres"
+          config:
+            - type: docker
+              containers.ids:
+                - "${data.docker.container.id}"

--- a/docker/filebeat/filebeat.yml
+++ b/docker/filebeat/filebeat.yml
@@ -4,7 +4,7 @@ setup.template.settings:
   index.number_of_replicas: 0
 
 setup.kibana:
-  host: "kibana:5601"
+  host: "${KIBANA_HOST:kibana:5601}"
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/docker/heartbeat/heartbeat.yml
+++ b/docker/heartbeat/heartbeat.yml
@@ -1,8 +1,8 @@
 output.elasticsearch:
-  hosts: ["elasticsearch:9200"]
+  hosts: ["${ELASTICSEARCH_HOSTS:elasticsearch:9200}"]
 
 setup.kibana:
-  host: "kibana:5601"
+  host: "${KIBANA_HOST:kibana:5601}"
 
 heartbeat.monitors:
 - type: icmp

--- a/docker/heartbeat/heartbeat.yml
+++ b/docker/heartbeat/heartbeat.yml
@@ -1,3 +1,4 @@
+---
 output.elasticsearch:
   hosts: ["${ELASTICSEARCH_HOSTS:elasticsearch:9200}"]
 
@@ -5,18 +6,18 @@ setup.kibana:
   host: "${KIBANA_HOST:kibana:5601}"
 
 heartbeat.monitors:
-- type: icmp
-  schedule: '*/5 * * * * * *'
-  hosts: ["google.com"]
-- type: tcp
-  schedule: '@every 5s'
-  hosts: ["myhost:7"]  # default TCP Echo Protocol
-  check.send: "Check"
-  check.receive: "Check"
-- type: http
-  schedule: '@every 5s'
-  urls: ["https://www.elastic.co/"]
-  check.response.status: 200
+  - type: icmp
+    schedule: '*/5 * * * * * *'
+    hosts: ["google.com"]
+  - type: tcp
+    schedule: '@every 5s'
+    hosts: ["myhost:7"]  # default TCP Echo Protocol
+    check.send: "Check"
+    check.receive: "Check"
+  - type: http
+    schedule: '@every 5s'
+    urls: ["https://www.elastic.co/"]
+    check.response.status: 200
 heartbeat.scheduler:
   limit: 10
 

--- a/docker/logstash/pipeline/apm.conf
+++ b/docker/logstash/pipeline/apm.conf
@@ -33,7 +33,7 @@ filter {
 
 output {
   elasticsearch {
-    hosts => ["elasticsearch:9200"]
+    hosts => ["${ELASTICSEARCH_HOSTS:elasticsearch:9200}"]
     index => "%{[@metadata][beat]}-%{[@metadata][version]}%{[@metadata][index_suffix]}-%{+YYYY.MM.dd}"
   }
 }

--- a/docker/metricbeat/metricbeat.yml
+++ b/docker/metricbeat/metricbeat.yml
@@ -1,3 +1,4 @@
+---
 setup.template.settings:
   index.number_of_shards: 1
   index.codec: best_compression
@@ -23,60 +24,60 @@ metricbeat.config.modules:
   reload.enabled: false
 
 metricbeat.modules:
-- module: golang
-  metricsets: ["expvar","heap"]
-  period: 10s
-  hosts: ["${APM_SERVER_PPROF_HOST:apm-server:6060}"]
-  heap.path: "/debug/vars"
-  expvar:
-    namespace: "apm-server"
-    path: "/debug/vars"
-- module: docker
-  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
-  hosts: ["unix:///var/run/docker.sock"]
-  period: 10s
+  - module: golang
+    metricsets: ["expvar", "heap"]
+    period: 10s
+    hosts: ["${APM_SERVER_PPROF_HOST:apm-server:6060}"]
+    heap.path: "/debug/vars"
+    expvar:
+      namespace: "apm-server"
+      path: "/debug/vars"
+  - module: docker
+    metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
+    hosts: ["unix:///var/run/docker.sock"]
+    period: 10s
 
 metricbeat.autodiscover:
   providers:
     - type: docker
       templates:
-      - condition:
-          contains:
-            docker.container.image: "redis"
-        config:
-          - module: redis
-            metricsets: ["info", "keyspace"]
-            hosts: "${data.host}:6379"
-      - condition:
-          contains:
-            docker.container.image: "postgres"
-        config:
-          - module: postgresql
-            metricsets: ["database", "bgwriter", "activity"]
-            hosts: ["postgres://${data.host}:5432?sslmode=disable"]
-            password: verysecure
-            username: postgres
-      - condition:
-          contains:
-            docker.container.image: "elasticsearch"
-        config:
-          - module: elasticsearch
-            metricsets: ["node", "node_stats"]
-            period: 10s
-            hosts: "${data.host}:9200"
-      - condition:
-          contains:
-            docker.container.image: "kafka"
-        config:
-          - module: kafka
-            metricsets: ["consumergroup", "partition"]
-            period: 10s
-            hosts: "${data.host}:9092"
-      - condition:
-          contains:
-            docker.container.image: "logstash"
-        config:
-          - module: logstash
-            metricsets: ["node", "node_stats"]
-            period: 10s
-            hosts: "${data.host}:9600"
+        - condition:
+            contains:
+              docker.container.image: "redis"
+          config:
+            - module: redis
+              metricsets: ["info", "keyspace"]
+              hosts: "${data.host}:6379"
+        - condition:
+            contains:
+              docker.container.image: "postgres"
+          config:
+            - module: postgresql
+              metricsets: ["database", "bgwriter", "activity"]
+              hosts: ["postgres://${data.host}:5432?sslmode=disable"]
+              password: verysecure
+              username: postgres
+        - condition:
+            contains:
+              docker.container.image: "elasticsearch"
+          config:
+            - module: elasticsearch
+              metricsets: ["node", "node_stats"]
+              period: 10s
+              hosts: "${data.host}:9200"
+        - condition:
+            contains:
+              docker.container.image: "kafka"
+          config:
+            - module: kafka
+              metricsets: ["consumergroup", "partition"]
+              period: 10s
+              hosts: "${data.host}:9092"
+        - condition:
+            contains:
+              docker.container.image: "logstash"
+          config:
+            - module: logstash
+              metricsets: ["node", "node_stats"]
+              period: 10s
+              hosts: "${data.host}:9600"

--- a/docker/metricbeat/metricbeat.yml
+++ b/docker/metricbeat/metricbeat.yml
@@ -4,7 +4,7 @@ setup.template.settings:
   index.number_of_replicas: 0
 
 setup.kibana:
-  host: "kibana:5601"
+  host: "${KIBANA_HOST:kibana:5601}"
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'
@@ -26,7 +26,7 @@ metricbeat.modules:
 - module: golang
   metricsets: ["expvar","heap"]
   period: 10s
-  hosts: ["apm-server:6060"]
+  hosts: ["${APM_SERVER_PPROF_HOST:apm-server:6060}"]
   heap.path: "/debug/vars"
   expvar:
     namespace: "apm-server"

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -557,7 +557,7 @@ class ApmServer(StackService, Service):
             '--apm-server-elasticsearch-url',
             action="append",
             dest="apm_server_elasticsearch_urls",
-            help="apm-server elasticsearch output url(s)."
+            help="apm-server elasticsearch output url(s) (e.g. 'http://es1.example.com,http://es2.example.com')."
         )
         parser.add_argument(
             '--apm-server-elasticsearch-username',
@@ -885,7 +885,8 @@ class BeatMixin(object):
             "--{}-elasticsearch-url".format(cls.name()),
             action="append",
             dest="apm_server_elasticsearch_urls",
-            help="{} elasticsearch output url(s).".format(cls.name()),
+            help="{} elasticsearch output url(s) (e.g. 'http://es1.example.com,http://es2.example.com')."
+                 .format(cls.name()),
         )
         parser.add_argument(
             "--{}-elasticsearch-username".format(cls.name()),
@@ -1062,7 +1063,7 @@ class Kibana(StackService, Service):
             "--kibana-elasticsearch-url",
             action="append",
             dest="kibana_elasticsearch_urls",
-            help="kibana elasticsearch output url(s)."
+            help="kibana elasticsearch output url(s) (e.g. 'http://es1.example.com,http://es2.example.com')."
         )
 
     def _content(self):
@@ -1112,7 +1113,7 @@ class Logstash(StackService, Service):
             "--logstash-elasticsearch-url",
             action="append",
             dest="logstash_elasticsearch_urls",
-            help="logstash elasticsearch output url(s)."
+            help="logstash elasticsearch output url(s) (e.g. 'http://es1.example.com,http://es2.example.com')."
         )
 
 
@@ -1683,9 +1684,7 @@ class OpbeansService(Service):
         self.agent_local_repo = options.get(self.option_name() + "_agent_local_repo")
         self.opbeans_branch = options.get(self.option_name() + "_branch") or ""
         self.opbeans_repo = options.get(self.option_name() + "_repo") or ""
-        self.es_urls = self.options.get("opbeans_elasticsearch_urls")
-        if not self.es_urls:
-            self.es_urls = ["http://elasticsearch:9200"]
+        self.es_urls = self.options.get("opbeans_elasticsearch_urls") or ["http://elasticsearch:9200"]
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1709,12 +1708,6 @@ class OpbeansService(Service):
             default=None,
             dest=cls.option_name() + '_agent_local_repo',
             help=cls.name() + " local repo path for agent"
-        )
-        parser.add_argument(
-            "--{}-elasticsearch-url".format(cls.name()),
-            default=None,
-            dest="opbeans_elasticsearch_urls",
-            help="opbeans elasticsearch output url(s)."
         )
         if hasattr(cls, 'DEFAULT_SERVICE_NAME'):
             parser.add_argument(
@@ -2582,6 +2575,12 @@ class LocalSetup(object):
             help='server_url to use for Opbeans frontend service',
             dest='opbeans_apm_js_server_url',
             default='http://apm-server:8200',
+        )
+
+        parser.add_argument(
+            "--opbeans-elasticsearch-url",
+            dest="opbeans_elasticsearch_urls",
+            help="opbeans elasticsearch output url(s) (e.g. 'http://es1.example.com,http://es2.example.com')."
         )
 
         parser.add_argument(

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1125,14 +1125,12 @@ class Metricbeat(BeatMixin, StackService, Service):
         parser.add_argument(
             "--apm-server-pprof-url",
             help="apm server profiling url to use.",
-            dest='apm_server_pprof_url',
+            dest="apm_server_pprof_url",
             default="apm-server:6060"
         )
 
     def _content(self):
-        print("*****************----->{}".format(self.options.get('apm_server_pprof_url')))
-
-        self.environment["APM_SERVER_PPROF_HOST"] = json.dumps(self.options.get('apm_server_pprof_url'))
+        self.environment['APM_SERVER_PPROF_HOST'] = self.options.get("apm_server_pprof_url")
         return dict(
             command=self.command,
             depends_on=self.depends_on,

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -220,6 +220,8 @@ class Service(object):
         # bc depends on version for resolution
         self._bc = resolve_bc(self._version, options.get(self.option_name() + "_bc") or options.get("bc"))
 
+        self.depends_on = {}
+
     @property
     def bc(self):
         return self._bc
@@ -1034,7 +1036,10 @@ class Heartbeat(BeatMixin, StackService, Service):
 
 
 class Kibana(StackService, Service):
-    default_environment = {"SERVER_NAME": "kibana.example.org", "ELASTICSEARCH_URL": "http://elasticsearch:9200"}
+    default_environment = {
+        "SERVER_NAME": "kibana.example.org",
+        "ELASTICSEARCH_URL": "http://elasticsearch:9200"
+        }
 
     SERVICE_PORT = 5601
 
@@ -1211,9 +1216,10 @@ class AgentRUMJS(Service):
         super(AgentRUMJS, self).__init__(**options)
         self.agent_branch = options.get("rum_agent_branch", self.DEFAULT_AGENT_BRANCH)
         self.agent_repo = options.get("rum_agent_repo", self.DEFAULT_AGENT_REPO)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1276,9 +1282,10 @@ class AgentGoNetHttp(Service):
         super(AgentGoNetHttp, self).__init__(**options)
         self.agent_version = options.get("go_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_repo = options.get("go_agent_repo", self.DEFAULT_AGENT_REPO)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
@@ -1318,9 +1325,10 @@ class AgentNodejsExpress(Service):
     def __init__(self, **options):
         super(AgentNodejsExpress, self).__init__(**options)
         self.agent_package = options.get("nodejs_agent_package", self.DEFAULT_AGENT_PACKAGE)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1361,9 +1369,10 @@ class AgentPython(Service):
     def __init__(self, **options):
         super(AgentPython, self).__init__(**options)
         self.agent_package = options.get("python_agent_package", self.DEFAULT_AGENT_PACKAGE)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1464,9 +1473,10 @@ class AgentRubyRails(Service):
         self.agent_version = options.get("ruby_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_version_state = options.get("ruby_agent_version_state", self.DEFAULT_AGENT_VERSION_STATE)
         self.agent_repo = options.get("ruby_agent_repo", self.DEFAULT_AGENT_REPO)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
@@ -1534,9 +1544,10 @@ class AgentJavaSpring(Service):
         self.agent_version = options.get("java_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_release = options.get("java_agent_release", self.DEFAULT_AGENT_RELEASE)
         self.agent_repo = options.get("java_agent_repo", self.DEFAULT_AGENT_REPO)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
@@ -1597,9 +1608,10 @@ class AgentDotnet(Service):
         self.agent_version = options.get("dotnet_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_release = options.get("dotnet_agent_release", self.DEFAULT_AGENT_RELEASE)
         self.agent_repo = options.get("dotnet_agent_repo", self.DEFAULT_AGENT_REPO)
-        self.depends_on = {
-            "apm-server": {"condition": "service_healthy"},
-        }
+        if options.get("enable_apm_server", True):
+            self.depends_on = {
+                "apm-server": {"condition": "service_healthy"},
+            }
 
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1053,9 +1053,7 @@ class Kibana(StackService, Service):
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
                 self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
-        self.es_urls = self.options.get("kibana_elasticsearch_urls")
-        if not self.es_urls:
-            self.es_urls = ["http://elasticsearch:9200"]
+        self.es_urls = self.options.get("kibana_elasticsearch_urls") or ["http://elasticsearch:9200"]
         self.environment["ELASTICSEARCH_URL"] = self.es_urls
 
     @classmethod
@@ -1096,9 +1094,7 @@ class Logstash(StackService, Service):
         return self.bc["projects"]["logstash-docker"]["packages"][key]
 
     def _content(self):
-        self.es_urls = self.options.get("logstash_elasticsearch_urls")
-        if not self.es_urls:
-            self.es_urls = ["http://elasticsearch:9200"]
+        self.es_urls = self.options.get("logstash_elasticsearch_urls") or ["http://elasticsearch:9200"]
         return dict(
             depends_on={"elasticsearch": {"condition": "service_healthy"}} if self.options.get(
                 "enable_elasticsearch", True) else {},

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -67,7 +67,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_FLUSH_INTERVAL=5
                       - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                       - ELASTIC_APM_SAMPLE_RATE=1
-                      - ELASTICSEARCH_URL=http://elasticsearch:9200
+                      - ELASTICSEARCH_URL=elasticsearch:9200
                       - OPBEANS_DT_PROBABILITY=0.50
                     logging:
                       driver: 'json-file'
@@ -123,7 +123,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_FLUSH_INTERVAL=5
                       - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                       - ELASTIC_APM_SAMPLE_RATE=1
-                      - ELASTICSEARCH_URL=http://elasticsearch:9200
+                      - ELASTICSEARCH_URL=elasticsearch:9200
                       - OPBEANS_CACHE=redis://redis:6379
                       - OPBEANS_PORT=3000
                       - PGHOST=postgres
@@ -185,7 +185,7 @@ class OpbeansServiceTest(ServiceTest):
                       - DATABASE_DIALECT=POSTGRESQL
                       - DATABASE_DRIVER=org.postgresql.Driver
                       - REDIS_URL=redis://redis:6379
-                      - ELASTICSEARCH_URL=http://elasticsearch:9200
+                      - ELASTICSEARCH_URL=elasticsearch:9200
                       - OPBEANS_SERVER_PORT=3000
                       - JAVA_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
@@ -320,7 +320,7 @@ class OpbeansServiceTest(ServiceTest):
                         - ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES
                         - ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES
                         - REDIS_URL=redis://redis:6379
-                        - ELASTICSEARCH_URL=http://elasticsearch:9200
+                        - ELASTICSEARCH_URL=elasticsearch:9200
                         - OPBEANS_SERVER_URL=http://opbeans-python:3000
                         - PYTHON_AGENT_BRANCH=
                         - PYTHON_AGENT_REPO=
@@ -396,7 +396,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_SERVICE_NAME=opbeans-ruby
                       - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans-ruby
                       - REDIS_URL=redis://redis:6379
-                      - ELASTICSEARCH_URL=http://elasticsearch:9200
+                      - ELASTICSEARCH_URL=elasticsearch:9200
                       - OPBEANS_SERVER_URL=http://opbeans-ruby:3000
                       - RAILS_ENV=production
                       - RAILS_LOG_TO_STDOUT=1
@@ -616,7 +616,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_6.2.10_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
+                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -693,7 +693,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_6.3.10_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
+                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -774,7 +774,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_8.0.0_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
+                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
                     interval: 10s
                     retries: 20

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -90,12 +90,12 @@ class OpbeansServiceTest(ServiceTest):
         value = [e for e in opbeans["build"]["args"] if e.startswith("DOTNET_AGENT_VERSION")]
         self.assertEqual(value, ["DOTNET_AGENT_VERSION=1.0"])
 
-    def test_opbeans_go_branch(self):
+    def test_opbeans_dotnet_branch(self):
         opbeans = OpbeansDotnet(opbeans_dotnet_branch="1.x").render()["opbeans-dotnet"]
         branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_DOTNET_BRANCH")]
         self.assertEqual(branch, ["OPBEANS_DOTNET_BRANCH=1.x"])
 
-    def test_opbeans_go_repo(self):
+    def test_opbeans_dotnet_repo(self):
         opbeans = OpbeansDotnet(opbeans_dotnet_repo="foo/bar").render()["opbeans-dotnet"]
         branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_DOTNET_REPO")]
         self.assertEqual(branch, ["OPBEANS_DOTNET_REPO=foo/bar"])
@@ -464,6 +464,45 @@ class OpbeansServiceTest(ServiceTest):
                          retries: 12""")  # noqa: 501
         )
 
+    def test_opbeans_elasticsearch_urls(self):
+        def assertOneElasticsearch(opbean):
+            self.assertTrue("elasticsearch" in opbean['depends_on'])
+            self.assertTrue("ELASTICSEARCH_URL=elasticsearch01:9200" in opbean['environment'])
+
+        def assertTwoElasticsearch(opbean):
+            self.assertTrue("elasticsearch" in opbean['depends_on'])
+            self.assertTrue("ELASTICSEARCH_URL=elasticsearch01:9200,elasticsearch02:9200" in opbean['environment'])
+
+        opbeans = OpbeansDotnet(opbeans_elasticsearch_urls=["elasticsearch01:9200"]).render()["opbeans-dotnet"]
+        assertOneElasticsearch(opbeans)
+        opbeans = OpbeansDotnet(opbeans_elasticsearch_urls=["elasticsearch01:9200", "elasticsearch02:9200"]
+                                ).render()["opbeans-dotnet"]
+        assertTwoElasticsearch(opbeans)
+
+        opbeans = OpbeansGo(opbeans_elasticsearch_urls=["elasticsearch01:9200"]).render()["opbeans-go"]
+        assertOneElasticsearch(opbeans)
+        opbeans = OpbeansGo(opbeans_elasticsearch_urls=["elasticsearch01:9200", "elasticsearch02:9200"]
+                            ).render()["opbeans-go"]
+        assertTwoElasticsearch(opbeans)
+
+        opbeans = OpbeansJava(opbeans_elasticsearch_urls=["elasticsearch01:9200"]).render()["opbeans-java"]
+        assertOneElasticsearch(opbeans)
+        opbeans = OpbeansJava(opbeans_elasticsearch_urls=["elasticsearch01:9200", "elasticsearch02:9200"]
+                              ).render()["opbeans-java"]
+        assertTwoElasticsearch(opbeans)
+
+        opbeans = OpbeansPython(opbeans_elasticsearch_urls=["elasticsearch01:9200"]).render()["opbeans-python"]
+        assertOneElasticsearch(opbeans)
+        opbeans = OpbeansPython(opbeans_elasticsearch_urls=["elasticsearch01:9200", "elasticsearch02:9200"]
+                                ).render()["opbeans-python"]
+        assertTwoElasticsearch(opbeans)
+
+        opbeans = OpbeansRuby(opbeans_elasticsearch_urls=["elasticsearch01:9200"]).render()["opbeans-ruby"]
+        assertOneElasticsearch(opbeans)
+        opbeans = OpbeansRuby(opbeans_elasticsearch_urls=["elasticsearch01:9200", "elasticsearch02:9200"]
+                              ).render()["opbeans-ruby"]
+        assertTwoElasticsearch(opbeans)
+
     def test_opbeans_secret_token(self):
         for cls in opbeans_services():
             services = cls(version="6.5.0", apm_server_secret_token="supersecret").render()
@@ -496,7 +535,6 @@ class OpbeansServiceTest(ServiceTest):
                 logging:
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}""")
-
 
 class PostgresServiceTest(ServiceTest):
     def test_postgres(self):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -721,7 +721,7 @@ class KibanaServiceTest(ServiceTest):
                     container_name: localtesting_6.2.4_kibana
                     environment:
                         SERVER_NAME: kibana.example.org
-                        ELASTICSEARCH_URL: http://elasticsearch:9200
+                        ELASTICSEARCH_URL: elasticsearch:9200
                         XPACK_MONITORING_ENABLED: 'true'
                     ports:
                         - "127.0.0.1:5601:5601"
@@ -750,7 +750,7 @@ class KibanaServiceTest(ServiceTest):
                     container_name: localtesting_6.3.5_kibana
                     environment:
                         SERVER_NAME: kibana.example.org
-                        ELASTICSEARCH_URL: http://elasticsearch:9200
+                        ELASTICSEARCH_URL: elasticsearch:9200
                         XPACK_MONITORING_ENABLED: 'true'
                         XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'
                     ports:
@@ -790,7 +790,7 @@ class LogstashServiceTest(ServiceTest):
             container_name: localtesting_6.3.0_logstash
             depends_on:
                 elasticsearch: {condition: service_healthy}
-            environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200'}
+            environment: {ELASTICSEARCH_URL: 'elasticsearch:9200'}
             healthcheck:
                 test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://logstash:9600/"]
                 interval: 10s
@@ -816,7 +816,7 @@ class MetricbeatServiceTest(ServiceTest):
                     container_name: localtesting_6.2.4_metricbeat
                     user: root
                     command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
-                    environment: {}
+                    environment: {APM_SERVER_PPROF_HOST: 'None'}
                     logging:
                         driver: 'json-file'
                         options:

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -808,7 +808,7 @@ class LogstashServiceTest(ServiceTest):
 
 class MetricbeatServiceTest(ServiceTest):
     def test_metricbeat(self):
-        metricbeat = Metricbeat(version="6.2.4", release=True).render()
+        metricbeat = Metricbeat(version="6.2.4", release=True, apm_server_pprof_url='apm-server:6060').render()
         self.assertEqual(
             metricbeat, yaml.load("""
                 metricbeat:
@@ -816,7 +816,7 @@ class MetricbeatServiceTest(ServiceTest):
                     container_name: localtesting_6.2.4_metricbeat
                     user: root
                     command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
-                    environment: {APM_SERVER_PPROF_HOST: 'None'}
+                    environment: {APM_SERVER_PPROF_HOST: 'apm-server:6060'}
                     logging:
                         driver: 'json-file'
                         options:


### PR DESCRIPTION
* Allow disabling APM Server, now fails because agents depend on APM Server even do you pass `--no-apm-server`
* Use the ES_URL elasticsearch to dump test data on failed tests
* Allow overwriting Makefile environment vars
* Allow changing elasticsearch URL for OpBeans, Logstash, and Kibana
* Unit tests for the new arguments

After these changes, it is possible to launch the integration test against one of our k8s clusters or an Elastic Cloud instance.