### PR TITLE
enhance: add API Key support

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -1,29 +1,30 @@
+---
 apm_server:
-  cluster: ['manage_ilm','manage_security','manage_api_key']
+  cluster: ['manage_ilm', 'manage_security', 'manage_api_key']
   indices:
     - names: ['apm-*']
-      privileges: ['write','create_index','manage','manage_ilm']
+      privileges: ['write', 'create_index', 'manage', 'manage_ilm']
   applications:
     - application: 'apm-backend'
-      privileges: ['action:access','action:intake','action:sourcemap','action:config','action:full']
+      privileges: ['action:access', 'action:intake', 'action:sourcemap', 'action:config', 'action:full']
       resources: '*'
 beats:
-  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
-    - names: ['filebeat-*','shrink-filebeat-*']
+    - names: ['filebeat-*', 'shrink-filebeat-*']
       privileges: ['all']
 filebeat:
-  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
-    - names: ['filebeat-*','shrink-filebeat-*']
+    - names: ['filebeat-*', 'shrink-filebeat-*']
       privileges: ['all']
 heartbeat:
-  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
-    - names: ['heartbeat-*','shrink-heartbeat-*']
+    - names: ['heartbeat-*', 'shrink-heartbeat-*']
       privileges: ['all']
 metricbeat:
-  cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
-    - names: ['metricbeat-*','shrink-metricbeat-*']
+    - names: ['metricbeat-*', 'shrink-metricbeat-*']
       privileges: ['all']

--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -1,8 +1,12 @@
 apm_server:
-  cluster: ["manage_ilm"]
+  cluster: ['manage_ilm','manage_security','manage_api_key']
   indices:
     - names: ['apm-*']
       privileges: ['write','create_index','manage','manage_ilm']
+  applications:
+    - application: 'apm-backend'
+      privileges: ['action:access','action:intake','action:sourcemap','action:config','action:full']
+      resources: '*'
 beats:
   cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
   indices:

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -476,6 +476,10 @@ class Elasticsearch(StackService, Service):
                     self.environment.append("xpack.security.authc.realms.file1.type=file")
                     self.environment.append("xpack.security.authc.realms.native1.type=native")
                     self.environment.append("xpack.security.authc.realms.native1.order=1")
+                if self.at_least_version("7.3"):
+                    self.environment.append("xpack.security.transport.ssl.verification_mode=none")
+                    self.environment.append("xpack.security.authc.token.enabled=true")
+                    self.environment.append("xpack.security.authc.api_key.enabled=true")
             self.environment.append("xpack.security.enabled=" + xpack_security_enabled)
             self.environment.append("xpack.license.self_generated.type=trial")
             if self.at_least_version("6.3"):


### PR DESCRIPTION
Enable API Key usage in ES security config and add cluster and apm
application privileges to apm_system_user for testing with API Keys.

cc @graphaelli 