### PR TITLE
fix: elastic namespace should be opbeans namespace

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1691,7 +1691,7 @@ class OpbeansDotnet(OpbeansService):
     DEFAULT_SERVICE_NAME = "opbeans-dotnet"
     DEFAULT_AGENT_VERSION = ""
     DEFAULT_OPBEANS_BRANCH = "master"
-    DEFAULT_OPBEANS_REPO = "elastic/opbeans-dotnet"
+    DEFAULT_OPBEANS_REPO = "opbeans/opbeans-dotnet"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1763,7 +1763,7 @@ class OpbeansGo(OpbeansService):
     DEFAULT_AGENT_BRANCH = "master"
     DEFAULT_AGENT_REPO = "elastic/apm-agent-go"
     DEFAULT_OPBEANS_BRANCH = "master"
-    DEFAULT_OPBEANS_REPO = "elastic/opbeans-go"
+    DEFAULT_OPBEANS_REPO = "opbeans/opbeans-go"
     DEFAULT_SERVICE_NAME = "opbeans-go"
 
     @classmethod
@@ -1838,7 +1838,7 @@ class OpbeansJava(OpbeansService):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-java"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = 'opbeans-java'
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-java'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-java'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod
@@ -1916,7 +1916,7 @@ class OpbeansJava(OpbeansService):
 class OpbeansNode(OpbeansService):
     SERVICE_PORT = 3000
     DEFAULT_LOCAL_REPO = "."
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-node'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-node'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod
@@ -2005,7 +2005,7 @@ class OpbeansPython(OpbeansService):
     DEFAULT_AGENT_BRANCH = "2.x"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = 'opbeans-python'
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-python'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-python'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod
@@ -2093,7 +2093,7 @@ class OpbeansRuby(OpbeansService):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-ruby"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = "opbeans-ruby"
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-ruby'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-ruby'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1691,7 +1691,7 @@ class OpbeansDotnet(OpbeansService):
     DEFAULT_SERVICE_NAME = "opbeans-dotnet"
     DEFAULT_AGENT_VERSION = ""
     DEFAULT_OPBEANS_BRANCH = "master"
-    DEFAULT_OPBEANS_REPO = "opbeans/opbeans-dotnet"
+    DEFAULT_OPBEANS_REPO = "elastic/opbeans-dotnet"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1763,7 +1763,7 @@ class OpbeansGo(OpbeansService):
     DEFAULT_AGENT_BRANCH = "master"
     DEFAULT_AGENT_REPO = "elastic/apm-agent-go"
     DEFAULT_OPBEANS_BRANCH = "master"
-    DEFAULT_OPBEANS_REPO = "opbeans/opbeans-go"
+    DEFAULT_OPBEANS_REPO = "elastic/opbeans-go"
     DEFAULT_SERVICE_NAME = "opbeans-go"
 
     @classmethod

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -56,7 +56,7 @@ class OpbeansServiceTest(ServiceTest):
                         - DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
                         - DOTNET_AGENT_VERSION=
                         - OPBEANS_DOTNET_BRANCH=master
-                        - OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
+                        - OPBEANS_DOTNET_REPO=opbeans/opbeans-dotnet
                     container_name: localtesting_6.3.10_opbeans-dotnet
                     ports:
                       - "127.0.0.1:3004:80"
@@ -112,7 +112,7 @@ class OpbeansServiceTest(ServiceTest):
                         - GO_AGENT_BRANCH=master
                         - GO_AGENT_REPO=elastic/apm-agent-go
                         - OPBEANS_GO_BRANCH=master
-                        - OPBEANS_GO_REPO=elastic/opbeans-go
+                        - OPBEANS_GO_REPO=opbeans/opbeans-go
                     container_name: localtesting_6.3.10_opbeans-go
                     ports:
                       - "127.0.0.1:3003:3000"
@@ -169,7 +169,7 @@ class OpbeansServiceTest(ServiceTest):
                       args:
                         - JAVA_AGENT_BRANCH=
                         - JAVA_AGENT_REPO=elastic/apm-agent-java
-                        - OPBEANS_JAVA_IMAGE=elastic/opbeans-java
+                        - OPBEANS_JAVA_IMAGE=opbeans/opbeans-java
                         - OPBEANS_JAVA_VERSION=latest
                     container_name: localtesting_6.3.10_opbeans-java
                     ports:
@@ -226,7 +226,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/node
                       args:
-                      - OPBEANS_NODE_IMAGE=elastic/opbeans-node
+                      - OPBEANS_NODE_IMAGE=opbeans/opbeans-node
                       - OPBEANS_NODE_VERSION=latest
                     container_name: localtesting_6.2.4_opbeans-node
                     ports:
@@ -297,7 +297,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/python
                       args:
-                      - OPBEANS_PYTHON_IMAGE=elastic/opbeans-python
+                      - OPBEANS_PYTHON_IMAGE=opbeans/opbeans-python
                       - OPBEANS_PYTHON_VERSION=latest
                     container_name: localtesting_6.2.4_opbeans-python
                     ports:
@@ -386,7 +386,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/ruby
                       args:
-                        - OPBEANS_RUBY_IMAGE=elastic/opbeans-ruby
+                        - OPBEANS_RUBY_IMAGE=opbeans/opbeans-ruby
                         - OPBEANS_RUBY_VERSION=latest
                     container_name: localtesting_6.3.10_opbeans-ruby
                     ports:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -56,7 +56,7 @@ class OpbeansServiceTest(ServiceTest):
                         - DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
                         - DOTNET_AGENT_VERSION=
                         - OPBEANS_DOTNET_BRANCH=master
-                        - OPBEANS_DOTNET_REPO=opbeans/opbeans-dotnet
+                        - OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
                     container_name: localtesting_6.3.10_opbeans-dotnet
                     ports:
                       - "127.0.0.1:3004:80"
@@ -112,7 +112,7 @@ class OpbeansServiceTest(ServiceTest):
                         - GO_AGENT_BRANCH=master
                         - GO_AGENT_REPO=elastic/apm-agent-go
                         - OPBEANS_GO_BRANCH=master
-                        - OPBEANS_GO_REPO=opbeans/opbeans-go
+                        - OPBEANS_GO_REPO=elastic/opbeans-go
                     container_name: localtesting_6.3.10_opbeans-go
                     ports:
                       - "127.0.0.1:3003:3000"


### PR DESCRIPTION
Regression caused by https://github.com/elastic/apm-integration-testing/pull/556

Default opbeans are hosted in:
- https://hub.docker.com/u/opbeans