### PR TITLE
[apm-ci]: cache docker images

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -59,6 +59,7 @@ python:3.4
 python:3.5
 python:3.6
 python:3.7
+python:3.7-stretch
 python:3.8
 ruby:2.3
 ruby:2.4

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -66,6 +66,7 @@ ruby:2.4
 ruby:2.5
 ruby:2.6
 ruby:latest
+wordpress:php7.3-fpm-alpine
 "
 
 for di in ${DOCKER_IMAGES}


### PR DESCRIPTION
## What does this PR do?

Cache docker images for the apm-agent-python and apm-agent-php

## Why is it important?

Faster builds

## Related issues

Relates to:
- https://github.com/elastic/apm-agent-php/pull/8
- https://github.com/elastic/apm-agent-python/pull/559