### PR TITLE
fix: remove whitespaces from label

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -219,6 +219,7 @@ def wrappingup(label){
     def stepName = label.replace(";","/")
       .replace("--","_")
       .replace(".","_")
+      .replace(" ","_")
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
     sh('make stop-env || echo 0')
     archiveArtifacts(


### PR DESCRIPTION
## What does this PR do?

it removes whitespaces from the label before to grab the Docker logs.

## Why is it important?

Whit some label it is not possible to grab the Docker info because the name of the folder has white spaces (e.g `java:github;master#master --oss`).

```
[2019-12-12T03:25:10.072Z] + ./scripts/docker-get-logs.sh java-github/master-master _oss
[2019-12-12T03:25:10.072Z] cp: -r not specified; omitting directory 'docker-info/java-github/master-master'
```
