### PR TITLE
fix: add a call to add_arguments supper method on Kibana, some test to check the missing options

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1093,8 +1093,9 @@ class Kibana(StackService, Service):
 
     @classmethod
     def add_arguments(cls, parser):
+        super(Kibana, cls).add_arguments(parser)
         parser.add_argument(
-            "--kibana-elasticsearch-url",
+            "--{}-elasticsearch-url".format(cls.name()),
             action="append",
             dest="kibana_elasticsearch_urls",
             help="kibana elasticsearch output url(s)."
@@ -1146,7 +1147,7 @@ class Logstash(StackService, Service):
     def add_arguments(cls, parser):
         super(Logstash, cls).add_arguments(parser)
         parser.add_argument(
-            "--logstash-elasticsearch-url",
+            "--{}-elasticsearch-url".format(cls.name()),
             action="append",
             dest="logstash_elasticsearch_urls",
             help="logstash elasticsearch output url(s)."

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -885,6 +885,22 @@ class KibanaServiceTest(ServiceTest):
         self.assertTrue("elasticsearch" in kibana['depends_on'])
         self.assertEqual("elasticsearch01:9200,elasticsearch02:9200", kibana['environment']["ELASTICSEARCH_URL"])
 
+    def test_kibana_port(self):
+        kibana = Kibana(version="7.3.0", release=True, kibana_port="1234").render()["kibana"]
+        self.assertTrue("127.0.0.1:1234:5601" in kibana['ports'])
+
+    def test_kibana_version(self):
+        kibana = Kibana(version="7.3.0", release=True, kibana_version="7.3.0").render()["kibana"]
+        self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0", kibana["image"])
+
+    def test_kibana_oss(self):
+        kibana = Kibana(version="7.3.0", release=True, kibana_oss=True, kibana_version="7.3.0").render()["kibana"]
+        self.assertEqual("docker.elastic.co/kibana/kibana-oss:7.3.0", kibana["image"])
+
+    def test_kibana_snapshot(self):
+        kibana = Kibana(version="7.3.0", kibana_snapshot=True, kibana_version="7.3.0").render()["kibana"]
+        self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
+
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):
         logstash = Logstash(version="6.2.4", snapshot=True).render()["logstash"]


### PR DESCRIPTION
I've introduced a regression by adding a new method `add_arguments`to Kibana, basically, I've removed all configuration options because I've missed adding a call to the superclass method. It is fixed on this PR, also I've added some test to avoid this happens in the future.

closes #601