### PR TITLE
Add support for Elastic Code from 7.2+

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -559,6 +559,8 @@ class Kibana(StackService, Service):
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
                 self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
+        if options.get("xpack_code_ui_enabled"):
+            self.environment["XPACK_CODE_UI_ENABLED"] = "true"
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
 
@@ -569,6 +571,11 @@ class Kibana(StackService, Service):
             action="append",
             dest="kibana_elasticsearch_urls",
             help="kibana elasticsearch output url(s)."
+        )
+        parser.add_argument(
+            "--xpack-code-ui-enabled",
+            action="store_true",
+            help="enable Code",
         )
 
     def _content(self):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -559,7 +559,7 @@ class Kibana(StackService, Service):
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
                 self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
-        if self.at_least_version("7.3"):
+        if self.at_least_version("7.2"):
             self.environment["XPACK_CODE_UI_ENABLED"] = "true"
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -559,7 +559,7 @@ class Kibana(StackService, Service):
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
                 self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
-        if options.get("xpack_code_ui_enabled"):
+        if self.at_least_version("7.3"):
             self.environment["XPACK_CODE_UI_ENABLED"] = "true"
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
@@ -571,11 +571,6 @@ class Kibana(StackService, Service):
             action="append",
             dest="kibana_elasticsearch_urls",
             help="kibana elasticsearch output url(s)."
-        )
-        parser.add_argument(
-            "--xpack-code-ui-enabled",
-            action="store_true",
-            help="enable Code",
         )
 
     def _content(self):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -858,7 +858,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_8.0.0_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
+                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_CODE_UI_ENABLED: 'true', XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
                     interval: 10s
                     retries: 20

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -900,6 +900,14 @@ class KibanaServiceTest(ServiceTest):
         kibana = Kibana(version="7.3.0", kibana_snapshot=True, kibana_version="7.3.0").render()["kibana"]
         self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
 
+    def test_kibana_with_code_ui_enabled(self):
+        kibana = Kibana(version="7.3.0", xpack_code_ui_enabled=True).render()["kibana"]
+        self.assertEqual("true", kibana["environment"]["XPACK_CODE_UI_ENABLED"])
+
+    def test_kibana_with_code_ui_disabled(self):
+        kibana = Kibana(version="7.3.0", xpack_code_ui_enabled=False).render()["kibana"]
+        self.assertFalse("XPACK_CODE_UI_ENABLED" in kibana["environment"])
+
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):
         logstash = Logstash(version="6.2.4", snapshot=True).render()["logstash"]

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -900,12 +900,12 @@ class KibanaServiceTest(ServiceTest):
         kibana = Kibana(version="7.3.0", kibana_snapshot=True, kibana_version="7.3.0").render()["kibana"]
         self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
 
-    def test_kibana_with_code_ui_enabled(self):
-        kibana = Kibana(version="7.3.0", xpack_code_ui_enabled=True).render()["kibana"]
+    def test_kibana_with_code_enabled(self):
+        kibana = Kibana(version="7.3.0").render()["kibana"]
         self.assertEqual("true", kibana["environment"]["XPACK_CODE_UI_ENABLED"])
 
-    def test_kibana_with_code_ui_disabled(self):
-        kibana = Kibana(version="7.3.0", xpack_code_ui_enabled=False).render()["kibana"]
+    def test_kibana_with_code_disabled(self):
+        kibana = Kibana(version="7.1.0").render()["kibana"]
         self.assertFalse("XPACK_CODE_UI_ENABLED" in kibana["environment"])
 
 class LogstashServiceTest(ServiceTest):


### PR DESCRIPTION
## What does this PR do?

Enable Elastic Code by default when version is +7.2

## Why is it important?

Welcome Code team!! :)

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/596

## Tests

```bash
scripts/compose.py start master
```

![image](https://user-images.githubusercontent.com/2871786/66047340-820abf00-e51f-11e9-9378-b6170c9d2805.png)
