### PR TITLE
xpack secure by default

### DIFF
--- a/.ci/scripts/8.0-upgrade.sh
+++ b/.ci/scripts/8.0-upgrade.sh
@@ -5,7 +5,7 @@ test -z "$srcdir" && srcdir=.
 # shellcheck disable=SC1090
 . "${srcdir}/common.sh"
 
-export COMPOSE_ARGS="7.2 --force-build --build-parallel --no-apm-server-dashboards --no-apm-server-self-instrument --apm-server-count 2 --apm-server-tee --elasticsearch-data-dir '' --no-apm-server-pipeline --all --no-kibana"
+export COMPOSE_ARGS="7.2 --force-build --no-xpack-secure --build-parallel --no-apm-server-dashboards --no-apm-server-self-instrument --apm-server-count 2 --apm-server-tee --elasticsearch-data-dir '' --no-apm-server-pipeline --all --no-kibana"
 make start-env docker-compose-wait
 
 # let opbeans apps generate some data

--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -8,6 +8,6 @@ test -z "$srcdir" && srcdir=.
 
 AGENT=$1
 APP=$2
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --with-agent-${APP} --no-apm-server-dashboards --no-apm-server-self-instrument --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --with-agent-${APP} --no-apm-server-dashboards --no-apm-server-self-instrument --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-${AGENT}" "docker-test-agent-${AGENT}"

--- a/.ci/scripts/all.sh
+++ b/.ci/scripts/all.sh
@@ -6,6 +6,6 @@ test -z "$srcdir" && srcdir=.
 # shellcheck disable=SC1090
 . "${srcdir}/common.sh"
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --with-agent-dotnet --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --with-agent-python-django --with-agent-python-flask --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --with-agent-dotnet --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --with-agent-python-django --with-agent-python-flask --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-all docker-test-all

