### PR TITLE
add Python 3.8 to packer cache

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -59,6 +59,7 @@ python:3.4
 python:3.5
 python:3.6
 python:3.7
+python:3.8
 ruby:2.3
 ruby:2.4
 ruby:2.5


### PR DESCRIPTION
## What does this PR do?

Python 3.8 was recently released and was added to the test matrix
for the Python APM agent. Caching the image will help with using
less resources.