### PR TITLE
enable fielddata for _id

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -551,6 +551,8 @@ class Elasticsearch(StackService, Service):
 
         self.environment = self.default_environment + [
             java_opts_env, "path.data=/usr/share/elasticsearch/data/" + data_dir]
+        if self.at_least_version("8.0"):
+            self.environment.append("indices.id_field_data.enabled=true")
         if not self.oss:
             xpack_security_enabled = "false"
             if self.xpack_secure:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -861,6 +861,7 @@ class LocalTest(unittest.TestCase):
                     path.repo=/usr/share/elasticsearch/data/backups,
                     'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g',
                     path.data=/usr/share/elasticsearch/data/8.0.0,
+                    indices.id_field_data.enabled=true,
                     xpack.security.authc.anonymous.roles=remote_monitoring_collector,
                     xpack.security.authc.realms.file.file1.order=0,
                     xpack.security.authc.realms.native.native1.order=1,


### PR DESCRIPTION
To address the spew of these es warnings:

```
localtesting_8.0.0_elasticsearch | {"type": "server", "timestamp": "2019-12-16T19:27:23,866Z", "level": "DEBUG", "component": "o.e.a.s.TransportSearchAction", "cluster.name": "docker-cluster", "node.name": "0cea8eb8e7b6", "message": "[.kibana_task_manager_1][0], node[939krZVATICVQTypc4RYWw], [P], s[STARTED], a[id=ctYMwMXLTrmvzGC2DqqMug]: Failed to execute [SearchRequest{searchType=QUERY_THEN_FETCH, indices=[.kibana_task_manager], indicesOptions=IndicesOptions[ignore_unavailable=true, allow_no_indices=true, expand_wildcards_open=true, expand_wildcards_closed=false, allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true], routing='null', preference='null', requestCache=null, scroll=null, maxConcurrentShardRequests=0, batchedReduceSize=512, preFilterShardSize=128, allowPartialSearchResults=true, localClusterAlias=null, getOrCreateAbsoluteStartMillis=-1, ccsMinimizeRoundtrips=true, source={\"query\":{\"bool\":{\"must\":[{\"term\":{\"type\":{\"value\":\"task\",\"boost\":1.0}}},{\"bool\":{\"filter\":[{\"term\":{\"_id\":{\"value\":\"task:Lens-lens_telemetry\",\"boost\":1.0}}}],\"boost\":1.0}}],\"boost\":1.0}},\"sort\":[{\"task.runAt\":{\"order\":\"asc\"}},{\"_id\":{\"order\":\"desc\"}}]}}]", "cluster.uuid": "g-B-m2JTTo-iYzNeRdx4Xw", "node.id": "939krZVATICVQTypc4RYWw" , 
localtesting_8.0.0_elasticsearch | "stacktrace": ["org.elasticsearch.transport.RemoteTransportException: [0cea8eb8e7b6][172.20.0.3:9300][indices:data/read/search[phase/query]]",
localtesting_8.0.0_elasticsearch | "Caused by: java.lang.IllegalArgumentException: Fielddata access on the _id field is disallowed, you can re-enable it by updating the dynamic cluster setting: indices.id_field_data.enabled",
```