### PR TITLE
add --apm-server-api-key-auth option

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -93,6 +93,9 @@ class ApmServer(StackService, Service):
                     ("setup.dashboards.enabled", "true")
                 )
 
+        # configure authentication
+        if options.get("apm_server_api_key_auth", False):
+            self.apm_server_command_args.append(("apm-server.api_key.enabled", "true"))
         if self.options.get("apm_server_secret_token"):
             self.apm_server_command_args.append(("apm-server.secret_token", self.options["apm_server_secret_token"]))
 
@@ -298,6 +301,11 @@ class ApmServer(StackService, Service):
         parser.add_argument(
             "--apm-server-queue-write-flush-timeout",
             help="apm-server file write flush timeout.",
+        )
+        parser.add_argument(
+            "--apm-server-api-key-auth",
+            action="store_true",
+            help="enable apm-server api key authentication for agent communication.",
         )
         parser.add_argument(
             '--apm-server-secret-token',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -378,6 +378,10 @@ class ApmServerServiceTest(ServiceTest):
             apm_server["image"], "docker.elastic.co/apm/apm-server-oss:6.3.100"
         )
 
+    def test_api_key_auth(self):
+        apm_server = ApmServer(version="7.6.100", apm_server_api_key_auth=True).render()["apm-server"]
+        self.assertIn("apm-server.api_key.enabled=true", apm_server["command"])
+
     def test_elasticsearch_output(self):
         apm_server = ApmServer(version="6.3.100", apm_server_output="elasticsearch").render()["apm-server"]
         self.assertFalse(


### PR DESCRIPTION
APM Server can use api keys to authenticate agents now.  This change permits enabling that feature.