### PR TITLE
ci: update JJBB to ignore branches which are also filled as PRs

### DIFF
--- a/.ci/jobs/apm-integration-tests.yml
+++ b/.ci/jobs/apm-integration-tests.yml
@@ -7,7 +7,7 @@
     script-path: .ci/Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current


### PR DESCRIPTION
## Highlights
- We don't need to build branches which are also filled as PRs.
- There are three different options as shown below:
![image](https://user-images.githubusercontent.com/2871786/62041096-c9f52900-b1f2-11e9-8fd9-0099ed5aae8e.png)
- `no-pr` in the JJB (see [here](https://opendev.org/jjb/jenkins-job-builder/src/branch/master/jenkins_jobs/modules/project_multibranch.py#L883 ) refers to `ExcludeOriginPRBranchesSCMHeadFilter` (see [here](https://github.com/jenkinsci/github-branch-source-plugin/blob/df8ff4885daebd16cbcb17320dc308287706bea0/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java#L120-L123)) in the Jenkins plugin implementation.

