### PR TITLE
lighter docker image for the obpeans-ruby

### DIFF
--- a/docker/opbeans/ruby/Dockerfile
+++ b/docker/opbeans/ruby/Dockerfile
@@ -5,4 +5,4 @@ FROM ${OPBEANS_RUBY_IMAGE}:${OPBEANS_RUBY_VERSION}
 COPY entrypoint.sh /app/entrypoint.sh
 
 CMD ["bin/boot"]
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/opbeans/ruby/entrypoint.sh
+++ b/docker/opbeans/ruby/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -e
+set -ex
 if [ -f /local-install/Gemfile ]; then
     echo "Installing from local folder"
     # copy to folder inside container to ensure were not poluting the local folder
@@ -13,6 +13,8 @@ elif [ -n "${RUBY_AGENT_BRANCH}" ]; then
     if [ -z "${RUBY_AGENT_REPO}" ]; then
         RUBY_AGENT_REPO="elastic/apm-agent-ruby"
     fi
+    # This is required with the alpine version
+    apk --no-cache add git
     echo "Installing ${RUBY_AGENT_REPO}:${RUBY_AGENT_BRANCH} from Github"
     gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b "${RUBY_AGENT_BRANCH}"
 else

--- a/docker/opbeans/ruby/entrypoint.sh
+++ b/docker/opbeans/ruby/entrypoint.sh
@@ -1,19 +1,20 @@
-#!/bin/bash -e
-if [[ -f /local-install/Gemfile ]]; then
+#!/usr/bin/env sh
+set -e
+if [ -f /local-install/Gemfile ]; then
     echo "Installing from local folder"
     # copy to folder inside container to ensure were not poluting the local folder
     cp -r /local-install ~
     cd ~/local-install && bundle
     cd -
-elif [[ $RUBY_AGENT_VERSION ]]; then
-    gem install elastic-apm -v $RUBY_AGENT_VERSION
-elif [[ $RUBY_AGENT_BRANCH ]]; then
+elif [ -n "${RUBY_AGENT_VERSION}" ]; then
+    gem install elastic-apm -v "${RUBY_AGENT_VERSION}"
+elif [ -n "${RUBY_AGENT_BRANCH}" ]; then
     gem install specific_install
-    if [[ -z ${RUBY_AGENT_REPO} ]]; then
+    if [ -z "${RUBY_AGENT_REPO}" ]; then
         RUBY_AGENT_REPO="elastic/apm-agent-ruby"
     fi
     echo "Installing ${RUBY_AGENT_REPO}:${RUBY_AGENT_BRANCH} from Github"
-    gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b $RUBY_AGENT_BRANCH
+    gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b "${RUBY_AGENT_BRANCH}"
 else
     gem install elastic-apm
 fi

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -87,6 +87,16 @@ def curl_healthcheck(port, host="localhost", path="/healthcheck",
     }
 
 
+def wget_healthcheck(port, host="localhost", path="/healthcheck",
+                     interval=DEFAULT_HEALTHCHECK_INTERVAL, retries=DEFAULT_HEALTHCHECK_RETRIES):
+    return {
+        "interval": interval,
+        "retries": retries,
+        "test": ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null",
+                 "http://{}:{}{}".format(host, port, path)]
+    }
+
+
 build_manifests = {}  # version -> manifest cache
 
 

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -4,7 +4,7 @@
 
 from collections import OrderedDict
 
-from .helpers import add_agent_environment, curl_healthcheck
+from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck
 from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_JS_SERVER_URL
 
 
@@ -589,7 +589,7 @@ class OpbeansRuby(OpbeansService):
             image=None,
             labels=None,
             # lots of retries as the ruby app can take a long time to boot
-            healthcheck=curl_healthcheck(3000, "opbeans-ruby", path="/", retries=50),
+            healthcheck=wget_healthcheck(3000, "opbeans-ruby", path="/", retries=50),
             ports=[self.publish_port(self.port, 3000)],
         )
         if self.agent_local_repo:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -429,7 +429,7 @@ class OpbeansServiceTest(ServiceTest):
                       apm-server:
                         condition: service_healthy
                     healthcheck:
