### PR TITLE
ci: enable junit reporting for the pre-commit stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,16 +73,22 @@ pipeline {
             HOME = "${env.WORKSPACE}"
           }
           steps {
-            withGithubNotify(context: 'Check pre-commit') {
+            withGithubNotify(context: 'Check pre-commit', tab: 'tests') {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
                 sh '''
-                  env | sort
                   curl https://pre-commit.com/install-local.py | python -
-                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files | tee pre-commit.out
                 '''
               }
+            }
+          }
+          post {
+            always {
+              preCommitToJunit(input: "${BASE_DIR}/pre-commit.out", output: "${BASE_DIR}/pre-commit-junit.xml")
+              archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
+              junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                preCommitToJunit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
         */
         stage('Unit Tests'){
           agent { label 'linux && immutable && docker' }
+          options { skipDefaultCheckout() }
           steps {
             withGithubNotify(context: 'Unit Tests', tab: 'tests') {
               deleteDir()
@@ -68,6 +69,7 @@ pipeline {
         }
         stage('Sanity checks') {
           agent { label 'linux && immutable && docker' }
+          options { skipDefaultCheckout() }
           environment {
             PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
             HOME = "${env.WORKSPACE}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -66,29 +66,19 @@ pipeline {
             }
           }
         }
-        stage('Check pre-commit') {
+        stage('Sanity checks') {
           agent { label 'linux && immutable && docker' }
           environment {
             PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
             HOME = "${env.WORKSPACE}"
           }
           steps {
-            withGithubNotify(context: 'Check pre-commit', tab: 'tests') {
+            withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh '''
-                  curl https://pre-commit.com/install-local.py | python -
-                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files | tee pre-commit.out
-                '''
+                preCommitToJunit(commit: "${GIT_BASE_COMMIT}", junit: true)
               }
-            }
-          }
-          post {
-            always {
-              preCommitToJunit(input: "${BASE_DIR}/pre-commit.out", output: "${BASE_DIR}/pre-commit-junit.xml")
-              archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
-              junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
             }
           }
         }


### PR DESCRIPTION
## Highlights
- Let's report the pre-commit output as JUnit now.
- Let's wait for the pre-commit pipeline step which will be released shortly this week. Then the pipeline changes will just require a simple call to the step `preCommit(junit:true)`