### PR TITLE
lighter docker image for the obpeans-dotnet

### DIFF
--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -12,10 +12,7 @@ COPY . /src
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app
-## Alpine image produces a segmentation fault:
-##        further details: https://github.com/aspnet/EntityFrameworkCore/issues/14504
-## FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=build /src/aspnetcore/build ./
 EXPOSE 8100

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -15,5 +15,8 @@ RUN ./run.sh
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=build /src/aspnetcore/build ./
+RUN apk update \
+    && apk add --no-cache curl \
+    && rm -rf /var/cache/apk/*
 EXPOSE 8100
 ENTRYPOINT ["dotnet", "TestAspNetCoreApp.dll", "--urls=http://0.0.0.0:8100"]

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -15,10 +15,7 @@ COPY . /src
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app
-## Alpine image produces a segmentation fault:
-##        further details: https://github.com/aspnet/EntityFrameworkCore/issues/14504
-## FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=opbeans-dotnet /src/opbeans-dotnet/opbeans-dotnet/build ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -19,5 +19,8 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=opbeans-dotnet /src/opbeans-dotnet/opbeans-dotnet/build ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
+RUN apk update \
+    && apk add --no-cache curl \
+    && rm -rf /var/cache/apk/*
 EXPOSE 80
 ENTRYPOINT ["dotnet", "opbeans-dotnet.dll"]


### PR DESCRIPTION
## What does this PR do?

https://github.com/elastic/opbeans-dotnet/pull/18 reduces the docker image size by using the alpine docker image

## Why is it important?

Lighter docker images mean faster builds :)

## Test cases
- default
```
scripts/compose.py start master --with-opbeans-dotnet --with-agent-dotnet --skip-pull
...

Successfully tagged apm-integration-testing_opbeans-dotnet:latest
Pulling elasticsearch          ... done
Pulling kibana                 ... done
Pulling apm-server             ... done
Pulling opbeans-load-generator ... done
Pulling postgres               ... done
Pulling redis                  ... done
localtesting_8.0.0_postgres is up-to-date
localtesting_8.0.0_redis is up-to-date
localtesting_8.0.0_elasticsearch is up-to-date
localtesting_8.0.0_kibana is up-to-date
localtesting_8.0.0_apm-server is up-to-date
Recreating localtesting_8.0.0_opbeans-dotnet ... done
Creating dotnetapp                           ... done
Recreating localtesting_8.0.0_opbeans-load-generator ... done
```

```
docker ps
CONTAINER ID        IMAGE                                                          COMMAND                  CREATED             STATUS                            PORTS                                                NAMES
71086e8166b5        apm-integration-testing_opbeans-dotnet                         "dotnet opbeans-dotn…"   11 seconds ago      Up 9 seconds (health: starting)   127.0.0.1:3004->80/tcp                               localtesting_8.0.0_opbeans-dotnet
2afdf091b7d9        apm-integration-testing_agent-dotnet                           "dotnet TestAspNetCo…"   11 seconds ago      Up 11 seconds (healthy)           127.0.0.1:8100->8100/tcp                             dotnetapp
a6c22b526c62        docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT                "/usr/local/bin/dock…"   32 minutes ago      Up 32 minutes (healthy)           127.0.0.1:6060->6060/tcp, 127.0.0.1:8200->8200/tcp   localtesting_8.0.0_apm-server
ff994621c907        docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT                 "/usr/local/bin/dumb…"   32 minutes ago      Up 32 minutes (healthy)           127.0.0.1:5601->5601/tcp                             localtesting_8.0.0_kibana
c561db2187a2        docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT   "/usr/local/bin/dock…"   33 minutes ago      Up 33 minutes (healthy)           127.0.0.1:9200->9200/tcp, 9300/tcp                   localtesting_8.0.0_elasticsearch
191495d52469        postgres:10                                                    "docker-entrypoint.s…"   33 minutes ago      Up 33 minutes (healthy)           0.0.0.0:5432->5432/tcp                               localtesting_8.0.0_postgres
755a7b9235b5        redis:4                                                        "docker-entrypoint.s…"   33 minutes ago      Up 33 minutes (healthy)           0.0.0.0:6379->6379/tcp                               localtesting_8.0.0_redis
```