### PR TITLE
feat: grab elasticsearch data on fails

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -100,6 +100,7 @@ pipeline {
       environment {
         TMPDIR = "${WORKSPACE}"
         REUSE_CONTAINERS = "true"
+        PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
       }
       steps {
         deleteDir()
@@ -174,7 +175,10 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
       steps.node('linux && immutable'){
         def env = ["APM_SERVER_BRANCH=${y}",
           "${steps.agentMapping.envVar(tag)}=${x}",
-          "REUSE_CONTAINERS=true"
+          "REUSE_CONTAINERS=true",
+          "ENABLE_ES_DUMP=true",
+          "PATH=${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}",
+          "TMPDIR=${WORKSPACE}"
           ]
         def label = "${tag}-${x}-${y}"
         try{
@@ -205,10 +209,7 @@ def runScript(Map params = [:]){
   unstash "source"
   dir("${BASE_DIR}"){
     withEnv(env){
-      sh """#!/bin/bash
-      export TMPDIR="${WORKSPACE}"
-      .ci/scripts/${agentType}.sh
-      """
+      sh(label: "Testing ${agentType}", script: ".ci/scripts/${agentType}.sh")
     }
   }
 }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -46,6 +46,13 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests"){
+      environment {
+        TMPDIR = "${WORKSPACE}"
+        ENABLE_ES_DUMP = "true"
+        PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
+        AGENT_NAME = agentMapping.id(params.AGENT_INTEGRATION_TEST)
+        AGENT_APP = agentMapping.app(params.AGENT_INTEGRATION_TEST)
+      }
       when {
         expression {
           return (params.AGENT_INTEGRATION_TEST != 'All' &&
@@ -56,14 +63,7 @@ pipeline {
         deleteDir()
         unstash "source"
         dir("${BASE_DIR}"){
-          script {
-            def agentName = agentMapping.id(params.AGENT_INTEGRATION_TEST)
-            def agentApp = agentMapping.app(params.AGENT_INTEGRATION_TEST)
-            sh """#!/bin/bash
-            export TMPDIR="${WORKSPACE}"
-            .ci/scripts/agent.sh ${agentName} ${agentApp}
-            """
-          }
+          sh(label: "Testing ${AGENT_NAME} ${AGENT_APP}", script: ".ci/scripts/agent.sh ${AGENT_NAME} ${AGENT_APP}")
         }
       }
       post {
@@ -78,6 +78,8 @@ pipeline {
       }
       environment {
         TMPDIR = "${WORKSPACE}"
+        ENABLE_ES_DUMP = "true"
+        PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
       }
       steps {
         deleteDir()
@@ -123,6 +125,8 @@ pipeline {
       }
       environment {
         TMPDIR = "${WORKSPACE}"
+        ENABLE_ES_DUMP = "true"
+        PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
       }
       steps {
         deleteDir()

--- a/.ci/scripts/elasticdump
+++ b/.ci/scripts/elasticdump
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+DOCKER_IMAGE=taskrabbit/elasticsearch-dump
+docker image inspect ${DOCKER_IMAGE} > /dev/null 2>&1 || docker pull ${DOCKER_IMAGE} > /dev/null
+
+docker run --rm -t -v "$(pwd):/app" -u "$(id -u):$(id -g)" -w /app \
+  -e HOME=/app \
+  "${DOCKER_IMAGE}" "$@"


### PR DESCRIPTION
## What does this PR do?

Enable the feature to dump all data on Elasticsearch after a test failure. It also refactors some environment variables.

## Why is it important?

Some times the test fails because of Elasticsearch query returns less or more data than expected but we do not really know what it is in Elasticsearch, this PR grab that data so we can check what it is really on Elasticsearch.
