### PR TITLE
Bump dotnet agent version 1.1.1

### DIFF
--- a/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
+++ b/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.1" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
## What does this PR do?

Bump version [1.1.1](https://github.com/elastic/apm-agent-dotnet/releases/tag/1.1.1)

## Why is it important?

Keep up to date

## Related issues
Closes #ISSUE