### PR TITLE
fix: Docker images to work with latest changes

### DIFF
--- a/docker/opbeans/node/Dockerfile
+++ b/docker/opbeans/node/Dockerfile
@@ -1,5 +1,9 @@
 FROM opbeans/opbeans-node:latest
 
+RUN apk update && \
+    apk --no-cache add curl bash && \
+    rm -rf /var/cache/apk/*
+
 COPY entrypoint.sh /app/entrypoint.sh
 
 CMD ["pm2-runtime", "ecosystem-workload.config.js"]

--- a/docker/opbeans/ruby/Dockerfile
+++ b/docker/opbeans/ruby/Dockerfile
@@ -1,6 +1,10 @@
 FROM opbeans/opbeans-ruby:latest
 
+RUN apk update && \
+    apk --no-cache add curl bash && \
+    rm -rf /var/cache/apk/*
+
 COPY entrypoint.sh /app/entrypoint.sh
 
-CMD ["bin/boot"]
 ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+CMD ["bin/boot"]


### PR DESCRIPTION
## What does this PR do?

add some missing packages in the current opbeans Docker image

## Why is it important?

After the changes in our Docker images, we should update 7.x branch

