### PR TITLE
remove tls verification mode setting

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -478,7 +478,6 @@ class Elasticsearch(StackService, Service):
                     self.environment.append("xpack.security.authc.realms.native1.type=native")
                     self.environment.append("xpack.security.authc.realms.native1.order=1")
                 if self.at_least_version("7.3"):
-                    self.environment.append("xpack.security.transport.ssl.verification_mode=none")
                     self.environment.append("xpack.security.authc.token.enabled=true")
                     self.environment.append("xpack.security.authc.api_key.enabled=true")
             self.environment.append("xpack.security.enabled=" + xpack_security_enabled)


### PR DESCRIPTION
As of 8.0, this no TLS + verification mode set will prevent elasticsearch from starting:

```
 the following settings have been configured in elasticsearch.yml : [xpack.security.transport.ssl.verification_mode]
```

In 7.x this is technically valid but not useful so can be removed for all versions.

cc @dgieselaar @jalvz 