### PR TITLE
Document pytest markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ markers =
     django: mark a test as for the Django framework in the Python APM agent
     dotnet: mark a test as for the .NET APM agent
     flask: mark a test as for the Flask framework in the Python APM agent
-    go_nethttp: marks a test as for the nethttp framework in the Go APM agent
+    go_nethttp: mark a test as for the net/http framework in the Go APM agent
     java_spring: mark a test as for the Spring framework in the Java APM agent
     rails: mark a test as for the Rails framework in the Ruby APM agent
     upgradetest: mark a test as an upgrade test.  disabled by default, use --run-upgrade to enable.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 markers =
-    django: marks a test as for the Django framework in the Python APM agent
+    django: mark a test as for the Django framework in the Python APM agent
     dotnet: marks a test as for the .NET APM agent
     flask: marks a test as for the flask framework in the Python APM agent
     go_nethttp: marks a test as for the nethttp framework in the Go APM agent

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,10 @@
 [pytest]
 markers =
+    django: marks a test as for the Django framework in the Python APM agent
+    dotnet: marks a test as for the .NET APM agent
+    flask: marks a test as for the flask framework in the Python APM agent
+    go_nethttp: marks a test as for the nethttp framework in the Go APM agent
+    java_spring: mark a test as for the Spring framework in the Java APM agent
+    rails: mark a test as for the Rails framework in the Ruby APM agent
     upgradetest: mark a test as an upgrade test.  disabled by default, use --run-upgrade to enable.
+    version: mark a test for a specific version.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 markers =
     django: mark a test as for the Django framework in the Python APM agent
-    dotnet: marks a test as for the .NET APM agent
+    dotnet: mark a test as for the .NET APM agent
     flask: marks a test as for the flask framework in the Python APM agent
     go_nethttp: marks a test as for the nethttp framework in the Go APM agent
     java_spring: mark a test as for the Spring framework in the Java APM agent

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 markers =
     django: mark a test as for the Django framework in the Python APM agent
     dotnet: mark a test as for the .NET APM agent
-    flask: marks a test as for the flask framework in the Python APM agent
+    flask: mark a test as for the Flask framework in the Python APM agent
     go_nethttp: marks a test as for the nethttp framework in the Go APM agent
     java_spring: mark a test as for the Spring framework in the Java APM agent
     rails: mark a test as for the Rails framework in the Ruby APM agent


