### PR TITLE
Fix upgrade test

### DIFF
--- a/.ci/scripts/7.0-upgrade.sh
+++ b/.ci/scripts/7.0-upgrade.sh
@@ -2,14 +2,15 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
+# shellcheck source=/dev/null
 . "${srcdir}/common.sh"
 
-export COMPOSE_ARGS="6.6 --force-build --build-parallel \
+export COMPOSE_ARGS="6.6 --release --force-build --build-parallel \
   --no-apm-server-dashboards --no-apm-server-self-instrument \
-  --apm-server-count 2 --apm-server-tee --elasticsearch-data-dir '' \
+  --elasticsearch-data-dir '' \
   --no-apm-server-pipeline --all-opbeans --no-kibana\
   --opbeans-dotnet-version=1.1.1\
-  --opbeans-go-agent-branch=v1.5.0\
+  --opbeans-go-agent-branch=1.x\
   --opbeans-java-agent-branch=v1.10.0\
   --opbeans-node-agent-branch=v3.0.0\
   --opbeans-python-agent-branch=v5.2.1\

--- a/.ci/scripts/7.0-upgrade.sh
+++ b/.ci/scripts/7.0-upgrade.sh
@@ -5,16 +5,19 @@ test -z "$srcdir" && srcdir=.
 # shellcheck source=/dev/null
 . "${srcdir}/common.sh"
 
-export COMPOSE_ARGS="6.6 --release --force-build --build-parallel \
+docker build --build-arg GO_AGENT_BRANCH=v1.5.0 -t localtesting_6.6.2_opbeans-go docker/opbeans/go
+docker build --build-arg JAVA_AGENT_VERSION=v1.10.0 -t localtesting_6.6.2_opbeans-java docker/opbeans/java
+docker build --build-arg PYTHON_AGENT_VERSION=v5.2.1 -t localtesting_6.6.2_opbeans-python docker/opbeans/python
+docker build --build-arg NODE_AGENT_VERSION=v3.0.0 -t localtesting_6.6.2_opbeans-node docker/opbeans/node
+docker build --build-arg RUBY_AGENT_VERSION=v3.0.0 -t localtesting_6.6.2_opbeans-ruby docker/opbeans/ruby
+docker build --build-arg DOTNET_AGENT_VERSION=1.1.1 -t localtesting_6.6.2_opbeans-dotnet docker/opbeans/dotnet
+
+export REUSE_CONTAINERS="true"
+export COMPOSE_ARGS="6.6 --release \
   --no-apm-server-dashboards --no-apm-server-self-instrument \
   --elasticsearch-data-dir '' \
-  --no-apm-server-pipeline --all-opbeans --no-kibana\
-  --opbeans-dotnet-version=1.1.1\
-  --opbeans-go-agent-branch=1.x\
-  --opbeans-java-agent-branch=v1.10.0\
-  --opbeans-node-agent-branch=v3.0.0\
-  --opbeans-python-agent-branch=v5.2.1\
-  --opbeans-ruby-agent-branch=v3.0.0"
+  --no-apm-server-pipeline --all-opbeans --no-kibana"
+
 make start-env docker-compose-wait
 
 # let opbeans apps generate some data

--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.8
 ENV GO111MODULE=on
 WORKDIR /src/testapp
 COPY . /src/testapp

--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -2,7 +2,7 @@
 #
 # GO_AGENT_REPO and GO_AGENT_BRANCH parameterise the Go agent
 # repo and branch (or commit) to use.
-FROM golang:latest
+FROM golang:1.8
 ENV GO111MODULE=on
 WORKDIR /src/opbeans-go
 RUN git clone https://github.com/elastic/opbeans-go.git .
@@ -10,7 +10,8 @@ RUN rm -fr vendor/go.elastic.co/apm
 ARG GO_AGENT_REPO=elastic/apm-agent-go
 ARG GO_AGENT_BRANCH=master
 # adding this file will invalidate the layer cache when the branch head changes
-ADD https://api.github.com/repos/${GO_AGENT_REPO}/git/refs/heads/${GO_AGENT_BRANCH} version.json
+# it does not work with TAGs
+#ADD https://api.github.com/repos/${GO_AGENT_REPO}/git/refs/heads/${GO_AGENT_BRANCH} version.json
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/go.elastic.co/apm
 RUN (cd /src/go.elastic.co/apm && git checkout ${GO_AGENT_BRANCH})
 # Add "replace" stanzas to go.mod to use the local agent repo
@@ -19,7 +20,7 @@ RUN go build
 
 # Stage 1: copy static assets from opbeans/opbeans-frontend and
 # opbeans-go from stage 0 into a minimal image.
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base-debian10
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
 COPY --from=0 /src/opbeans-go/opbeans-go /
 COPY --from=0 /src/opbeans-go/db /


### PR DESCRIPTION
## What does this PR do?

it changes to build a fixed version of the APM agents because compose does not support to pass the version to Opbeans, the script builds the images manually. Fix the Opbeans Go that does not start due to https://github.com/GoogleContainerTools/distroless/issues/390

## Why is it important?

The test is still broken.

## Related issues
Closes https://github.com/elastic/observability-dev/issues/395
