### PR TITLE
update apm-server healthcheck url

### DIFF
--- a/docker/apm-server/haproxy/docker-entrypoint.sh
+++ b/docker/apm-server/haproxy/docker-entrypoint.sh
@@ -23,7 +23,7 @@ frontend http
 backend servers
     mode http
     balance roundrobin
-    option httpchk HEAD /healthcheck HTTP/1.0
+    option httpchk HEAD / HTTP/1.0
 EOF
 
 for ((i=1; i<=$backends; i++)); do


### PR DESCRIPTION
drops <6.5 support in load balancing config