### PR TITLE
fix: define ELASTIC_APM_VERIFY_SERVER_CERT only on Python latest versions

### DIFF
--- a/docker/python/django/Dockerfile
+++ b/docker/python/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 RUN pip install -q -U Django==2.1.5
 

--- a/docker/python/flask/Dockerfile
+++ b/docker/python/flask/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 RUN pip install -q -U Flask blinker gunicorn
 

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -218,7 +218,7 @@ class AgentPythonDjango(AgentPython):
             logging=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
-        if (self.agent_package != 'elastic-apm==5.1' and self.agent_package != 'elastic-apm==4.1'):
+        if ('elastic-apm==5.1' not in self.agent_package and 'elastic-apm==4.' not in self.agent_package):
             ret["environment"]["ELASTIC_APM_VERIFY_SERVER_CERT"] = (
                 str(not self.options.get("no_verify_server_cert")).lower())
         return ret
@@ -247,7 +247,7 @@ class AgentPythonFlask(AgentPython):
             depends_on=self.depends_on,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
-        if (self.agent_package != 'elastic-apm==5.1' and self.agent_package != 'elastic-apm==4.1'):
+        if ('elastic-apm==5.1' not in self.agent_package and 'elastic-apm==4.' not in self.agent_package):
             ret["environment"]["ELASTIC_APM_VERIFY_SERVER_CERT"] = (
                 str(not self.options.get("no_verify_server_cert")).lower())
         return ret

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -202,7 +202,7 @@ class AgentPythonDjango(AgentPython):
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):
-        return dict(
+        ret = dict(
             build={"context": "docker/python/django", "dockerfile": "Dockerfile"},
             command="bash -c \"pip install -q -U {} && python testapp/manage.py runserver 0.0.0.0:{}\"".format(
                 self.agent_package, self.SERVICE_PORT),
@@ -210,7 +210,6 @@ class AgentPythonDjango(AgentPython):
             environment={
                 "DJANGO_PORT": self.SERVICE_PORT,
                 "DJANGO_SERVICE_NAME": "djangoapp",
-                "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             },
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "djangoapp"),
             depends_on=self.depends_on,
@@ -219,6 +218,13 @@ class AgentPythonDjango(AgentPython):
             logging=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
+        # TODO remove elastic-apm match when the latest release support it
+        if (self.agent_package != 'elastic-apm==5.1'
+                and self.agent_package != 'elastic-apm==4.1'
+                and self.agent_package != 'elastic-apm'):
+            ret["environment"]["ELASTIC_APM_VERIFY_SERVER_CERT"] = (
+                str(not self.options.get("no_verify_server_cert")).lower())
+        return ret
 
 
 class AgentPythonFlask(AgentPython):
@@ -229,7 +235,7 @@ class AgentPythonFlask(AgentPython):
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):
-        return dict(
+        ret = dict(
             build={"context": "docker/python/flask", "dockerfile": "Dockerfile"},
             command="bash -c \"pip install -q -U {} && gunicorn app:app\"".format(self.agent_package),
             container_name="flaskapp",
@@ -239,12 +245,18 @@ class AgentPythonFlask(AgentPython):
             environment={
                 "FLASK_SERVICE_NAME": "flaskapp",
                 "GUNICORN_CMD_ARGS": "-w 4 -b 0.0.0.0:{}".format(self.SERVICE_PORT),
-                "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             },
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "flaskapp"),
             depends_on=self.depends_on,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
+        # TODO remove elastic-apm match when the latest release support it
+        if (self.agent_package != 'elastic-apm==5.1'
+                and self.agent_package != 'elastic-apm==4.1'
+                and self.agent_package != 'elastic-apm'):
+            ret["environment"]["ELASTIC_APM_VERIFY_SERVER_CERT"] = (
+                str(not self.options.get("no_verify_server_cert")).lower())
+        return ret
 
 
 class AgentRubyRails(Service):

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -218,10 +218,7 @@ class AgentPythonDjango(AgentPython):
             logging=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
-        # TODO remove elastic-apm match when the latest release support it
-        if (self.agent_package != 'elastic-apm==5.1'
-                and self.agent_package != 'elastic-apm==4.1'
-                and self.agent_package != 'elastic-apm'):
+        if (self.agent_package != 'elastic-apm==5.1' and self.agent_package != 'elastic-apm==4.1'):
             ret["environment"]["ELASTIC_APM_VERIFY_SERVER_CERT"] = (
                 str(not self.options.get("no_verify_server_cert")).lower())
         return ret
@@ -250,10 +247,7 @@ class AgentPythonFlask(AgentPython):
             depends_on=self.depends_on,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
-        # TODO remove elastic-apm match when the latest release support it
-        if (self.agent_package != 'elastic-apm==5.1'
-                and self.agent_package != 'elastic-apm==4.1'
-                and self.agent_package != 'elastic-apm'):
+        if (self.agent_package != 'elastic-apm==5.1' and self.agent_package != 'elastic-apm==4.1'):
             ret["environment"]["ELASTIC_APM_VERIFY_SERVER_CERT"] = (
                 str(not self.options.get("no_verify_server_cert")).lower())
         return ret

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -124,6 +124,7 @@ class AgentServiceTest(ServiceTest):
                         apm-server:
                             condition: 'service_healthy'
                     environment:
+                        ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         DJANGO_SERVICE_NAME: djangoapp
                         DJANGO_PORT: 8003
                     healthcheck:
@@ -160,6 +161,7 @@ class AgentServiceTest(ServiceTest):
                         apm-server:
                             condition: 'service_healthy'
                     environment:
+                        ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         FLASK_SERVICE_NAME: flaskapp
                         GUNICORN_CMD_ARGS: "-w 4 -b 0.0.0.0:8001"
                     healthcheck:

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -124,7 +124,6 @@ class AgentServiceTest(ServiceTest):
                         apm-server:
                             condition: 'service_healthy'
                     environment:
-                        ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         DJANGO_SERVICE_NAME: djangoapp
                         DJANGO_PORT: 8003
                     healthcheck:
@@ -161,7 +160,6 @@ class AgentServiceTest(ServiceTest):
                         apm-server:
                             condition: 'service_healthy'
                     environment:
-                        ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         FLASK_SERVICE_NAME: flaskapp
                         GUNICORN_CMD_ARGS: "-w 4 -b 0.0.0.0:8001"
                     healthcheck:

--- a/tests/versions/python.yml
+++ b/tests/versions/python.yml
@@ -4,5 +4,5 @@ PYTHON_AGENT:
   # release;release -> pip install elastic-apm==version
   - 'github;master'
   - 'release;latest'
-  - 'release;5.1'
-  - 'release;4.2'
+  - 'release;5.3.2'
+  - 'release;4.2.2'


### PR DESCRIPTION
## What does this PR do?

set Python 3.7 as the version used on containers, and define ELASTIC_APM_VERIFY_SERVER_CERT only on Python master branch. Finally, we have bump the APM agent Python versions to current latest minor releases

## Why is it important?

We have found two errors on current Python configuration for the integration test, Docker containers throw some errors with python 3.8 so we changed to the tested version 3.7, and ELASTIC_APM_VERIFY_SERVER_CERT is only supported on latest versions see https://github.com/elastic/apm-agent-python/issues/570

## Related issues
Closes #685