### PR TITLE
feat: enable OSS artifacts on test

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,2 +1,3 @@
 APM_SERVER:
   - master
+  - master --oss


### PR DESCRIPTION
## What does this PR do?

it adds a flag to use the latest snapshot OSS artifact on test.  

## Why is it important?

We do not run the integration tests on OSS binaries.

<img width="737" alt="Screenshot 2019-10-24 at 18 20 51" src="https://user-images.githubusercontent.com/5400788/67505330-55b01180-f68b-11e9-8db8-60f0e1d454fa.png">
<img width="756" alt="Screenshot 2019-10-24 at 18 21 02" src="https://user-images.githubusercontent.com/5400788/67505331-55b01180-f68b-11e9-9d9f-a46eabb6043a.png">

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/60
