### PR TITLE
ci(jenkins): Set GitHub notification context to apm-ci

### DIFF
--- a/.ci/jobs/apm-integration-test-downstream.yml
+++ b/.ci/jobs/apm-integration-test-downstream.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
+        notification-context: 'apm-ci/downstream'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        notification-context: 'apm-ci/selector'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true

--- a/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        notification-context: 'apm-ci/upgrade'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true

--- a/.ci/jobs/apm-integration-tests.yml
+++ b/.ci/jobs/apm-integration-tests.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        notification-context: 'apm-ci'
         repo: apm-integration-testing
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
it will replace the generic context `continuous-integration/jenkins/*` for a fixed one that points to the name of the instance that generates the context `apm-ci`, it is important when we have multiple multibranch jobs listening on a repo to avoid to overwrite contexts.

**Now**

<img width="715" alt="Screenshot 2019-09-03 at 17 44 35" src="https://user-images.githubusercontent.com/5400788/64188351-86857e80-ce72-11e9-953a-c52c837bd46c.png">

**After**
<img width="736" alt="Screenshot 2019-09-03 at 17 43 59" src="https://user-images.githubusercontent.com/5400788/64188359-8a190580-ce72-11e9-83b5-67071a560bd7.png">
