### PR TITLE
Add flags combination to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ docker-compose stop <service name>
 
 ## Example environments
 
+We have a list with the most common flags combination that we internally use when developing our APM solution. You can find the list [here](https://docs.google.com/spreadsheets/d/1NCPR3RX670ZZOHXx7_y6bhe1zrSMYabPQ5Htheu3oZA/edit?usp=sharing).
+
 ### Change default ports
 
 Expose Kibana on http://localhost:1234:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,26 @@ docker-compose stop <service name>
 
 ## Example environments
 
-We have a list with the most common flags combination that we internally use when developing our APM solution. You can find the list [here](https://docs.google.com/spreadsheets/d/1NCPR3RX670ZZOHXx7_y6bhe1zrSMYabPQ5Htheu3oZA/edit?usp=sharing).
+We have a list with the most common flags combination that we internally use when developing our APM solution. You can find the list here:
+
+|Persona | Flags | Motivation / Use Case | Team | Comments |
+|--------|-------|-----------------------|------|----------|
+| CI Server | `python scripts/compose.py start 8.0.0 --java-agent-version ${COMMIT_SHA} --build-parallel --with-agent-java-spring --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --force-build` | Prepare environment for running tests for APM Java agent | APM Agents |
+| CI Server	| `python scripts/compose.py start 8.0.0 --apm-server-build https://github.com/elastic/apm-server@${COMMIT_HASH} --build-parallel --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --with-agent-dotnet --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --with-agent-python-django --with-agent-python-flask --force-build`	| Prepare environment for running tests for APM Server	| APM Server | |
+| Demos & Screenshots	| `./scripts/compose.py start --release --with-opbeans-dotnet --with-opbeans-go --with-opbeans-java --opbeans-java-agent-branch=pr/588/head --force-build --with-opbeans-node --with-opbeans-python --with-opbeans-ruby --with-opbeans-rum --with-filebeat --with-metricbeat 7.3.0`	| demos, screenshots, ad hoc QA. It's also used to send heartbeat data to the cluster for Uptime | PMM	| Used for snapshots when close to a release, without the `--release` flag |
+| Development | `./scripts/compose.py start 7.3 --bc --with-opbeans-python --opbeans-python-agent-local-repo=~/elastic/apm-agent-python` | Use current state of local agent repo with opbeans | APM Agents | This works perfectly for Python, but has problems with Node.js. We are not mounting the local folder as a volume, but copy it. This is to avoid any side effects to the local repo. The node local dev folder can get very large due to node_modules, which takes some time to copy. |
+| | `./scripts/compose.py start 7.3 --bc --start-opbeans-deps` | This flag would start all opbeans dependencies (postgres, redis, apm-server, ...), but not any opbeans instances | APM Agents | This would help when developing with a locally running opbeans. Currently, we start the environment with a `--with-opbeans-python` flag, then stop the opbeans-python container manually |
+| Developer | `./scripts/compose.py start master --no-apm-server` | Only use Kibana + ES in desired version for testing | APM Server |  |
+| Developer | `./scripts/compose.py start --release 7.3 --no-apm-server` | Use released Kibana + ES, with custom agent and server running on host, for developing new features that span agent and server. | APM Agents | If `--opbeans-go-agent-local-repo` worked, we might be inclined to use that instead of running custom apps on the host. Would have been handy while developing support for breakdown graphs. Even then, it's probably still faster to iterate on the agent without involving Docker. |
+| Demos & Compettive | `./scripts/compose.py start 6.7.0 --release --with-services ~/src/elastic/apm-dev/docs/static/jaeger.json --with-services ~/src/elastic/apm-dev/docs/static/zipkin.json --with-services ~/src/elastic/apm-dev/docs/static/haystack.json` | Integration / comparison with external products that we'd prefer not to include in compose.py | APM | https://github.com/elastic/apm-dev/blob/master/docs/competitive.md |
+| Developer | `./scripts/compose.py start master --no-kibana` | Use newest ES/master, with custom kibana on host, for developing new features in kibana | APM |  |
+| Developer | `./scripts/compose.py start 6.3 --with-kafka --with-zookeeper --apm-server-output=kafka --with-logstash --with-agent-python-flask` | Testing with kafka and logstash ingestion methods | APM |  |	
+| Developer | `./scripts/compose.py start master --no-kibana --with-opbeans-node --with-opbeans-rum --with-opbeans-x` | Developing UI features locally | APM UI | |
+| Developer | `./scripts/compose.py start master --docker-compose-path - --skip-download --no-kibana --with-opbeans-ruby --opbeans-ruby-agent-branch=master > docker-compose.yml` | Developing UI features againt specific configuration | APM UI | We sometimes explicity write a `docker-compose.yml` file and tinker with it until we get the desired configuration becore running `docker-compose up` |
+| Developer | `scripts/compose.py start ${version}` | Manual testing of agent features | APM Agents | |
+| Developer | `./scripts/compose.py start master --with-opbeans-java --opbeans-java-agent-branch=pr/588/head --apm-server-build https://github.com/elastic/apm-server.git@master` | Test with in-progress agent/server features | APM UI |  |
+| Developer | `compose.py start 7.0 --release --apm-server-version=6.8.0` | Upgrade/mixed version testing | APM | Then, without losing es data, upgrade/downgrade various components |
+
 
 ### Change default ports
 


### PR DESCRIPTION
## What does this PR do?
This PR adds the most used flag combinations the team uses for internal development.

## Why is it important?
We want to share with the public this information just in case they need to replicate a custom environment we already use, not reinventing the wheel.

## Related issues
Closes elastic/observability-dev#131