### PR TITLE
fix: incorrect Go version on Dockerfile

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.11
 ENV GO111MODULE=on
 WORKDIR /src/testapp
 COPY . /src/testapp


### PR DESCRIPTION
## What does this PR do?

Use a Golang 1.11 Docker container as a base.

## Why is it important?

The use of 1.8 causes a fail building the container

```
[2019-10-18T10:22:33.044Z] Step 9/16 : RUN CGO_ENABLED=0 go build
[2019-10-18T10:22:33.044Z]  ---> Running in 914aa9b2f422
[2019-10-18T10:22:33.985Z] main.go:6:2: cannot find package "go.elastic.co/apm" in any of:
[2019-10-18T10:22:33.985Z] 	/usr/local/go/src/go.elastic.co/apm (from $GOROOT)
[2019-10-18T10:22:33.985Z] 	/go/src/go.elastic.co/apm (from $GOPATH)
[2019-10-18T10:22:33.985Z] main.go:7:2: cannot find package "go.elastic.co/apm/module/apmhttp" in any of:
[2019-10-18T10:22:33.985Z] 	/usr/local/go/src/go.elastic.co/apm/module/apmhttp (from $GOROOT)
[2019-10-18T10:22:33.985Z] 	/go/src/go.elastic.co/apm/module/apmhttp (from $GOPATH)
[2019-10-18T10:22:34.245Z] Service 'agent-go-net-http' failed to build: The command '/bin/sh -c CGO_ENABLED=0 go build' returned a non-zero code: 1
[2019-10-18T10:22:34.245Z] Makefile:30: recipe for target 'start-env' failed
[2019-10-18T10:22:34.245Z] make[1]: *** [start-env] Error 1
[2019-10-18T10:22:34.245Z] make[1]: Leaving directory '/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing'
[2019-10-18T10:22:34.245Z] Makefile:41: recipe for target 'env-agent-all' failed
[2019-10-18T10:22:34.245Z] make: *** [env-agent-all] Error 2
```

