### PR TITLE
add bash to customized opbeans-ruby image, as it is used for the entrypoint

### DIFF
--- a/docker/opbeans/ruby/Dockerfile
+++ b/docker/opbeans/ruby/Dockerfile
@@ -2,6 +2,8 @@ ARG OPBEANS_RUBY_IMAGE=opbeans/opbeans-ruby
 ARG OPBEANS_RUBY_VERSION=latest
 FROM ${OPBEANS_RUBY_IMAGE}:${OPBEANS_RUBY_VERSION}
 
+RUN apk add --update bash && rm -rf /var/cache/apk/*
+
 COPY entrypoint.sh /app/entrypoint.sh
 
 CMD ["bin/boot"]


### PR DESCRIPTION
the [recent](https://github.com/elastic/opbeans-ruby/pull/18) switch to alpine in the base image makes this necessary