### PR TITLE
feat: allow to disable loadgen

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -204,6 +204,13 @@ class LocalSetup(object):
                 )
             service.add_arguments(parser)
 
+        enabled_group.add_argument(
+            '--no-opbeans-load-generator',
+            action='store_false',
+            dest='enable_opbeans_load_generator',
+            help='Disable opbeans-load-generator'
+        )
+
         parser.add_argument(
             '--opbeans-dt-probability',
             action="store",
@@ -481,10 +488,13 @@ class LocalSetup(object):
         run_all = args.get("run_all")
         all_opbeans = args.get('run_all_opbeans') or run_all
         any_opbeans = all_opbeans or any(v and k.startswith('enable_opbeans_') for k, v in args.items())
+        opbeans_sidecars = ['postgres', 'redis', 'opbeans-load-generator']
+        if not args.get("enable_opbeans_load_generator"):
+            opbeans_sidecars.remove('opbeans-load-generator')
         for service in self.services:
             service_enabled = args.get("enable_" + service.option_name())
             is_opbeans_service = issubclass(service, OpbeansService) or service is OpbeansRum
-            is_opbeans_sidecar = service.name() in ('postgres', 'redis', 'opbeans-load-generator')
+            is_opbeans_sidecar = service.name() in opbeans_sidecars
             is_opbeans_2nd = service.name() in ('opbeans-go01', 'opbeans-java01',
                                                 'opbeans-python01', 'opbeans-ruby01',
                                                 'opbeans-dotnet01', 'opbeans-node01')

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -8,6 +8,7 @@ import logging
 import os
 import subprocess
 import sys
+import re
 
 from .beats import BeatMixin
 from .helpers import load_images
@@ -206,8 +207,8 @@ class LocalSetup(object):
 
         enabled_group.add_argument(
             '--no-opbeans-load-generator',
-            action='store_false',
-            dest='enable_opbeans_load_generator',
+            action='store_true',
+            dest='disable_opbeans_load_generator',
             help='Disable opbeans-load-generator',
             default=False,
         )
@@ -488,22 +489,21 @@ class LocalSetup(object):
         selections = set()
         run_all = args.get("run_all")
         all_opbeans = args.get('run_all_opbeans') or run_all
-        any_opbeans = all_opbeans or any(v and k.startswith('enable_opbeans_') and
-                                         not k.startswith('enable_opbeans_load_generator') for k, v in args.items())
+        any_opbeans = all_opbeans or any(v and k.startswith('enable_opbeans_') for k, v in args.items())
         opbeans_sidecars = ['postgres', 'redis', 'opbeans-load-generator']
-        if not args.get("enable_opbeans_load_generator"):
-            opbeans_sidecars.remove('opbeans-load-generator')
+        opbeans_2nds = ('opbeans-go01', 'opbeans-java01', 'opbeans-python01', 'opbeans-ruby01', 'opbeans-dotnet01',
+                        'opbeans-node01')
         for service in self.services:
             service_enabled = args.get("enable_" + service.option_name())
             is_opbeans_service = issubclass(service, OpbeansService) or service is OpbeansRum
             is_opbeans_sidecar = service.name() in opbeans_sidecars
-            is_opbeans_2nd = service.name() in ('opbeans-go01', 'opbeans-java01',
-                                                'opbeans-python01', 'opbeans-ruby01',
-                                                'opbeans-dotnet01', 'opbeans-node01')
+            is_opbeans_2nd = service.name() in opbeans_2nds
             is_obs = issubclass(service, BeatMixin)
-            if service_enabled or (all_opbeans and is_opbeans_service and not is_opbeans_2nd) \
-                    or (any_opbeans and is_opbeans_sidecar and not is_opbeans_2nd) or \
-                    (run_all and is_obs and not is_opbeans_2nd):
+            if (service_enabled
+                or (all_opbeans and is_opbeans_service and not is_opbeans_2nd)
+                or (any_opbeans and is_opbeans_sidecar and not is_opbeans_2nd)
+                or (run_all and is_obs and not is_opbeans_2nd)
+            ):
                 selections.add(service(**args))
 
         # `docker load` images if necessary, usually only for build candidates
@@ -534,6 +534,12 @@ class LocalSetup(object):
                 services[s]["environment"]["OPBEANS_SERVICES"] = enabled_opbeans_services_str
             else:
                 services[s]["environment"].append("OPBEANS_SERVICES=" + enabled_opbeans_services_str)
+
+        loadgen = services.get("opbeans-load-generator")
+        if not loadgen is None:
+            enabled_opbeans = any(re.search('OPBEANS_URLS=.+',v) for v in loadgen["environment"])
+            if args.get("disable_opbeans_load_generator") or not enabled_opbeans:
+                del services["opbeans-load-generator"]
 
         compose = dict(
             version="2.1",

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -208,7 +208,8 @@ class LocalSetup(object):
             '--no-opbeans-load-generator',
             action='store_false',
             dest='enable_opbeans_load_generator',
-            help='Disable opbeans-load-generator'
+            help='Disable opbeans-load-generator',
+            default=False,
         )
 
         parser.add_argument(
@@ -487,7 +488,8 @@ class LocalSetup(object):
         selections = set()
         run_all = args.get("run_all")
         all_opbeans = args.get('run_all_opbeans') or run_all
-        any_opbeans = all_opbeans or any(v and k.startswith('enable_opbeans_') for k, v in args.items())
+        any_opbeans = all_opbeans or any(v and k.startswith('enable_opbeans_') and
+                                         not k.startswith('enable_opbeans_load_generator') for k, v in args.items())
         opbeans_sidecars = ['postgres', 'redis', 'opbeans-load-generator']
         if not args.get("enable_opbeans_load_generator"):
             opbeans_sidecars.remove('opbeans-load-generator')

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -979,7 +979,7 @@ class LocalTest(unittest.TestCase):
     def test_start_one_opbeans(self, _ignore_load_images):
         docker_compose_yml = stringIO()
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["master", "--with-opbeans-node"])
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--with-opbeans-python"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -987,6 +987,37 @@ class LocalTest(unittest.TestCase):
         services = got["services"]
         self.assertIn("redis", services)
         self.assertIn("postgres", services)
+        self.assertIn("opbeans-load-generator", services)
+
+    @mock.patch(cli.__name__ + ".load_images")
+    def test_start_one_opbeans_without_loadgen(self, _ignore_load_images):
+        docker_compose_yml = stringIO()
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--with-opbeans-python",
+                                                              "--no-opbeans-python-loadgen"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        services = got["services"]
+        self.assertIn("redis", services)
+        self.assertIn("postgres", services)
+        self.assertNotIn("opbeans-load-generator", services)
+
+    @mock.patch(cli.__name__ + ".load_images")
+    def test_start_one_opbeans_without_loadgen_global_arg(self, _ignore_load_images):
+        docker_compose_yml = stringIO()
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--with-opbeans-python",
+                                                              "--no-opbeans-load-generator"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        services = got["services"]
+        self.assertIn("redis", services)
+        self.assertIn("postgres", services)
+        self.assertNotIn("opbeans-load-generator", services)
 
     @mock.patch(cli.__name__ + ".load_images")
     def test_start_opbeans_2nd(self, _ignore_load_images):


### PR DESCRIPTION
## What does this PR do?

adds a new parameter `--no-opbeans-load-generator` to disable the load generator.

## Why is it important?

if you run `--all` or `--al-beans`you would have to use the `--no-opbeans-*-loadgen` parameters for every Opbean.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/173 https://github.com/elastic/apm-integration-testing/issues/213