### PR DESCRIPTION
## What does this PR do?
It adds existing pytest markers to the pytest.ini file, which is used to document them.
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
Having this list will enable visibility about what kind of filter we can use to run the python tests, so running:
```shell
$ pytest --markers
```
will show the list of existing markers, including default ones, when at this moment it's just showing defaults.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Console Outputs
Before:
```shell
@pytest.mark.upgradetest: mark a test as an upgrade test.  disabled by default, use --run-upgrade to enable.

@pytest.mark.random_order(disabled=True): disable reordering of tests within a module or class

@pytest.mark.nondestructive: mark the test as nondestructive. Tests are assumed to be destructive unless this marker is present. This reduces the risk of running destructive tests accidentally.

@pytest.mark.firefox_arguments(args): arguments to be passed to Firefox. This marker will be ignored for other browsers. For example: firefox_arguments('-foreground')

@pytest.mark.firefox_preferences(dict): preferences to be passed to Firefox. This marker will be ignored for other browsers. For example: firefox_preferences({'browser.startup.homepage': 'https://pytest.org/'})

@pytest.mark.skip(reason=None): skip the given test function with an optional reason. Example: skip(reason="no way of currently testing this") skips the test.

@pytest.mark.skipif(condition): skip the given test function if eval(condition) results in a True value.  Evaluation happens within the module global context. Example: skipif('sys.platform == "win32"') skips the test if we are on the win32 platform. see http://pytest.org/latest/skipping.html

@pytest.mark.xfail(condition, reason=None, run=True, raises=None, strict=False): mark the test function as an expected failure if eval(condition) has a True value. Optionally specify a reason for better reporting and run=False if you don't even want to execute the test function. If only specific exception(s) are expected, you can list them in raises, and if the test fails in other ways, it will be reported as a true failure. See http://pytest.org/latest/skipping.html

@pytest.mark.parametrize(argnames, argvalues): call a test function multiple times passing in different arguments in turn. argvalues generally needs to be a list of values if argnames specifies only one name or a list of tuples of values if argnames specifies multiple names. Example: @parametrize('arg1', [1,2]) would lead to two calls of the decorated test function, one with arg1=1 and another with arg1=2.see http://pytest.org/latest/parametrize.html for more info and examples.

@pytest.mark.usefixtures(fixturename1, fixturename2, ...): mark tests as needing all of the specified fixtures. see http://pytest.org/latest/fixture.html#usefixtures 

@pytest.mark.tryfirst: mark a hook implementation function such that the plugin machinery will try to call it first/as early as possible.

@pytest.mark.trylast: mark a hook implementation function such that the plugin machinery will try to call it last/as late as possible.

@pytest.mark.capabilities(kwargs): add or change existing capabilities. specify capabilities as keyword arguments, for example capabilities(foo=bar)
```
After:
```shell
@pytest.mark.django: marks a test as for the Django framework in the Python APM agent

@pytest.mark.dotnet: marks a test as for the .NET APM agent

@pytest.mark.flask: marks a test as for the flask framework in the Python APM agent

@pytest.mark.go_nethttp: marks a test as for the nethttp framework in the Go APM agent

@pytest.mark.java_spring: mark a test as for the Spring framework in the Java APM agent

@pytest.mark.rails: mark a test as for the Rails framework in the Ruby APM agent

@pytest.mark.upgradetest: mark a test as an upgrade test.  disabled by default, use --run-upgrade to enable.

@pytest.mark.version: mark a test for a specific version.

@pytest.mark.random_order(disabled=True): disable reordering of tests within a module or class

@pytest.mark.nondestructive: mark the test as nondestructive. Tests are assumed to be destructive unless this marker is present. This reduces the risk of running destructive tests accidentally.

@pytest.mark.firefox_arguments(args): arguments to be passed to Firefox. This marker will be ignored for other browsers. For example: firefox_arguments('-foreground')

@pytest.mark.firefox_preferences(dict): preferences to be passed to Firefox. This marker will be ignored for other browsers. For example: firefox_preferences({'browser.startup.homepage': 'https://pytest.org/'})

@pytest.mark.skip(reason=None): skip the given test function with an optional reason. Example: skip(reason="no way of currently testing this") skips the test.

@pytest.mark.skipif(condition): skip the given test function if eval(condition) results in a True value.  Evaluation happens within the module global context. Example: skipif('sys.platform == "win32"') skips the test if we are on the win32 platform. see http://pytest.org/latest/skipping.html

@pytest.mark.xfail(condition, reason=None, run=True, raises=None, strict=False): mark the test function as an expected failure if eval(condition) has a True value. Optionally specify a reason for better reporting and run=False if you don't even want to execute the test function. If only specific exception(s) are expected, you can list them in raises, and if the test fails in other ways, it will be reported as a true failure. See http://pytest.org/latest/skipping.html

@pytest.mark.parametrize(argnames, argvalues): call a test function multiple times passing in different arguments in turn. argvalues generally needs to be a list of values if argnames specifies only one name or a list of tuples of values if argnames specifies multiple names. Example: @parametrize('arg1', [1,2]) would lead to two calls of the decorated test function, one with arg1=1 and another with arg1=2.see http://pytest.org/latest/parametrize.html for more info and examples.

@pytest.mark.usefixtures(fixturename1, fixturename2, ...): mark tests as needing all of the specified fixtures. see http://pytest.org/latest/fixture.html#usefixtures 

@pytest.mark.tryfirst: mark a hook implementation function such that the plugin machinery will try to call it first/as early as possible.

@pytest.mark.trylast: mark a hook implementation function such that the plugin machinery will try to call it last/as late as possible.

@pytest.mark.capabilities(kwargs): add or change existing capabilities. specify capabilities as keyword arguments, for example capabilities(foo=bar)
```


## Related issues
Relates elastic/observability-dev#501