### PR TITLE
generate valid version 3.7 docker-compose.yml

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -620,7 +620,7 @@ class Elasticsearch(StackService, Service):
         return dict(
             environment=self.environment,
             healthcheck={
-                "interval": "20",
+                "interval": "20s",
                 "retries": 10,
                 "test": ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"],
             },


### PR DESCRIPTION
adds `--docker-compose-yml-version` option.