### PR TITLE
Make opbeans-dotnet listen on port 3000 instead of 80

### DIFF
--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -22,5 +22,5 @@ COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
 RUN apk update \
     && apk add --no-cache curl \
     && rm -rf /var/cache/apk/*
-EXPOSE 80
-ENTRYPOINT ["dotnet", "opbeans-dotnet.dll"]
+EXPOSE 3000
+ENTRYPOINT ["dotnet", "opbeans-dotnet.dll", "--urls", "http://*:3000"]

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -134,8 +134,8 @@ class OpbeansDotnet(OpbeansService):
             depends_on=depends_on,
             image=None,
             labels=None,
-            healthcheck=curl_healthcheck(80, "opbeans-dotnet", path="/", retries=36),
-            ports=[self.publish_port(self.port, 80)],
+            healthcheck=curl_healthcheck(3000, "opbeans-dotnet", path="/", retries=36),
+            ports=[self.publish_port(self.port, 3000)],
         )
         return content
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -61,7 +61,7 @@ class OpbeansServiceTest(ServiceTest):
                         - OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
                     container_name: localtesting_6.3.10_opbeans-dotnet
                     ports:
-                      - "127.0.0.1:3004:80"
+                      - "127.0.0.1:3004:3000"
                     environment:
                       - ELASTIC_APM_SERVICE_NAME=opbeans-dotnet
                       - ELASTIC_APM_SERVER_URLS=http://apm-server:8200
@@ -84,7 +84,7 @@ class OpbeansServiceTest(ServiceTest):
                       apm-server:
                         condition: service_healthy
                     healthcheck:
-                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-dotnet:80/"]
+                        test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-dotnet:3000/"]
                         interval: 10s
                         retries: 36""")
         )


### PR DESCRIPTION
Addressing #681 - which is that the load generator does not hit opbeans-dotnet except the health check url - so no real load was generated for opbeans-dotnet. - #681 talks about frontend, but turned out it is not really needed with the load generator. The current problem is that basically `opbeans-dotnet` does not generate any data, which this PR seems to solve.

@beniwohli found that opbeans-dotnet was listening on port `80` while the load generator uses port 3000 - or 3004 in case of .NET. 

In any case, this makes it work on my machine:
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/1091853/70259521-9fae0c00-178e-11ea-8ff6-6c09a730012c.png">
