### PR TITLE
fix: set DEFAULT_APM_JS_SERVER_URL to http://localhost:8200

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -36,6 +36,7 @@ __version__ = "4.0.0"
 
 DEFAULT_STACK_VERSION = "8.0"
 DEFAULT_APM_SERVER_URL = "http://apm-server:8200"
+DEFAULT_APM_JS_SERVER_URL = "http://localhost:8200"
 
 
 #
@@ -1723,7 +1724,7 @@ class OpbeansService(Service):
     def __init__(self, **options):
         super(OpbeansService, self).__init__(**options)
         self.apm_server_url = options.get("apm_server_url", DEFAULT_APM_SERVER_URL)
-        self.apm_js_server_url = options.get("opbeans_apm_js_server_url", DEFAULT_APM_SERVER_URL)
+        self.apm_js_server_url = options.get("opbeans_apm_js_server_url", DEFAULT_APM_JS_SERVER_URL)
         self.opbeans_dt_probability = options.get("opbeans_dt_probability", 0.5)
         if hasattr(self, "DEFAULT_SERVICE_NAME"):
             self.service_name = options.get(self.option_name() + "_service_name", self.DEFAULT_SERVICE_NAME)

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -63,7 +63,7 @@ class OpbeansServiceTest(ServiceTest):
                     environment:
                       - ELASTIC_APM_SERVICE_NAME=opbeans-dotnet
                       - ELASTIC_APM_SERVER_URLS=http://apm-server:8200
-                      - ELASTIC_APM_JS_SERVER_URL=http://apm-server:8200
+                      - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                       - ELASTIC_APM_FLUSH_INTERVAL=5
                       - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                       - ELASTIC_APM_SAMPLE_RATE=1
@@ -120,7 +120,7 @@ class OpbeansServiceTest(ServiceTest):
                     environment:
                       - ELASTIC_APM_SERVICE_NAME=opbeans-go
                       - ELASTIC_APM_SERVER_URL=http://apm-server:8200
-                      - ELASTIC_APM_JS_SERVER_URL=http://apm-server:8200
+                      - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                       - ELASTIC_APM_FLUSH_INTERVAL=5
                       - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                       - ELASTIC_APM_SAMPLE_RATE=1
@@ -241,7 +241,7 @@ class OpbeansServiceTest(ServiceTest):
                             max-file: '5'
                     environment:
                         - ELASTIC_APM_SERVER_URL=http://apm-server:8200
-                        - ELASTIC_APM_JS_SERVER_URL=http://apm-server:8200
+                        - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                         - ELASTIC_APM_LOG_LEVEL=info
                         - ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES
                         - ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES=5
@@ -315,7 +315,7 @@ class OpbeansServiceTest(ServiceTest):
                         - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans
                         - ELASTIC_APM_SERVICE_NAME=opbeans-python
                         - ELASTIC_APM_SERVER_URL=http://apm-server:8200
-                        - ELASTIC_APM_JS_SERVER_URL=http://apm-server:8200
+                        - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                         - ELASTIC_APM_FLUSH_INTERVAL=5
                         - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                         - ELASTIC_APM_TRANSACTION_SAMPLE_RATE=0.5


### PR DESCRIPTION
When you run the integration test docker-compose file, the RUM agent should point to "http://localhost:8200" to be able to report to the APM Server from the local browser.

closes #412 