### PR TITLE
feat: disable shallow cloning when using downstream pipelines (#583)

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -94,7 +94,8 @@ pipeline {
           repo: "${REPO}",
           credentialsId: "${JOB_GIT_CREDENTIALS}",
           mergeTarget: "${params.MERGE_TARGET}",
-          reference: "/var/lib/jenkins/apm-integration-testing.git"
+          reference: "/var/lib/jenkins/apm-integration-testing.git",
+          shallow: false
         )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{


### PR DESCRIPTION
Backport https://github.com/elastic/apm-integration-testing/pull/583/files