### PR TITLE
feat: add option to set service.enviroment value for opbeans

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1694,6 +1694,7 @@ class OpbeansService(Service):
         self.opbeans_branch = options.get(self.option_name() + "_branch") or ""
         self.opbeans_repo = options.get(self.option_name() + "_repo") or ""
         self.es_urls = ",".join(self.options.get("opbeans_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
+        self.service_environment = options.get(self.option_name() + "_service_environment") or ""
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1717,6 +1718,12 @@ class OpbeansService(Service):
             default=None,
             dest=cls.option_name() + '_agent_local_repo',
             help=cls.name() + " local repo path for agent"
+        )
+        parser.add_argument(
+            '--' + cls.name() + '-service-environment',
+            default=None,
+            dest=cls.option_name() + '_service_environment',
+            help=cls.name() + " service.environment value to display."
         )
         if hasattr(cls, 'DEFAULT_SERVICE_NAME'):
             parser.add_argument(
@@ -1791,6 +1798,7 @@ class OpbeansDotnet(OpbeansService):
                 "ELASTIC_APM_SAMPLE_RATE=1",
                 "ELASTICSEARCH_URL={}".format(self.es_urls),
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
+                "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
             depends_on=depends_on,
             image=None,
@@ -1866,6 +1874,7 @@ class OpbeansGo(OpbeansService):
                 "PGPASSWORD=verysecure",
                 "PGSSLMODE=disable",
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
+                "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
             depends_on=depends_on,
             image=None,
@@ -1942,6 +1951,7 @@ class OpbeansJava(OpbeansService):
                 "OPBEANS_SERVER_PORT=3000",
                 "JAVA_AGENT_VERSION",
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
+                "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
             depends_on=depends_on,
             image=None,
@@ -2025,6 +2035,7 @@ class OpbeansNode(OpbeansService):
                 "NODE_AGENT_BRANCH=" + self.agent_branch,
                 "NODE_AGENT_REPO=" + self.agent_repo,
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
+                "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
             depends_on=depends_on,
             image=None,
@@ -2116,6 +2127,7 @@ class OpbeansPython(OpbeansService):
                 "PYTHON_AGENT_REPO=" + self.agent_repo,
                 "PYTHON_AGENT_VERSION",
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
+                "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
             depends_on=depends_on,
             image=None,
@@ -2195,6 +2207,7 @@ class OpbeansRuby(OpbeansService):
                 "RUBY_AGENT_REPO=" + self.agent_repo,
                 "RUBY_AGENT_VERSION",
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
+                "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
             depends_on=depends_on,
             image=None,

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1694,7 +1694,8 @@ class OpbeansService(Service):
         self.opbeans_branch = options.get(self.option_name() + "_branch") or ""
         self.opbeans_repo = options.get(self.option_name() + "_repo") or ""
         self.es_urls = ",".join(self.options.get("opbeans_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
-        self.service_environment = options.get(self.option_name() + "_service_environment") or self.DEFAULT_ELASTIC_APM_ENVIRONMENT
+        self.service_environment = \
+            options.get(self.option_name() + "_service_environment") or self.DEFAULT_ELASTIC_APM_ENVIRONMENT
 
     @classmethod
     def add_arguments(cls, parser):

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1694,7 +1694,7 @@ class OpbeansService(Service):
         self.opbeans_branch = options.get(self.option_name() + "_branch") or ""
         self.opbeans_repo = options.get(self.option_name() + "_repo") or ""
         self.es_urls = ",".join(self.options.get("opbeans_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
-        self.service_environment = options.get(self.option_name() + "_service_environment") or ""
+        self.service_environment = options.get(self.option_name() + "_service_environment") or self.DEFAULT_ELASTIC_APM_ENVIRONMENT
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1742,6 +1742,7 @@ class OpbeansDotnet(OpbeansService):
     DEFAULT_AGENT_VERSION = ""
     DEFAULT_OPBEANS_BRANCH = "master"
     DEFAULT_OPBEANS_REPO = "elastic/opbeans-dotnet"
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1811,6 +1812,7 @@ class OpbeansDotnet(OpbeansService):
 
 class OpbeansDotnet01(OpbeansDotnet):
     SERVICE_PORT = 3104
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "testing"
 
     def __init__(self, **options):
         super(OpbeansDotnet01, self).__init__(**options)
@@ -1823,6 +1825,7 @@ class OpbeansGo(OpbeansService):
     DEFAULT_OPBEANS_BRANCH = "master"
     DEFAULT_OPBEANS_REPO = "elastic/opbeans-go"
     DEFAULT_SERVICE_NAME = "opbeans-go"
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1893,6 +1896,7 @@ class OpbeansGo(OpbeansService):
 
 class OpbeansGo01(OpbeansGo):
     SERVICE_PORT = 3103
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "testing"
 
     def __init__(self, **options):
         super(OpbeansGo01, self).__init__(**options)
@@ -1906,6 +1910,7 @@ class OpbeansJava(OpbeansService):
     DEFAULT_SERVICE_NAME = 'opbeans-java'
     DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-java'
     DEFAULT_OPBEANS_VERSION = 'latest'
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -1982,6 +1987,7 @@ class OpbeansJava(OpbeansService):
 
 class OpbeansJava01(OpbeansJava):
     SERVICE_PORT = 3102
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "testing"
 
     def __init__(self, **options):
         super(OpbeansJava01, self).__init__(**options)
@@ -1992,6 +1998,7 @@ class OpbeansNode(OpbeansService):
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-node'
     DEFAULT_OPBEANS_VERSION = 'latest'
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -2076,6 +2083,7 @@ class OpbeansNode(OpbeansService):
 
 class OpbeansNode01(OpbeansNode):
     SERVICE_PORT = 3100
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "testing"
 
     def __init__(self, **options):
         super(OpbeansNode01, self).__init__(**options)
@@ -2089,6 +2097,7 @@ class OpbeansPython(OpbeansService):
     DEFAULT_SERVICE_NAME = 'opbeans-python'
     DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-python'
     DEFAULT_OPBEANS_VERSION = 'latest'
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -2172,6 +2181,7 @@ class OpbeansPython(OpbeansService):
 
 class OpbeansPython01(OpbeansPython):
     SERVICE_PORT = 8100
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "testing"
 
     def __init__(self, **options):
         super(OpbeansPython01, self).__init__(**options)
@@ -2185,6 +2195,7 @@ class OpbeansRuby(OpbeansService):
     DEFAULT_SERVICE_NAME = "opbeans-ruby"
     DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-ruby'
     DEFAULT_OPBEANS_VERSION = 'latest'
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -2260,6 +2271,7 @@ class OpbeansRuby(OpbeansService):
 
 class OpbeansRuby01(OpbeansRuby):
     SERVICE_PORT = 3101
+    DEFAULT_ELASTIC_APM_ENVIRONMENT = "testing"
 
     def __init__(self, **options):
         super(OpbeansRuby01, self).__init__(**options)

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1747,7 +1747,7 @@ class OpbeansDotnet(OpbeansService):
     def add_arguments(cls, parser):
         super(OpbeansDotnet, cls).add_arguments(parser)
         parser.add_argument(
-            '--opbeans-dotnet-version',
+            '--' + cls.name() + '-version',
             default=cls.DEFAULT_AGENT_VERSION,
         )
         parser.add_argument(
@@ -1807,6 +1807,13 @@ class OpbeansDotnet(OpbeansService):
             ports=[self.publish_port(self.port, 80)],
         )
         return content
+
+
+class OpbeansDotnet01(OpbeansDotnet):
+    SERVICE_PORT = 3104
+
+    def __init__(self, **options):
+        super(OpbeansDotnet01, self).__init__(**options)
 
 
 class OpbeansGo(OpbeansService):
@@ -1882,6 +1889,13 @@ class OpbeansGo(OpbeansService):
             ports=[self.publish_port(self.port, 3000)],
         )
         return content
+
+
+class OpbeansGo01(OpbeansGo):
+    SERVICE_PORT = 3103
+
+    def __init__(self, **options):
+        super(OpbeansGo01, self).__init__(**options)
 
 
 class OpbeansJava(OpbeansService):
@@ -1964,6 +1978,13 @@ class OpbeansJava(OpbeansService):
                 "{}:/local-install".format(self.agent_local_repo),
             ]
         return content
+
+
+class OpbeansJava01(OpbeansJava):
+    SERVICE_PORT = 3102
+
+    def __init__(self, **options):
+        super(OpbeansJava01, self).__init__(**options)
 
 
 class OpbeansNode(OpbeansService):
@@ -2053,6 +2074,13 @@ class OpbeansNode(OpbeansService):
         return content
 
 
+class OpbeansNode01(OpbeansNode):
+    SERVICE_PORT = 3100
+
+    def __init__(self, **options):
+        super(OpbeansNode01, self).__init__(**options)
+
+
 class OpbeansPython(OpbeansService):
     SERVICE_PORT = 8000
     DEFAULT_AGENT_REPO = "elastic/apm-agent-python"
@@ -2066,7 +2094,7 @@ class OpbeansPython(OpbeansService):
     def add_arguments(cls, parser):
         super(OpbeansPython, cls).add_arguments(parser)
         parser.add_argument(
-            '--opbeans-python-local-repo',
+            '--' + cls.name() + '-local-repo',
             default=cls.DEFAULT_LOCAL_REPO,
         )
         parser.add_argument(
@@ -2140,6 +2168,13 @@ class OpbeansPython(OpbeansService):
                 "{}:/local-install".format(self.agent_local_repo),
             ]
         return content
+
+
+class OpbeansPython01(OpbeansPython):
+    SERVICE_PORT = 8100
+
+    def __init__(self, **options):
+        super(OpbeansPython01, self).__init__(**options)
 
 
 class OpbeansRuby(OpbeansService):
@@ -2223,6 +2258,13 @@ class OpbeansRuby(OpbeansService):
         return content
 
 
+class OpbeansRuby01(OpbeansRuby):
+    SERVICE_PORT = 3101
+
+    def __init__(self, **options):
+        super(OpbeansRuby01, self).__init__(**options)
+
+
 class OpbeansRum(Service):
     # OpbeansRum is not really an Opbeans service, so we inherit from Service
     SERVICE_PORT = 9222
@@ -2231,11 +2273,11 @@ class OpbeansRum(Service):
     def add_arguments(cls, parser):
         super(OpbeansRum, cls).add_arguments(parser)
         parser.add_argument(
-            '--opbeans-rum-backend-service',
+            '--' + cls.name() + '-backend-service',
             default='opbeans-node',
         )
         parser.add_argument(
-            '--opbeans-rum-backend-port',
+            '--' + cls.name() + '-backend-port',
             default='3000',
         )
 
@@ -2744,9 +2786,13 @@ class LocalSetup(object):
             service_enabled = args.get("enable_" + service.option_name())
             is_opbeans_service = issubclass(service, OpbeansService) or service is OpbeansRum
             is_opbeans_sidecar = service.name() in ('postgres', 'redis', 'opbeans-load-generator')
+            is_opbeans_2nd = service.name() in ('opbeans-go01', 'opbeans-java01',
+                                                'opbeans-python01', 'opbeans-ruby01',
+                                                'opbeans-dotnet01', 'opbeans-node01')
             is_obs = issubclass(service, BeatMixin)
-            if service_enabled or (all_opbeans and is_opbeans_service) or (any_opbeans and is_opbeans_sidecar) or \
-                    (run_all and is_obs):
+            if service_enabled or (all_opbeans and is_opbeans_service and not is_opbeans_2nd) \
+                    or (any_opbeans and is_opbeans_sidecar and not is_opbeans_2nd) or \
+                    (run_all and is_obs and not is_opbeans_2nd):
                 selections.add(service(**args))
 
         # `docker load` images if necessary, usually only for build candidates

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -503,6 +503,43 @@ class OpbeansServiceTest(ServiceTest):
                               ).render()["opbeans-ruby"]
         assertTwoElasticsearch(opbeans)
 
+    def test_opbeans_service_environment(self):
+        def assertWithoutOption(opbean):
+            self.assertTrue("ELASTIC_APM_ENVIRONMENT=" in opbean['environment'])
+
+        def assertWithOption(opbean):
+            self.assertTrue("ELASTIC_APM_ENVIRONMENT=test" in opbean['environment'])
+
+        opbeans = OpbeansDotnet().render()["opbeans-dotnet"]
+        assertWithoutOption(opbeans)
+        opbeans = OpbeansDotnet(opbeans_dotnet_service_environment="test").render()["opbeans-dotnet"]
+        assertWithOption(opbeans)
+
+        opbeans = OpbeansGo().render()["opbeans-go"]
+        assertWithoutOption(opbeans)
+        opbeans = OpbeansGo(opbeans_go_service_environment="test").render()["opbeans-go"]
+        assertWithOption(opbeans)
+
+        opbeans = OpbeansJava().render()["opbeans-java"]
+        assertWithoutOption(opbeans)
+        opbeans = OpbeansJava(opbeans_java_service_environment="test").render()["opbeans-java"]
+        assertWithOption(opbeans)
+
+        opbeans = OpbeansPython().render()["opbeans-python"]
+        assertWithoutOption(opbeans)
+        opbeans = OpbeansPython(opbeans_python_service_environment="test").render()["opbeans-python"]
+        assertWithOption(opbeans)
+
+        opbeans = OpbeansRuby().render()["opbeans-ruby"]
+        assertWithoutOption(opbeans)
+        opbeans = OpbeansRuby(opbeans_ruby_service_environment="test").render()["opbeans-ruby"]
+        assertWithOption(opbeans)
+
+        opbeans = OpbeansNode().render()["opbeans-node"]
+        assertWithoutOption(opbeans)
+        opbeans = OpbeansNode(opbeans_node_service_environment="test").render()["opbeans-node"]
+        assertWithOption(opbeans)
+
     def test_opbeans_secret_token(self):
         for cls in opbeans_services():
             services = cls(version="6.5.0", apm_server_secret_token="supersecret").render()

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -69,6 +69,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_SAMPLE_RATE=1
                       - ELASTICSEARCH_URL=elasticsearch:9200
                       - OPBEANS_DT_PROBABILITY=0.50
+                      - ELASTIC_APM_ENVIRONMENT=
                     logging:
                       driver: 'json-file'
                       options:
@@ -132,6 +133,7 @@ class OpbeansServiceTest(ServiceTest):
                       - PGPASSWORD=verysecure
                       - PGSSLMODE=disable
                       - OPBEANS_DT_PROBABILITY=0.50
+                      - ELASTIC_APM_ENVIRONMENT=
                     logging:
                       driver: 'json-file'
                       options:
@@ -189,6 +191,7 @@ class OpbeansServiceTest(ServiceTest):
                       - OPBEANS_SERVER_PORT=3000
                       - JAVA_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
+                      - ELASTIC_APM_ENVIRONMENT=
                     logging:
                       driver: 'json-file'
                       options:
@@ -258,6 +261,7 @@ class OpbeansServiceTest(ServiceTest):
                         - NODE_AGENT_BRANCH=
                         - NODE_AGENT_REPO=
                         - OPBEANS_DT_PROBABILITY=0.50
+                        - ELASTIC_APM_ENVIRONMENT=
                     depends_on:
                         redis:
                             condition: service_healthy
@@ -326,6 +330,7 @@ class OpbeansServiceTest(ServiceTest):
                         - PYTHON_AGENT_REPO=
                         - PYTHON_AGENT_VERSION
                         - OPBEANS_DT_PROBABILITY=0.50
+                        - ELASTIC_APM_ENVIRONMENT=
                     depends_on:
                         apm-server:
                             condition: service_healthy
@@ -405,6 +410,7 @@ class OpbeansServiceTest(ServiceTest):
                       - RUBY_AGENT_REPO=
                       - RUBY_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
+                      - ELASTIC_APM_ENVIRONMENT=
                     logging:
                       driver: 'json-file'
                       options:
@@ -978,6 +984,25 @@ class LocalTest(unittest.TestCase):
         services = got["services"]
         self.assertIn("redis", services)
         self.assertIn("postgres", services)
+
+    @mock.patch(compose.__name__ + '.load_images')
+    def test_start_opbeans_2nd(self, _ignore_load_images):
+        docker_compose_yml = stringIO()
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--with-opbeans-dotnet01", "--with-opbeans-node01",
+                                                              "--with-opbeans-java01", "--with-opbeans-go01",
+                                                              "--with-opbeans-python01", "--with-opbeans-ruby01"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        services = got["services"]
+        self.assertIn("opbeans-dotnet01", services)
+        self.assertIn("opbeans-node01", services)
+        self.assertIn("opbeans-java01", services)
+        self.assertIn("opbeans-go01", services)
+        self.assertIn("opbeans-python01", services)
+        self.assertIn("opbeans-ruby01", services)
 
     @mock.patch(compose.__name__ + '.load_images')
     def test_start_all_opbeans_no_apm_server(self, _ignore_load_images):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -69,7 +69,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_SAMPLE_RATE=1
                       - ELASTICSEARCH_URL=elasticsearch:9200
                       - OPBEANS_DT_PROBABILITY=0.50
-                      - ELASTIC_APM_ENVIRONMENT=
+                      - ELASTIC_APM_ENVIRONMENT=production
                     logging:
                       driver: 'json-file'
                       options:
@@ -133,7 +133,7 @@ class OpbeansServiceTest(ServiceTest):
                       - PGPASSWORD=verysecure
                       - PGSSLMODE=disable
                       - OPBEANS_DT_PROBABILITY=0.50
-                      - ELASTIC_APM_ENVIRONMENT=
+                      - ELASTIC_APM_ENVIRONMENT=production
                     logging:
                       driver: 'json-file'
                       options:
@@ -191,7 +191,7 @@ class OpbeansServiceTest(ServiceTest):
                       - OPBEANS_SERVER_PORT=3000
                       - JAVA_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
-                      - ELASTIC_APM_ENVIRONMENT=
+                      - ELASTIC_APM_ENVIRONMENT=production
                     logging:
                       driver: 'json-file'
                       options:
@@ -261,7 +261,7 @@ class OpbeansServiceTest(ServiceTest):
                         - NODE_AGENT_BRANCH=
                         - NODE_AGENT_REPO=
                         - OPBEANS_DT_PROBABILITY=0.50
-                        - ELASTIC_APM_ENVIRONMENT=
+                        - ELASTIC_APM_ENVIRONMENT=production
                     depends_on:
                         redis:
                             condition: service_healthy
@@ -330,7 +330,7 @@ class OpbeansServiceTest(ServiceTest):
                         - PYTHON_AGENT_REPO=
                         - PYTHON_AGENT_VERSION
                         - OPBEANS_DT_PROBABILITY=0.50
-                        - ELASTIC_APM_ENVIRONMENT=
+                        - ELASTIC_APM_ENVIRONMENT=production
                     depends_on:
                         apm-server:
                             condition: service_healthy
@@ -410,7 +410,7 @@ class OpbeansServiceTest(ServiceTest):
                       - RUBY_AGENT_REPO=
                       - RUBY_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
-                      - ELASTIC_APM_ENVIRONMENT=
+                      - ELASTIC_APM_ENVIRONMENT=production
                     logging:
                       driver: 'json-file'
                       options:
@@ -511,7 +511,7 @@ class OpbeansServiceTest(ServiceTest):
 
     def test_opbeans_service_environment(self):
         def assertWithoutOption(opbean):
-            self.assertTrue("ELASTIC_APM_ENVIRONMENT=" in opbean['environment'])
+            self.assertTrue("ELASTIC_APM_ENVIRONMENT=production" in opbean['environment'])
 
         def assertWithOption(opbean):
             self.assertTrue("ELASTIC_APM_ENVIRONMENT=test" in opbean['environment'])


### PR DESCRIPTION
it adds new options to set the value of `service.enviroment` for each Opbean. It will also allow launching a second instance of every Opbeans type with his own configuration, this second instance would be only launched is you request it with the `--with-opbeans-<AGENT>01` parameter. these are the new configuration parameter we will have on compose.py

* `--opbeans-<AGENT>-service-environment=<ENVIRONMENT_NAME>` ser the environment name
* `--with-opbeans-<AGENT>01` enable a second agent for <AGENT> type
* `--with-opbeans-<AGENT>01-*` configuration parameters for the second instance

some examples:

```shell
compose.py start 7.3.0 --all
``` 
it would launch every service but opbeans-<AGENTS>01

```shell
compose.py start 7.3.0 --with-opbeans-java --with-opbeans-java01
``` 
it would launch 2 Opbeans Java instances with the default configuration, the service environment will have different values on each opbeans instance, opbeans-java will use `production` and opbeans-java01 will use `testing`

```shell
compose.py start 7.3.0 \
  --with-opbeans-java  --opbeans-java-service-environment=stage\
  --with-opbeans-java01 -opbeans-java01-service-environment=pro
``` 
it would launch two Opbeans Java instances with two service environment values, opbeans-java will use `stage` and opbeans-java01 will use `pro`



