### PR TITLE
cache opbeans-frontend docker image

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -44,6 +44,7 @@ node:14.0
 node:8-slim
 node:8
 node:8.6
+opbeans/opbeans-frontend:latest
 opbeans/opbeans-go:latest
 opbeans/opbeans-java:latest
 opbeans/opbeans-loadgen:latest


### PR DESCRIPTION
## What does this PR do?

Enable the already removed docker image for the opbeans-frontend from the cached docker images in the CI workers.

## Why is it important?

This particular docker image is also used in this repo, see docker/opbeans/dotnet/Dockerfile and docker/opbeans/go/Dockerfile

## Related issues

Caused by https://github.com/elastic/apm-integration-testing/pull/663