### PR TITLE
fix: ignore lint documentation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ venv: requirements.txt
 	touch $(VENV);\
 
 lint: venv
-	flake8 tests/ scripts/compose.py
+	flake8 --ignore=D100,D101,D102,D103,D104,D105,D106,D107,D200,D205,D400,D401,D403,W504  tests/ scripts/compose.py
 
 .PHONY: lint
 


### PR DESCRIPTION
`make lint` show tons of warning related to documentation on the Python files, this makes really difficult to find a lint issue in the list, by adding these ignores you would only see the errors.

The list of lint checks regarding the docs can be found in the below doc:
- http://www.pydocstyle.org/en/2.1.1/error_codes.html#grouping