### PR TITLE
lighter docker image for the obpeans-java

### DIFF
--- a/docker/opbeans/java/Dockerfile
+++ b/docker/opbeans/java/Dockerfile
@@ -24,4 +24,4 @@ CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=customdb
                                         -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-org.postgresql.Driver}\
                                         -Dspring.jpa.database=${DATABASE_DIALECT:-POSTGRESQL}\
                                         -jar /app/app.jar
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/opbeans/java/entrypoint.sh
+++ b/docker/opbeans/java/entrypoint.sh
@@ -1,19 +1,22 @@
-#!/bin/bash -e
-if [[ -f /local-install/pom.xml ]]; then
+#!/usr/bin/env sh
+set -ex
+if [ -f /local-install/pom.xml ]; then
     echo "Using Java agent from from local folder"
     rm -f /app/elastic-apm-agent.jar
+    # Install xmllint in the alpine
+    apk --no-cache add libxml2-utils
     #Extract current version without using maven which is not available in this image
     JAVA_AGENT_LOCAL_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' /local-install/pom.xml)
-    
-    cp -v /local-install/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_LOCAL_VERSION}.jar /app/elastic-apm-agent.jar
+
+    cp -v "/local-install/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_LOCAL_VERSION}.jar" /app/elastic-apm-agent.jar
     # copy to folder inside container to ensure were not polluting the local folder
     cp -r /local-install ~
     cd ~/local-install && python setup.py install
     cd -
-elif [[ $JAVA_AGENT_VERSION ]]; then
+elif [ -n "${JAVA_AGENT_VERSION}" ]; then
     echo "Downloading Java agent $JAVA_AGENT_VERSION from maven central"
     rm -f /app/elastic-apm-agent.jar
-    curl -o /app/elastic-apm-agent.jar -L http://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/$JAVA_AGENT_VERSION/elastic-apm-agent-$JAVA_AGENT_VERSION.jar 
+    wget -O /app/elastic-apm-agent.jar -L "http://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/$JAVA_AGENT_VERSION/elastic-apm-agent-$JAVA_AGENT_VERSION.jar"
 else
     echo "Using Java agent from the docker image"
 fi

--- a/docker/opbeans/java/entrypoint.sh
+++ b/docker/opbeans/java/entrypoint.sh
@@ -9,12 +9,6 @@ if [ -f /local-install/pom.xml ]; then
     JAVA_AGENT_LOCAL_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' /local-install/pom.xml)
 
     cp -v "/local-install/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_LOCAL_VERSION}.jar" /app/elastic-apm-agent.jar
-    # copy to folder inside container to ensure were not polluting the local folder
-    cp -r /local-install ~
-    # Install xmllint in the alpine
-    apk --no-cache add python
-    cd ~/local-install && python setup.py install
-    cd -
 elif [ -n "${JAVA_AGENT_VERSION}" ]; then
     echo "Downloading Java agent $JAVA_AGENT_VERSION from maven central"
     rm -f /app/elastic-apm-agent.jar

--- a/docker/opbeans/java/entrypoint.sh
+++ b/docker/opbeans/java/entrypoint.sh
@@ -11,12 +11,14 @@ if [ -f /local-install/pom.xml ]; then
     cp -v "/local-install/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_LOCAL_VERSION}.jar" /app/elastic-apm-agent.jar
     # copy to folder inside container to ensure were not polluting the local folder
     cp -r /local-install ~
+    # Install xmllint in the alpine
+    apk --no-cache add python
     cd ~/local-install && python setup.py install
     cd -
 elif [ -n "${JAVA_AGENT_VERSION}" ]; then
     echo "Downloading Java agent $JAVA_AGENT_VERSION from maven central"
     rm -f /app/elastic-apm-agent.jar
-    wget -O /app/elastic-apm-agent.jar -L "http://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/$JAVA_AGENT_VERSION/elastic-apm-agent-$JAVA_AGENT_VERSION.jar"
+    wget -O /app/elastic-apm-agent.jar "http://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/$JAVA_AGENT_VERSION/elastic-apm-agent-$JAVA_AGENT_VERSION.jar"
 else
     echo "Using Java agent from the docker image"
 fi

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -87,6 +87,16 @@ def curl_healthcheck(port, host="localhost", path="/healthcheck",
     }
 
 
