### PR TITLE
Start Kibana when running the Python agent test only.

### DIFF
--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -14,6 +14,6 @@ if [ -n "${APM_AGENT_PYTHON_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} --python-agent-package='${APM_AGENT_PYTHON_VERSION}'"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-python-django --with-agent-python-flask --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-python-django --with-agent-python-flask --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-python docker-test-agent-python

--- a/tests/agent/__init__.py
+++ b/tests/agent/__init__.py
@@ -17,6 +17,7 @@ def remote_config(kibana_url, sampling_rate=1.0):
 
     headers = {"Content-Type": "application/json", "kbn-xsrf": "1"}
     wait = 1.5  # just higher than apm-server.agent.config.cache.expiration
+    config_id = ""
 
     try:
         r = requests.post(
@@ -31,6 +32,8 @@ def remote_config(kibana_url, sampling_rate=1.0):
         yield config_id
 
     finally:
+        if config_id == "":
+            return
         # revert to original
         r2 = requests.put(
             urljoin(kibana_url, "/api/apm/settings/agent-configuration/" + config_id),


### PR DESCRIPTION
Also initialize config_id properly.

Follow up of #641 with a bug fix.

This wasn't caught in the original PR because the agent-only test doesn't run in PRs