--- a/.ci/scripts/dotnet.sh
+++ b/.ci/scripts/dotnet.sh
@@ -13,6 +13,6 @@ if [ -n "${APM_AGENT_DOTNET_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} ${EXTRA_OPTS}"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-dotnet --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-dotnet --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-dotnet docker-test-agent-dotnet

--- a/.ci/scripts/go.sh
+++ b/.ci/scripts/go.sh
@@ -13,7 +13,7 @@ if [ -n "${APM_AGENT_GO_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} --go-agent-version='${APM_AGENT_GO_VERSION}'"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-go-net-http --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-go-net-http --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 
 runTests env-agent-go docker-test-agent-go

--- a/.ci/scripts/java.sh
+++ b/.ci/scripts/java.sh
@@ -13,6 +13,6 @@ if [ -n "${APM_AGENT_JAVA_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} ${EXTRA_OPTS}"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-java-spring --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-java-spring --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-java docker-test-agent-java

--- a/.ci/scripts/nodejs.sh
+++ b/.ci/scripts/nodejs.sh
@@ -12,6 +12,6 @@ if [ -n "${APM_AGENT_NODEJS_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} --nodejs-agent-package='${APM_AGENT_NODEJS_VERSION}'"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-nodejs-express --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-nodejs-express --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-nodejs docker-test-agent-nodejs

--- a/.ci/scripts/opbeans.sh
+++ b/.ci/scripts/opbeans.sh
@@ -6,6 +6,6 @@ test -z "$srcdir" && srcdir=.
 # shellcheck disable=SC1090
 . "${srcdir}/common.sh"
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-server test-compose lint test-helps

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -15,6 +15,6 @@ if [ -n "${APM_AGENT_PYTHON_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} --python-agent-package='${APM_AGENT_PYTHON_VERSION}'"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-python-django --with-agent-python-flask --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-python-django --with-agent-python-flask --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-python docker-test-agent-python

--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -10,6 +10,6 @@ if [ -n "${APM_AGENT_RUBY_VERSION}" ]; then
   BUILD_OPTS="${BUILD_OPTS} --ruby-agent-version='${APM_AGENT_RUBY_VERSION#*;}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}'"
 fi
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-ruby-rails --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-ruby-rails --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-ruby docker-test-agent-ruby

--- a/.ci/scripts/rum.sh
+++ b/.ci/scripts/rum.sh
@@ -14,6 +14,6 @@ if [ -n "${APM_AGENT_RUM_VERSION}" ]; then
 fi
 
 #--with-agent-python-django
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-rumjs --force-build"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-rumjs --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-rum docker-test-agent-rum

--- a/.ci/scripts/server.sh
+++ b/.ci/scripts/server.sh
@@ -6,6 +6,6 @@ test -z "$srcdir" && srcdir=.
 # shellcheck disable=SC1090
 . "${srcdir}/common.sh"
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-server docker-test-server

--- a/.ci/scripts/unit-tests.sh
+++ b/.ci/scripts/unit-tests.sh
@@ -6,6 +6,6 @@ test -z "$srcdir" && srcdir=.
 # shellcheck disable=SC1090
 . "${srcdir}/common.sh"
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana"
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-server test-compose lint test-helps

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -364,10 +364,10 @@ class LocalSetup(object):
         )
 
         parser.add_argument(
-            '--xpack-secure',
-            action="store_true",
+            '--no-xpack-secure',
+            action="store_false",
             dest="xpack_secure",
-            help="enable xpack security throughout the stack",
+            help="disable xpack security throughout the stack",
         )
 
         self.store_options(parser)

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -76,7 +76,8 @@ class ApmServer(StackService, Service):
                     if self.options.get(es_opt):
                         self.apm_server_command_args.append(("apm-server.kibana.{}".format(cfg), self.options[es_opt]))
                     elif self.options.get("xpack_secure"):
-                        self.apm_server_command_args.append(("apm-server.kibana.{}".format(cfg), default_apm_server_creds.get(cfg)))
+                        self.apm_server_command_args.append(
+                            ("apm-server.kibana.{}".format(cfg), default_apm_server_creds.get(cfg)))
 
         if self.options.get("enable_kibana", True):
             self.depends_on["kibana"] = {"condition": "service_healthy"}

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -819,6 +819,7 @@ class LocalTest(unittest.TestCase):
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true,
                     -E, apm-server.kibana.enabled=true, -E, apm-server.agent.config.cache.expiration=1s, -E, 'apm-server.kibana.host=kibana:5601',
+                    -E, apm-server.kibana.username=apm_server_user, -E, apm-server.kibana.password=changeme,
                     -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]',
                     -E, output.elasticsearch.username=apm_server_user, -E, output.elasticsearch.password=changeme,
                     -E, output.elasticsearch.enabled=true,

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -355,7 +355,8 @@ class OpbeansServiceTest(ServiceTest):
         branch = [e for e in opbeans_python_6_1["environment"] if e.startswith("PYTHON_AGENT_BRANCH")]
         self.assertEqual(branch, ["PYTHON_AGENT_BRANCH=1.x"])
 
-        opbeans_python_master = OpbeansPython(version="7.0.0-alpha1", opbeans_python_agent_branch="2.x").render()["opbeans-python"]
+        opbeans_python_master = OpbeansPython(
+            version="7.0.0-alpha1", opbeans_python_agent_branch="2.x").render()["opbeans-python"]
         branch = [e for e in opbeans_python_master["environment"] if e.startswith("PYTHON_AGENT_BRANCH")]
         self.assertEqual(branch, ["PYTHON_AGENT_BRANCH=2.x"])
 
@@ -582,6 +583,7 @@ class OpbeansServiceTest(ServiceTest):
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}""")
 
+
 class PostgresServiceTest(ServiceTest):
     def test_postgres(self):
         postgres = Postgres(version="6.2.4").render()
@@ -646,7 +648,8 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml = stringIO()
         image_cache_dir = "/foo"
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.2': '6.2.10'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["6.2", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
+            setup = LocalSetup(argv=self.common_setup_args +
+                               ["6.2", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -723,7 +726,8 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml = stringIO()
         image_cache_dir = "/foo"
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.3': '6.3.10'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["6.3", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
+            setup = LocalSetup(argv=self.common_setup_args +
+                               ["6.3", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -955,25 +959,25 @@ class LocalTest(unittest.TestCase):
         self.assertTrue(any(cmd.startswith("output.elasticsearch.username=") for cmd in apm_server_cmd), apm_server_cmd)
         # elasticsearch configuration
         es_env = got["services"]["elasticsearch"]["environment"]
-        ## auditing disabled by default
+        # auditing disabled by default
         self.assertNotIn("xpack.security.audit.enabled=true", es_env)
-        ## allow anonymous healthcheck
+        # allow anonymous healthcheck
         self.assertIn("xpack.security.authc.anonymous.roles=remote_monitoring_collector", es_env)
-        ## file based realm
+        # file based realm
         self.assertIn("xpack.security.authc.realms.file.file1.order=0", es_env)
-        ## native realm
+        # native realm
         self.assertIn("xpack.security.authc.realms.native.native1.order=1", es_env)
         # kibana should use user/pass -> es
         kibana_env = got["services"]["kibana"]["environment"]
         self.assertIn("ELASTICSEARCH_PASSWORD", kibana_env)
         self.assertIn("ELASTICSEARCH_USERNAME", kibana_env)
-        ## allow anonymous healthcheck
+        # allow anonymous healthcheck
         self.assertIn("STATUS_ALLOWANONYMOUS", kibana_env)
 
     @mock.patch(cli.__name__ + ".load_images")
     def test_start_no_elasticesarch(self, _ignore_load_images):
         docker_compose_yml = stringIO()
-        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master':'8.0.0'}):
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
             setup = LocalSetup(argv=self.common_setup_args + ["master", "--no-elasticsearch"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -646,7 +646,7 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml = stringIO()
         image_cache_dir = "/foo"
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.2': '6.2.10'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["6.2", "--image-cache-dir", image_cache_dir])
+            setup = LocalSetup(argv=self.common_setup_args + ["6.2", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -723,7 +723,7 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml = stringIO()
         image_cache_dir = "/foo"
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.3': '6.3.10'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["6.3", "--image-cache-dir", image_cache_dir])
+            setup = LocalSetup(argv=self.common_setup_args + ["6.3", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -819,7 +819,9 @@ class LocalTest(unittest.TestCase):
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true,
                     -E, apm-server.kibana.enabled=true, -E, apm-server.agent.config.cache.expiration=1s, -E, 'apm-server.kibana.host=kibana:5601',
-                    -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true,
+                    -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]',
+                    -E, output.elasticsearch.username=apm_server_user, -E, output.elasticsearch.password=changeme,
+                    -E, output.elasticsearch.enabled=true,
                     -E, "output.elasticsearch.pipelines=[{pipeline: 'apm'}]", -E, 'apm-server.register.ingest.pipeline.enabled=true'
                     ]
                 container_name: localtesting_8.0.0_apm-server
@@ -839,7 +841,23 @@ class LocalTest(unittest.TestCase):
 
             elasticsearch:
                 container_name: localtesting_8.0.0_elasticsearch
-                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, cluster.routing.allocation.disk.threshold_enabled=false, discovery.type=single-node, path.repo=/usr/share/elasticsearch/data/backups, 'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/8.0.0, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
+                environment: [
+                    bootstrap.memory_lock=true,
+                    cluster.name=docker-cluster,
+                    cluster.routing.allocation.disk.threshold_enabled=false,
+                    discovery.type=single-node,
+                    path.repo=/usr/share/elasticsearch/data/backups,
+                    'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g',
+                    path.data=/usr/share/elasticsearch/data/8.0.0,
+                    xpack.security.authc.anonymous.roles=remote_monitoring_collector,
+                    xpack.security.authc.realms.file.file1.order=0,
+                    xpack.security.authc.realms.native.native1.order=1,
+                    xpack.security.authc.token.enabled=true,
+                    xpack.security.authc.api_key.enabled=true,
+                    xpack.security.enabled=true,
+                    xpack.license.self_generated.type=trial,
+                    xpack.monitoring.collection.enabled=true
+                ]
                 healthcheck:
                     interval: '20'
                     retries: 10
@@ -852,13 +870,26 @@ class LocalTest(unittest.TestCase):
                 ports: ['127.0.0.1:9200:9200']
                 ulimits:
                     memlock: {hard: -1, soft: -1}
-                volumes: ['esdata:/usr/share/elasticsearch/data']
+                volumes: [
+                    'esdata:/usr/share/elasticsearch/data',
+                    './docker/elasticsearch/roles.yml:/usr/share/elasticsearch/config/roles.yml',
+                    './docker/elasticsearch/users:/usr/share/elasticsearch/config/users',
+                    './docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles'
+                ]
 
             kibana:
                 container_name: localtesting_8.0.0_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
+                environment: {
+                    ELASTICSEARCH_PASSWORD: changeme,
+                    ELASTICSEARCH_URL: 'elasticsearch:9200',
+                    ELASTICSEARCH_USERNAME: kibana_system_user,
+                    SERVER_NAME: kibana.example.org,
+                    STATUS_ALLOWANONYMOUS: 'true',
+                    XPACK_MONITORING_ENABLED: 'true',
+                    XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'
+                }
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -881,7 +912,7 @@ class LocalTest(unittest.TestCase):
     def test_start_6_x_xpack_secure(self, _ignore_load_images):
         docker_compose_yml = stringIO()
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.6': '6.6.10'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["6.6", "--xpack-secure", "--elasticsearch-xpack-audit"])
+            setup = LocalSetup(argv=self.common_setup_args + ["6.6", "--elasticsearch-xpack-audit"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
@@ -912,7 +943,7 @@ class LocalTest(unittest.TestCase):
     def test_start_7_0_xpack_secure(self, _ignore_load_images):
         docker_compose_yml = stringIO()
         with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
-            setup = LocalSetup(argv=self.common_setup_args + ["master", "--xpack-secure"])
+            setup = LocalSetup(argv=self.common_setup_args + ["master"])
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -666,9 +666,24 @@ class ApmServerServiceTest(ServiceTest):
         self.assertTrue("apm-server.kibana.host=kibana:5601" in apm_server["command"],
                         "APM Server Kibana host set by default")
 
+
         apm_server = ApmServer(version="7.3", apm_server_acm_disable=True).render()["apm-server"]
         self.assertTrue("apm-server.kibana.enabled=false" in apm_server["command"],
                         "APM Server Kibana disabled when apm_server_disable_kibana=True")
+
+        apm_server = ApmServer(version="7.3", xpack_secure=True).render()["apm-server"]
+        self.assertTrue("apm-server.kibana.username=apm_server_user" in apm_server["command"],
+                        "APM Server Kibana username set by default")
+        self.assertTrue("apm-server.kibana.password=changeme" in apm_server["command"],
+                        "APM Server Kibana password set by default")
+
+        apm_server = ApmServer(version="7.3", xpack_secure=True,
+                               apm_server_elasticsearch_username="another_apm_server_user",
+                               apm_server_elasticsearch_password="notchangeme").render()["apm-server"]
+        self.assertTrue("apm-server.kibana.username=another_apm_server_user" in apm_server["command"],
+                        "APM Server Kibana username overridden")
+        self.assertTrue("apm-server.kibana.password=notchangeme" in apm_server["command"],
+                        "APM Server Kibana password overridden")
 
 
 class ElasticsearchServiceTest(ServiceTest):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -565,7 +565,7 @@ class ApmServerServiceTest(ServiceTest):
             ),
             (
                 dict(apm_server_queue_write_flush_timeout="0s"),
-                {"file": {"path": "$${path.data}/spool.dat"}, "write":{"flush.timeout": "0s"}},
+                {"file": {"path": "$${path.data}/spool.dat"}, "write": {"flush.timeout": "0s"}},
             ),
         ]
         for opts, want in cases:
@@ -665,7 +665,6 @@ class ApmServerServiceTest(ServiceTest):
                         "APM Server Kibana enabled by default")
         self.assertTrue("apm-server.kibana.host=kibana:5601" in apm_server["command"],
                         "APM Server Kibana host set by default")
-
 
         apm_server = ApmServer(version="7.3", apm_server_acm_disable=True).render()["apm-server"]
         self.assertTrue("apm-server.kibana.enabled=false" in apm_server["command"],
@@ -805,20 +804,25 @@ class FilebeatServiceTest(ServiceTest):
 
     def test_filebeat_7_1(self):
         filebeat = Filebeat(version="7.1.0", release=True).render()
-        self.assertTrue("./docker/filebeat/filebeat.6.x-compat.yml:/usr/share/filebeat/filebeat.yml" in filebeat["filebeat"]["volumes"])
+        self.assertTrue(
+            "./docker/filebeat/filebeat.6.x-compat.yml:/usr/share/filebeat/filebeat.yml" in filebeat["filebeat"]["volumes"])
 
     def test_filebeat_post_7_2(self):
         filebeat = Filebeat(version="7.2.0", release=True).render()
-        self.assertTrue("./docker/filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml" in filebeat["filebeat"]["volumes"])
+        self.assertTrue(
+            "./docker/filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml" in filebeat["filebeat"]["volumes"])
 
     def test_filebeat_elasticsearch_urls(self):
-        filebeat = Filebeat(version="6.1.1", release=True, filebeat_elasticsearch_urls=["elasticsearch01:9200"]).render()["filebeat"]
+        filebeat = Filebeat(version="6.1.1", release=True, filebeat_elasticsearch_urls=[
+                            "elasticsearch01:9200"]).render()["filebeat"]
         self.assertTrue("elasticsearch" in filebeat['depends_on'])
         self.assertTrue("output.elasticsearch.hosts=[\"elasticsearch01:9200\"]" in filebeat['command'])
 
-        filebeat = Filebeat(version="6.1.1", release=True, filebeat_elasticsearch_urls=["elasticsearch01:9200","elasticsearch02:9200"]).render()["filebeat"]
+        filebeat = Filebeat(version="6.1.1", release=True, filebeat_elasticsearch_urls=[
+                            "elasticsearch01:9200", "elasticsearch02:9200"]).render()["filebeat"]
         self.assertTrue("elasticsearch" in filebeat['depends_on'])
-        self.assertTrue("output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in filebeat['command'])
+        self.assertTrue(
+            "output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in filebeat['command'])
 
     def test_logstash_output(self):
         beat = Filebeat(version="6.3.100", filebeat_output="logstash").render()["filebeat"]
@@ -914,11 +918,13 @@ class KibanaServiceTest(ServiceTest):
         )
 
     def test_kibana_elasticsearch_urls(self):
-        kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=["elasticsearch01:9200"]).render()["kibana"]
+        kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=[
+                        "elasticsearch01:9200"]).render()["kibana"]
         self.assertTrue("elasticsearch" in kibana['depends_on'])
         self.assertEqual("elasticsearch01:9200", kibana['environment']["ELASTICSEARCH_URL"])
 
-        kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=["elasticsearch01:9200","elasticsearch02:9200"]).render()["kibana"]
+        kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=[
+                        "elasticsearch01:9200", "elasticsearch02:9200"]).render()["kibana"]
         self.assertTrue("elasticsearch" in kibana['depends_on'])
         self.assertEqual("elasticsearch01:9200,elasticsearch02:9200", kibana['environment']["ELASTICSEARCH_URL"])
 
@@ -937,6 +943,7 @@ class KibanaServiceTest(ServiceTest):
     def test_kibana_snapshot(self):
         kibana = Kibana(version="7.3.0", kibana_snapshot=True, kibana_version="7.3.0").render()["kibana"]
         self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
+
 
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):
@@ -990,13 +997,16 @@ class LogstashServiceTest(ServiceTest):
         )
 
     def test_logstash_elasticsearch_urls(self):
-        logstash = Logstash(version="6.3.5", release=True, logstash_elasticsearch_urls=["elasticsearch01:9200"]).render()["logstash"]
+        logstash = Logstash(version="6.3.5", release=True, logstash_elasticsearch_urls=[
+                            "elasticsearch01:9200"]).render()["logstash"]
         self.assertTrue("elasticsearch" in logstash['depends_on'])
         self.assertEqual("elasticsearch01:9200", logstash['environment']["ELASTICSEARCH_URL"])
 
-        logstash = Logstash(version="6.3.5", release=True, logstash_elasticsearch_urls=["elasticsearch01:9200","elasticsearch02:9200"]).render()["logstash"]
+        logstash = Logstash(version="6.3.5", release=True, logstash_elasticsearch_urls=[
+                            "elasticsearch01:9200", "elasticsearch02:9200"]).render()["logstash"]
         self.assertTrue("elasticsearch" in logstash['depends_on'])
         self.assertEqual("elasticsearch01:9200,elasticsearch02:9200", logstash['environment']["ELASTICSEARCH_URL"])
+
 
 class MetricbeatServiceTest(ServiceTest):
     def test_metricbeat(self):
@@ -1036,13 +1046,16 @@ class MetricbeatServiceTest(ServiceTest):
             self.assertTrue(o in beat["command"], "{} not set in {} while output=logstash".format(o, beat["command"]))
 
     def test_metricbeat_elasticsearch_urls(self):
-        beat = Metricbeat(version="6.2.4", release=True, metricbeat_elasticsearch_urls=["elasticsearch01:9200"]).render()["metricbeat"]
+        beat = Metricbeat(version="6.2.4", release=True, metricbeat_elasticsearch_urls=[
+                          "elasticsearch01:9200"]).render()["metricbeat"]
         self.assertTrue("elasticsearch" in beat['depends_on'])
         self.assertTrue("output.elasticsearch.hosts=[\"elasticsearch01:9200\"]" in beat['command'])
 
-        beat = Metricbeat(version="6.2.4", release=True, metricbeat_elasticsearch_urls=["elasticsearch01:9200","elasticsearch02:9200"]).render()["metricbeat"]
+        beat = Metricbeat(version="6.2.4", release=True, metricbeat_elasticsearch_urls=[
+                          "elasticsearch01:9200", "elasticsearch02:9200"]).render()["metricbeat"]
         self.assertTrue("elasticsearch" in beat['depends_on'])
-        self.assertTrue("output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in beat['command'])
+        self.assertTrue(
+            "output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in beat['command'])
 
     def test_apm_server_pprof_url(self):
         beat = Metricbeat(version="6.2.4", release=True, apm_server_pprof_url="apm-server:1234").render()["metricbeat"]
@@ -1050,17 +1063,19 @@ class MetricbeatServiceTest(ServiceTest):
 
     def test_config_6(self):
         beat = Metricbeat(version="6.8.0", release=True, metricbeat_output="logstash").render()["metricbeat"]
-        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in  beat["command"])
-        self.assertTrue("./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
+        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in beat["command"])
+        self.assertTrue(
+            "./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
 
     def test_config_71(self):
         beat = Metricbeat(version="7.1.0", release=True, metricbeat_output="logstash").render()["metricbeat"]
-        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in  beat["command"])
-        self.assertTrue("./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
+        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in beat["command"])
+        self.assertTrue(
+            "./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
 
     def test_config_post_72(self):
         beat = Metricbeat(version="7.2.0", release=True, metricbeat_output="logstash").render()["metricbeat"]
-        self.assertTrue("monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in  beat["command"])
+        self.assertTrue("monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in beat["command"])
         self.assertTrue("./docker/metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
 
 
@@ -1090,7 +1105,7 @@ class PacketbeatServiceTest(ServiceTest):
                         - /var/run/docker.sock:/var/run/docker.sock
                     network_mode: 'service:apm-server'
                     privileged: 'true'
-                    cap_add: ['NET_ADMIN', 'NET_RAW']""") # noqa: 501
+                    cap_add: ['NET_ADMIN', 'NET_RAW']""")  # noqa: 501
         )
 
     def test_config_6(self):
@@ -1121,10 +1136,11 @@ class PacketbeatServiceTest(ServiceTest):
         self.assertTrue(
             "output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in beat['command'])
 
+
 class HeartbeatServiceTest(ServiceTest):
     def test_heartbeat_elasticsearch_urls(self):
         beat = Heartbeat(version="6.2.4", release=True,
-                          heartbeat_elasticsearch_urls=["elasticsearch01:9200"]).render()["heartbeat"]
+                         heartbeat_elasticsearch_urls=["elasticsearch01:9200"]).render()["heartbeat"]
         self.assertTrue("elasticsearch" in beat['depends_on'])
         self.assertTrue("output.elasticsearch.hosts=[\"elasticsearch01:9200\"]" in beat['command'])
 
@@ -1134,6 +1150,7 @@ class HeartbeatServiceTest(ServiceTest):
         self.assertTrue("elasticsearch" in beat['depends_on'])
         self.assertTrue(
             "output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in beat['command'])
+
 
 class ZookeeperServiceTest(ServiceTest):
     def test_zookeeper(self):


### PR DESCRIPTION
## What does this PR do?

Enable xpack security by default, adding `--no-xpack-secure option` when needed

## Why is it important?

Everyone should be running with security enabled, this is a first step to making that simple in development and test envs.