### PR TITLE
ci(jenkins): avoid using master with or to skip running in the master-worker

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'master || immutable' }
+      agent { label 'linux && immutable' }
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")


### PR DESCRIPTION
## Highlights
- `master` worker could be used but causes bottlenecks in some cases.
- This will allow to use of another worker and get rid of any potential bottlenecks when the build queue is massive.