### PR TITLE
ci(jenkins): simplify the git base commit and avoid docker in the labels

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,18 +1,10 @@
 #!/usr/bin/env groovy
 @Library('apm@current') _
 
-import groovy.transform.Field
-
-/**
-This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
-*/
-@Field def gitBaseCommit
-
 pipeline {
-  agent none
+  agent { label 'linux && immutable' }
   environment {
-    BASE_DIR="src/github.com/elastic/apm-integration-testing"
+    BASE_DIR = 'src/github.com/elastic/apm-integration-testing'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     PIPELINE_LOG_LEVEL='INFO'
@@ -40,14 +32,10 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'linux && immutable' }
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-        script {
-          gitBaseCommit = env.GIT_BASE_COMMIT
-        }
       }
     }
 
@@ -57,7 +45,6 @@ pipeline {
           Validate UTs and lint the app
         */
         stage('Unit Tests'){
-          agent { label 'linux && immutable && docker' }
           options { skipDefaultCheckout() }
           steps {
             withGithubNotify(context: 'Unit Tests', tab: 'tests') {
@@ -77,7 +64,7 @@ pipeline {
           }
         }
         stage('Sanity checks') {
-          agent { label 'linux && immutable && docker' }
+          agent { label 'linux && immutable' }
           options { skipDefaultCheckout() }
           environment {
             PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
@@ -88,7 +75,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                preCommit(commit: "${gitBaseCommit}", junit: true)
+                preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true)
               }
             }
           }
@@ -147,7 +134,7 @@ def runJob(agentName, buildOpts = ''){
     parameters: [
     string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-    string(name: 'INTEGRATION_TESTING_VERSION', value: gitBaseCommit),
+    string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
     string(name: 'MERGE_TARGET', value: "${branch}"),
     string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
     string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -11,7 +11,7 @@ import groovy.transform.Field
 @Field def integrationTestsGen
 
 pipeline {
-  agent { label 'linux && immutable && docker' }
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     REPO="git@github.com:elastic/apm-integration-testing.git"


### PR DESCRIPTION
## What does this PR do?

- Remove docker label as it's redundant when using linux workers.
- Avoid the gitBaseCommit variable and use the env variable instead.

## Why is it important?

Let's keep the pipeline simpler.

## Related issues
Closes #ISSUE