+def wget_healthcheck(port, host="localhost", path="/healthcheck",
+                     interval=DEFAULT_HEALTHCHECK_INTERVAL, retries=DEFAULT_HEALTHCHECK_RETRIES):
+    return {
+        "interval": interval,
+        "retries": retries,
+        "test": ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null",
+                 "http://{}:{}{}".format(host, port, path)]
+    }
+
+
 build_manifests = {}  # version -> manifest cache
 
 

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -4,7 +4,7 @@
 
 from collections import OrderedDict
 
-from .helpers import add_agent_environment, curl_healthcheck
+from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck
 from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_JS_SERVER_URL
 
 
@@ -305,7 +305,7 @@ class OpbeansJava(OpbeansService):
             depends_on=depends_on,
             image=None,
             labels=None,
-            healthcheck=curl_healthcheck(3000, "opbeans-java", path="/", retries=36),
+            healthcheck=wget_healthcheck(3000, "opbeans-java", path="/", retries=36),
             ports=[self.publish_port(self.port, 3000)],
         )
         if self.agent_local_repo:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -208,7 +208,7 @@ class OpbeansServiceTest(ServiceTest):
                       apm-server:
                         condition: service_healthy
                     healthcheck:
-                      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-java:3000/"]
+                      test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-java:3000/"]
                       interval: 10s
                       retries: 36""")  # noqa: 501
         )


### PR DESCRIPTION
## What does this PR do?

https://github.com/elastic/opbeans-java/pull/38 reduces the docker image size by using the alpine docker image, for such it's required to use the sh shell rather than bash.

## Why is it important?

Lighter docker images mean faster builds :) and fixes some issues with a particular use case which apparently has not been used (phew!!) 

## Test cases


- default

```
docker run --rm -ti  opbeans-java-apm:latest
+ '[' -f /local-install/pom.xml ]
+ '[' -n  ]
+ echo 'Using Java agent from the docker image'
Using Java agent from the docker image
+ exec /bin/sh -c 'java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=customdb                                        -Dserver.port=${OPBEANS_SERVER_PORT:-3002}                                        -Dspring.datasource.url=${DATABASE_URL:-jdbc:postgresql://postgres/opbeans?user=postgres&password=verysecure}                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-org.postgresql.Driver}                                        -Dspring.jpa.database=${DATABASE_DIALECT:-POSTGRESQL}                                        -jar /app/app.jar'

```

- When using a local cache agent
```
docker run --rm -ti -v /Users/vmartinez/work/src/github.com/elastic/apm-agent-java:/local-install opbeans-java-apm:latest
+ '[' -f /local-install/pom.xml ]
+ echo 'Using Java agent from from local folder'
Using Java agent from from local folder
+ rm -f /app/elastic-apm-agent.jar
+ apk --no-cache add libxml2-utils
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/2) Installing libxml2 (2.9.9-r1)
(2/2) Installing libxml2-utils (2.9.9-r1)
Executing busybox-1.29.3-r10.trigger
OK: 85 MiB in 55 packages
+ xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' /local-install/pom.xml
+ JAVA_AGENT_LOCAL_VERSION=1.10.1-SNAPSHOT
+ cp -v /local-install/elastic-apm-agent/target/elastic-apm-agent-1.10.1-SNAPSHOT.jar /app/elastic-apm-agent.jar
'/local-install/elastic-apm-agent/target/elastic-apm-agent-1.10.1-SNAPSHOT.jar' -> '/app/elastic-apm-agent.jar'
+ cp -r /local-install /root

```

- When using the JAVA_AGENT_VERSION variable
```
 docker run --rm -ti -e JAVA_AGENT_VERSION=1.10.0 opbeans-java-apm:latest
+ '[' -f /local-install/pom.xml ]
+ '[' -n 1.10.0 ]
+ echo 'Downloading Java agent 1.10.0 from maven central'
Downloading Java agent 1.10.0 from maven central
+ rm -f /app/elastic-apm-agent.jar
+ wget -O /app/elastic-apm-agent.jar http://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.10.0/elastic-apm-agent-1.10.0.jar
Connecting to repo1.maven.org (199.232.56.209:80)
elastic-apm-agent.ja 100% |***************************************************************************************************************************************************************************************************************************************************| 4940k  0:00:00 ETA
+ exec /bin/sh -c 'java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=customdb                                        -Dserver.port=${OPBEANS_SERVER_PORT:-3002}                                        -Dspring.datasource.url=${DATABASE_URL:-jdbc:postgresql://postgres/opbeans?user=postgres&password=verysecure}                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-org.postgresql.Driver}                                        -Dspring.jpa.database=${DATABASE_DIALECT:-POSTGRESQL}                                        -jar /app/app.jar'
2019-10-17 14:28:09.075 [main] INFO co.elastic.apm.agent.configuration.StartupInfo - Starting Elastic APM 1.10.0 as app on Java 1.8.0_212 (IcedTea) Linux 4.9.184-linuxkit
```

- with apm-integration-testing

```
 scripts/compose.py start master --with-opbeans-java --opbeans-java-agent-local-repo /Users/vmartinez/work/src/github.com/elastic/apm-agent-java --skip-pull
Successfully built 6762d018c3e0
Successfully tagged apm-integration-testing_opbeans-java:latest
Pulling elasticsearch          ... done
Pulling kibana                 ... done
Pulling apm-server             ... done
Pulling postgres               ... done
Pulling opbeans-load-generator ... done
Pulling redis                  ... done
localtesting_8.0.0_redis is up-to-date
localtesting_8.0.0_elasticsearch is up-to-date
localtesting_8.0.0_postgres is up-to-date
localtesting_8.0.0_kibana is up-to-date
localtesting_8.0.0_apm-server is up-to-date
Recreating localtesting_latest_opbeans-java ... done
Creating localtesting_8.0.0_opbeans-load-generator ... done

CONTAINER ID        IMAGE                                                          COMMAND                  CREATED              STATUS                        PORTS                                                NAMES
fa4fa57f35f0        opbeans/opbeans-loadgen:latest                                 "/bin/bash /app/entr…"   50 seconds ago       Up 49 seconds                                                                      localtesting_8.0.0_opbeans-load-generator
b11dd2903b51        apm-integration-testing_opbeans-java                           "/app/entrypoint.sh …"   About a minute ago   Up About a minute (healthy)   127.0.0.1:3002->3000/tcp                             localtesting_latest_opbeans-java
a069ea178e56        docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT                "/usr/local/bin/dock…"   8 minutes ago        Up 8 minutes (healthy)        127.0.0.1:6060->6060/tcp, 127.0.0.1:8200->8200/tcp   localtesting_8.0.0_apm-server
01cf1620e6a4        docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT                 "/usr/local/bin/dumb…"   8 minutes ago        Up 8 minutes (healthy)        127.0.0.1:5601->5601/tcp                             localtesting_8.0.0_kibana
a3a111d34778        docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT   "/usr/local/bin/dock…"   9 minutes ago        Up 9 minutes (healthy)        127.0.0.1:9200->9200/tcp, 9300/tcp                   localtesting_8.0.0_elasticsearch
0ac2a5912b25        postgres:10                                                    "docker-entrypoint.s…"   9 minutes ago        Up 9 minutes (healthy)        0.0.0.0:5432->5432/tcp                               localtesting_8.0.0_postgres
3e35e18592d9        redis:4                                                        "docker-entrypoint.s…"   9 minutes ago        Up 9 minutes (healthy)        0.0.0.0:6379->6379/tcp                               localtesting_8.0.0_redis
```

## Fixes
- With local repo

```
## cd opbeans-java
docker build . --tag opbeans/opbeans-java:latest
...
## cd apm-integration-testing
scripts/compose.py start master --with-opbeans-java --opbeans-java-agent-local-repo /Users/vmartinez/work/src/github.com/elastic/apm-agent-java --skip-pull

docker logs localtesting_latest_opbeans-java
...
OK: 132 MiB in 62 packages
+ cd /root/local-install
+ python setup.py install
python: can't open file 'setup.py': [Errno 2] No such file or directory


```
## Related issues
Closes #ISSUE