### PR TITLE
custom APM server pipeline loading

### DIFF
--- a/docker/apm-server/pipelines/default.json
+++ b/docker/apm-server/pipelines/default.json
@@ -1,0 +1,61 @@
+[
+{
+  "id": "apm",
+  "body": {
+    "description" : "Default enrichment for APM events",
+    "processors" : [
+      {
+        "pipeline": {
+          "name": "apm_user_agent"
+        }
+      },
+      {
+        "pipeline": {
+          "name": "apm_user_geo"
+        }
+      }
+    ]
+  }
+},
+{
+  "id": "apm_user_agent",
+  "body": {
+    "description" : "Add user agent information for APM events",
+    "processors" : [
+      {
+        "user_agent" : {
+          "field": "user_agent.original",
+          "target_field": "user_agent",
+          "ignore_missing": true,
+          "ignore_failure": true
+        }
+      }
+    ]
+  }
+},
+{
+  "id": "apm_user_geo",
+  "body": {
+    "description" : "Add user geo information for APM events",
+    "processors" : [
+      {
+        "geoip" : {
+          "database_file": "GeoLite2-City.mmdb",
+          "field": "client.ip",
+          "target_field": "client.geo",
+          "ignore_missing": true,
+          "on_failure": [
+            {
+              "remove": {
+                  "field": "client.ip",
+                  "ignore_missing": true,
+                  "ignore_failure": true
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+]

--- a/docker/apm-server/pipelines/opbeans-servicemap.json
+++ b/docker/apm-server/pipelines/opbeans-servicemap.json
@@ -1,0 +1,84 @@
+[
+{
+  "id": "apm",
+  "body": {
+    "description" : "Default enrichment for APM events",
+    "processors" : [
+      {
+        "pipeline": {
+          "name": "apm_user_agent"
+        }
+      },
+      {
+        "pipeline": {
+          "name": "apm_user_geo"
+        }
+      },
+      {
+        "pipeline": {
+          "name": "opbeans_servicemap"
+        }
+      }
+    ]
+  }
+},
+{
+  "id": "apm_user_agent",
+  "body": {
+    "description" : "Add user agent information for APM events",
+    "processors" : [
+      {
+        "user_agent" : {
+          "field": "user_agent.original",
+          "target_field": "user_agent",
+          "ignore_missing": true,
+          "ignore_failure": true
+        }
+      }
+    ]
+  }
+},
+{
+  "id": "apm_user_geo",
+  "body": {
+    "description" : "Add user geo information for APM events",
+    "processors" : [
+      {
+        "geoip" : {
+          "database_file": "GeoLite2-City.mmdb",
+          "field": "client.ip",
+          "target_field": "client.geo",
+          "ignore_missing": true,
+          "on_failure": [
+            {
+              "remove": {
+                  "field": "client.ip",
+                  "ignore_missing": true,
+                  "ignore_failure": true
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+},
+{
+  "id": "opbeans_servicemap",
+  "body": {
+    "description": "sets destination on ext spans based on their name",
+    "processors": [
+      {
+        "set": {
+          "if": "ctx.span != null && ctx.span.type == 'ext'",
+          "field": "span.type",
+          "value": "external"
+        }
+      },
+      {
+        "script": "\n          if(ctx['span'] != null) {\n            if (ctx['span']['type'] == 'external') {\n              def spanName = ctx['span']['name'];\n              if (spanName.indexOf('/') > -1) {\n                spanName = spanName.substring(0, spanName.indexOf('/'));\n              }   \n              if (spanName.indexOf(' ') > -1) {\n                spanName = spanName.substring(spanName.indexOf(' ')+1, spanName.length());\n              }   \n            ctx['destination.address'] = spanName;\n            }   \n            if (ctx['span']['type'] == 'resource') {\n              def spanName = ctx['span']['name'];\n              if (spanName.indexOf('://') > -1) {\n                spanName = spanName.substring(spanName.indexOf('://')+3, spanName.length());\n              }   \n              if (spanName.indexOf('/') > -1) {\n                spanName = spanName.substring(0, spanName.indexOf('/'));\n              }   \n              ctx['destination.address'] = spanName;\n            }   \n            if (ctx['span']['type'] == 'db') {\n              def dest = ctx['span']['subtype'];\n              ctx['destination.address'] = dest;\n            }   \n            if (ctx['span']['type'] == 'cache') {\n              def dest = ctx['span']['subtype'];\n              ctx['destination.address'] = dest;\n            }   \n        }"
+      }
+    ]
+  }
+}
+]

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -144,6 +144,10 @@ class ApmServer(StackService, Service):
                     ("output.elasticsearch.pipelines", "[{pipeline: '%s'}]" % pipeline_name),
                     ("apm-server.register.ingest.pipeline.enabled", "true"),
                 ])
+                if options.get("apm_server_pipeline_path"):
+                    self.apm_server_command_args.append(
+                        ("apm-server.register.ingest.pipeline.overwrite", "true"),
+                    )
         else:
             add_es_config(self.apm_server_command_args,
                           prefix="monitoring" if self.at_least_version("7.2") else "xpack.monitoring")

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -694,6 +694,7 @@ class ApmServerServiceTest(ServiceTest):
     def test_apm_server_custom_pipeline(self):
         apm_server = ApmServer(version="8.0", apm_server_pipeline_path="foo").render()["apm-server"]
         self.assertIn("foo:/usr/share/apm-server/ingest/pipeline/definition.json", apm_server["volumes"])
+        self.assertIn("apm-server.register.ingest.pipeline.overwrite=true", apm_server["command"])
 
 
 class ElasticsearchServiceTest(ServiceTest):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -691,6 +691,10 @@ class ApmServerServiceTest(ServiceTest):
         self.assertTrue("apm-server.kibana.password=notchangeme" in apm_server["command"],
                         "APM Server Kibana password overridden")
 
+    def test_apm_server_custom_pipeline(self):
+        apm_server = ApmServer(version="8.0", apm_server_pipeline_path="foo").render()["apm-server"]
+        self.assertIn("foo:/usr/share/apm-server/ingest/pipeline/definition.json", apm_server["volumes"])
+
 
 class ElasticsearchServiceTest(ServiceTest):
     def test_6_2_release(self):


### PR DESCRIPTION
Enable custom APM server pipeline loading.  example usage:

```
/scripts/compose.py start master --apm-server-pipeline-path=./docker/apm-server/pipelines/opbeans-servicemap.json
```