### PR TITLE
bump agent-dotnet version to the last release

### DIFF
--- a/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
+++ b/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0-beta1" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
The opbeans-dotnet was already updated: https://github.com/elastic/opbeans-dotnet/pull/12

This is the same update.