### PR TITLE
feat: disable shallow cloning when using downstream pipelines

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -51,7 +51,8 @@ pipeline {
           repo: "${REPO}",
           credentialsId: "${JOB_GIT_CREDENTIALS}",
           mergeTarget: "${params.MERGE_TARGET}",
-          reference: "/var/lib/jenkins/apm-integration-testing.git"
+          reference: "/var/lib/jenkins/apm-integration-testing.git",
+          shallow: false
         )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{


### PR DESCRIPTION
## Highlights
- Shallow cloning with a mergeTarget causes` the refusing to merge unrelated histories` issue.
- Avoid shallow cloning then.