### PR TITLE
fix: upgrade test

### DIFF
--- a/.ci/scripts/7.0-upgrade.sh
+++ b/.ci/scripts/7.0-upgrade.sh
@@ -2,14 +2,15 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
+# shellcheck source=/dev/null
 . "${srcdir}/common.sh"
 
-export COMPOSE_ARGS="6.6 --force-build --build-parallel \
+export COMPOSE_ARGS="6.6 --release --force-build --build-parallel \
   --no-apm-server-dashboards --no-apm-server-self-instrument \
-  --apm-server-count 2 --apm-server-tee --elasticsearch-data-dir '' \
+  --elasticsearch-data-dir '' \
   --no-apm-server-pipeline --all-opbeans --no-kibana\
   --opbeans-dotnet-version=1.1.1\
-  --opbeans-go-agent-branch=v1.5.0\
+  --opbeans-go-agent-branch=1.x\
   --opbeans-java-agent-branch=v1.10.0\
   --opbeans-node-agent-branch=v3.0.0\
   --opbeans-python-agent-branch=v5.2.1\

--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.8
 ENV GO111MODULE=on
 WORKDIR /src/testapp
 COPY . /src/testapp


### PR DESCRIPTION
## What does this PR do?

fix the docker container used for the upgrade test, also it uses a release for the stack

## Why is it important?

the test is broken.

## Related issues
Closes https://github.com/elastic/observability-dev/issues/395
