### PR TITLE
feat: add more Node.js Docker images to the cache

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
 source /usr/local/bin/bash_standard_lib.sh
 
 DOCKER_IMAGES="alpine:3.4
@@ -35,6 +36,10 @@ node:11
 node:11.0
 node:12
 node:12.0
+node:13
+node:13.0
+node:14
+node:14.0
 node:6
 node:6.0
 node:8


### PR DESCRIPTION
## What does this PR do?

it adds some new Node.js Docker images to the packer cache.

## Why is it important?

by having the Docker images in the cache we avoid timeout issues pulling images from Docker hub, and we do not download thousand of times the same image.

Related to https://github.com/elastic/apm-agent-nodejs/pull/1464