-                      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-ruby:3000/"]
+                      test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-ruby:3000/"]
                       interval: 10s
                       retries: 50""")  # noqa: 501
         )


### PR DESCRIPTION
## What does this PR do?

https://github.com/elastic/opbeans-ruby/pull/18 reduces the docker image size by using the alpine docker image, for such it's required to use the sh shell rather than bash.

## Why is it important?

Lighter docker images mean faster builds :)

## Test cases
- Build local opbeans-ruby

```
~/work/src/github.com/elastic/opbeans-ruby
± |feature/55 → origin ✓| → docker build . --tag opbeans/opbeans-ruby:latest
```

- Default 
```
 scripts/compose.py start master --with-opbeans-ruby --skip-pull
Successfully built 5cd18e32ccb4
Successfully tagged apm-integration-testing_opbeans-ruby:latest

CONTAINER ID        IMAGE                                                          COMMAND                  CREATED             STATUS                    PORTS                                                NAMES
53b5b50d99e0        opbeans/opbeans-loadgen:latest                                 "/bin/bash /app/entr…"   20 seconds ago      Up 18 seconds                                                                  localtesting_8.0.0_opbeans-load-generator
2642a6c11ca0        apm-integration-testing_opbeans-ruby                           "/app/entrypoint.sh …"   42 seconds ago      Up 41 seconds (healthy)   127.0.0.1:3001->3000/tcp                             localtesting_latest_opbeans-ruby
a069ea178e56        docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT                "/usr/local/bin/dock…"   22 minutes ago      Up 22 minutes (healthy)   127.0.0.1:6060->6060/tcp, 127.0.0.1:8200->8200/tcp   localtesting_8.0.0_apm-server
01cf1620e6a4        docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT                 "/usr/local/bin/dumb…"   23 minutes ago      Up 23 minutes (healthy)   127.0.0.1:5601->5601/tcp                             localtesting_8.0.0_kibana
a3a111d34778        docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT   "/usr/local/bin/dock…"   23 minutes ago      Up 23 minutes (healthy)   127.0.0.1:9200->9200/tcp, 9300/tcp                   localtesting_8.0.0_elasticsearch
0ac2a5912b25        postgres:10                                                    "docker-entrypoint.s…"   23 minutes ago      Up 23 minutes (healthy)   0.0.0.0:5432->5432/tcp                               localtesting_8.0.0_postgres
3e35e18592d9        redis:4                                                        "docker-entrypoint.s…"   23 minutes ago      Up 23 minutes (healthy)   0.0.0.0:6379->6379/tcp                               localtesting_8.0.0_redis
```

```
docker logs localtesting_latest_opbeans-ruby

15:12:09 web.1  | I, [2019-10-17T15:12:08.058354 #47]  INFO -- : [e3a7908a-fbee-4a67-b964-34390d128e64] method=GET path=/api/products format=html controller=Api::ProductsController action=index status=200 duration=5.41 view=4.96 db=0.00
15:12:09 web.1  | I, [2019-10-17T15:12:08.663600 #47]  INFO -- : Proxying /api/products/6/customers to opbeans-ruby
15:12:09 web.1  | I, [2019-10-17T15:12:08.671344 #47]  INFO -- : [b6d78dd2-b428-4d0e-b45d-356a2bc45743] method=GET path=/api/products/6/customers format=html controller=Api::CustomersController action=index status=200 duration=4.53 view=2.29 db=0.00
15:12:09 web.1  | I, [2019-10-17T15:12:09.283462 #47]  INFO -- : [34319541-ff05-40e5-9610-a4c0a59caac6] method=GET path=/api/products format=*/* controller=Api::ProductsController action=index status=200 duration=5.68 view=5.30 db=0.00
````

- With the branch

```
scripts/compose.py start master --with-opbeans-ruby --skip-pull --opbeans-ruby-agent-branch 3.x
Starting stack services..
Successfully tagged apm-integration-testing_opbeans-ruby:latest
Pulling elasticsearch          ... done
Pulling kibana                 ... done
Pulling apm-server             ... done
Pulling postgres               ... done
Pulling redis                  ... done
Pulling opbeans-load-generator ... done
localtesting_8.0.0_elasticsearch is up-to-date
localtesting_8.0.0_postgres is up-to-date
localtesting_8.0.0_redis is up-to-date
localtesting_8.0.0_kibana is up-to-date
localtesting_8.0.0_apm-server is up-to-date
Recreating localtesting_latest_opbeans-ruby ... done
Recreating localtesting_8.0.0_opbeans-load-generator ... done
```

```
docker logs -f localtesting_latest_opbeans-ruby
+ '[' -f /local-install/Gemfile ]
+ '[' -n  ]
+ '[' -n 3.x ]
+ gem install specific_install
Successfully installed specific_install-0.3.5
1 gem installed
+ '[' -z  ]
+ RUBY_AGENT_REPO=elastic/apm-agent-ruby
+ apk --no-cache add git
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/5) Installing nghttp2-libs (1.39.2-r0)
(2/5) Installing libcurl (7.66.0-r0)
(3/5) Installing expat (2.2.8-r0)
(4/5) Installing pcre2 (10.33-r0)
(5/5) Installing git (2.22.0-r0)
Executing busybox-1.30.1-r2.trigger
OK: 227 MiB in 64 packages
Installing elastic/apm-agent-ruby:3.x from Github
+ echo 'Installing elastic/apm-agent-ruby:3.x from Github'
+ gem specific_install https://github.com/elastic/apm-agent-ruby.git -b 3.x
/usr/bin/git
git installing from https://github.com/elastic/apm-agent-ruby.git
Cloning into '/tmp/d20191017-19-gkl9jv'...
Branch '3.x' set up to track remote branch '3.x' from 'origin'.
Switched to a new branch '3.x'
* 3.x

```
## Related issues
Closes #ISSUE