### PR TITLE
lighter docker image for the obpeans-node

### DIFF
--- a/docker/opbeans/node/Dockerfile
+++ b/docker/opbeans/node/Dockerfile
@@ -5,4 +5,4 @@ FROM ${OPBEANS_NODE_IMAGE}:${OPBEANS_NODE_VERSION}
 COPY entrypoint.sh /app/entrypoint.sh
 
 CMD ["pm2-runtime", "ecosystem-workload.config.js"]
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/opbeans/node/entrypoint.sh
+++ b/docker/opbeans/node/entrypoint.sh
@@ -1,24 +1,22 @@
-#!/bin/bash -e
-
-set -x
-
-if [[ -f /local-install/package.json ]]; then
+#!/usr/bin/env sh
+set -ex
+if [ -f /local-install/package.json ]; then
     echo "Installing from local folder"
     # copy to folder inside container to ensure were not poluting the local folder
     cp -r /local-install ~
     cd ~/local-install && npm install .
     cd -
-elif [[ $NODE_AGENT_VERSION ]]; then
+elif [ -n "${NODE_AGENT_VERSION}" ]; then
     echo "Installing ${NODE_AGENT_VERSION} from npm"
     npm install elastic-apm-node@"${NODE_AGENT_VERSION}"
-elif [[ $NODE_AGENT_BRANCH ]]; then
-    if [[ -z ${NODE_AGENT_REPO} ]]; then
+elif [ -n "${NODE_AGENT_BRANCH}" ]; then
+    if [ -z "${NODE_AGENT_REPO}" ]; then
         NODE_AGENT_REPO="elastic/apm-agent-nodejs"
     fi
     echo "Installing ${NODE_AGENT_REPO}:${NODE_AGENT_BRANCH} from Github"
-    npm install https://github.com/${NODE_AGENT_REPO}/archive/${NODE_AGENT_BRANCH}.tar.gz
+    npm install "https://github.com/${NODE_AGENT_REPO}/archive/${NODE_AGENT_BRANCH}.tar.gz"
 fi
-if [[ -f /sourcemaps/README.md ]]; then
+if [ -f /sourcemaps/README.md ]; then
     rm -f /sourcemaps/*.map
     cp -f ./client/build/static/js/*.map /sourcemaps/
     chmod 0666 /sourcemaps/*.map

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -87,6 +87,16 @@ def curl_healthcheck(port, host="localhost", path="/healthcheck",
     }
 
 
+def wget_healthcheck(port, host="localhost", path="/healthcheck",
+                     interval=DEFAULT_HEALTHCHECK_INTERVAL, retries=DEFAULT_HEALTHCHECK_RETRIES):
+    return {
+        "interval": interval,
+        "retries": retries,
+        "test": ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null",
+                 "http://{}:{}{}".format(host, port, path)]
+    }
+
+
 build_manifests = {}  # version -> manifest cache
 
 

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -4,7 +4,7 @@
 
 from collections import OrderedDict
 
-from .helpers import add_agent_environment, curl_healthcheck
+from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck
 from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_JS_SERVER_URL
 
 
@@ -398,7 +398,7 @@ class OpbeansNode(OpbeansService):
             depends_on=depends_on,
             image=None,
             labels=None,
-            healthcheck=curl_healthcheck(3000, "opbeans-node", path="/"),
+            healthcheck=wget_healthcheck(3000, "opbeans-node", path="/"),
             ports=[self.publish_port(self.port, 3000)],
             volumes=[
                 "./docker/opbeans/node/sourcemaps:/sourcemaps",

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -273,7 +273,7 @@ class OpbeansServiceTest(ServiceTest):
                         apm-server:
                             condition: service_healthy
                     healthcheck:
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-node:3000/"]
+                        test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-node:3000/"]
                         interval: 10s
                         retries: 12
                     volumes:


### PR DESCRIPTION
## What does this PR do?

https://github.com/elastic/opbeans-node/pull/63 reduces the docker image size by using the alpine docker image, for such, it's required to use the sh shell rather than bash.

## Why is it important?

Lighter docker images mean faster builds :)

## Test cases
- default
```
scripts/compose.py start master --with-opbeans-node --skip-pull 
Starting stack services..

Successfully tagged apm-integration-testing_opbeans-node:latest
Pulling elasticsearch          ... done
Pulling kibana                 ... done
Pulling apm-server             ... done
Pulling opbeans-load-generator ... done
Pulling postgres               ... done
Pulling redis                  ... done
Creating network "apm-integration-testing" with the default driver
Creating volume "apm-integration-testing_esdata" with local driver
Creating volume "apm-integration-testing_pgdata" with local driver
Creating localtesting_8.0.0_redis                  ... done
Creating localtesting_8.0.0_elasticsearch          ... done
Creating localtesting_8.0.0_postgres               ... done
Creating localtesting_8.0.0_opbeans-load-generator ... done
Creating localtesting_8.0.0_kibana                 ... done
Creating localtesting_8.0.0_apm-server             ... done
Creating localtesting_latest_opbeans-node          ... done

docker ps 
CONTAINER ID        IMAGE                                                          COMMAND                  CREATED             STATUS                   PORTS                                                NAMES
b33f96ae846d        apm-integration-testing_opbeans-node                           "/app/entrypoint.sh …"   2 minutes ago       Up 2 minutes (healthy)   127.0.0.1:3000->3000/tcp                             localtesting_latest_opbeans-node
a6c22b526c62        docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT                "/usr/local/bin/dock…"   2 minutes ago       Up 2 minutes (healthy)   127.0.0.1:6060->6060/tcp, 127.0.0.1:8200->8200/tcp   localtesting_8.0.0_apm-server
ff994621c907        docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT                 "/usr/local/bin/dumb…"   2 minutes ago       Up 2 minutes (healthy)   127.0.0.1:5601->5601/tcp                             localtesting_8.0.0_kibana
c561db2187a2        docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT   "/usr/local/bin/dock…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:9200->9200/tcp, 9300/tcp                   localtesting_8.0.0_elasticsearch
191495d52469        postgres:10                                                    "docker-entrypoint.s…"   3 minutes ago       Up 3 minutes (healthy)   0.0.0.0:5432->5432/tcp                               localtesting_8.0.0_postgres
755a7b9235b5        redis:4                                                        "docker-entrypoint.s…"   3 minutes ago       Up 3 minutes (healthy)   0.0.0.0:6379->6379/tcp                               localtesting_8.0.0_redis
```

- With opbeans-node-branch

```
scripts/compose.py start master --with-opbeans-node --skip-pull  --opbeans-node-agent-branch opbeat

docker logs -f localtesting_latest_opbeans-node
+ '[' -f /local-install/package.json ]
+ '[' -n  ]
+ '[' -n opbeat ]
+ '[' -z  ]
+ NODE_AGENT_REPO=elastic/apm-agent-nodejs
+ echo 'Installing elastic/apm-agent-nodejs:opbeat from Github'
+ npm install https://github.com/elastic/apm-agent-nodejs/archive/opbeat.tar.gz
Installing elastic/apm-agent-nodejs:opbeat from Github


```