### PR TITLE
Remove python agent 4.2 tests.

### DIFF
--- a/tests/versions/python.yml
+++ b/tests/versions/python.yml
@@ -5,4 +5,3 @@ PYTHON_AGENT:
   - 'github;master'
   - 'release;latest'
   - 'release;5.1'
-  - 'release;4.2'


### PR DESCRIPTION
This is so because agent config is only implemented in python agent 5.
There will be no more work on the 4.2 branch, and that one is still tested
against apm-server 7.x, so it is OK to remove here.
Full e2e testing of agent config in apm-server/kibana master (8.0) is good enough
for now.

Follow up to #641 