### PR TITLE
ci(jenkins): Customise login with an assistance message

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -636,6 +636,8 @@ class Kibana(StackService, Service):
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
+        if self.at_least_version("7.6"):
+            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login details {}/{}".format(self.environment["ELASTICSEARCH_USERNAME"],self.environment["ELASTICSEARCH_PASSWORD"])
 
     @classmethod
     def add_arguments(cls, parser):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -637,8 +637,10 @@ class Kibana(StackService, Service):
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
         if self.at_least_version("7.6") and options.get("xpack_secure"):
-            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login details {}/{}".format(
-                self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"])
+            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login details `{}/{}`. " \
+                "Further details [here]({}).".format(
+                    self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"],
+                    "https://github.com/elastic/apm-integration-testing#logging-in")
 
     @classmethod
     def add_arguments(cls, parser):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -657,8 +657,8 @@ class Kibana(StackService, Service):
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
         if self.at_least_version("7.6") and options.get("xpack_secure"):
-            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login\\_details:\\_`{}/{}`.\\_" \
-                "Further\\_details\\_[here]({}).".format(
+            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login&#32;details:&#32;`{}/{}`.&#32;" \
+                "Further&#32;details&#32;[here]({}).".format(
                     self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"],
                     "https://github.com/elastic/apm-integration-testing#logging-in")
 

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -636,8 +636,9 @@ class Kibana(StackService, Service):
                 self.environment["STATUS_ALLOWANONYMOUS"] = "true"
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
-        if self.at_least_version("7.6"):
-            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login details {}/{}".format(self.environment["ELASTICSEARCH_USERNAME"],self.environment["ELASTICSEARCH_PASSWORD"])
+        if self.at_least_version("7.6") and options.get("xpack_secure"):
+            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login details {}/{}".format(
+                self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"])
 
     @classmethod
     def add_arguments(cls, parser):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -657,8 +657,8 @@ class Kibana(StackService, Service):
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
         if self.at_least_version("7.6") and options.get("xpack_secure"):
-            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login details `{}/{}`. " \
-                "Further details [here]({}).".format(
+            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login\_details:\_`{}/{}`.\_" \
+                "Further\_details\_[here]({}).".format(
                     self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"],
                     "https://github.com/elastic/apm-integration-testing#logging-in")
 

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -657,8 +657,8 @@ class Kibana(StackService, Service):
         self.environment["ELASTICSEARCH_URL"] = ",".join(self.options.get(
             "kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS])
         if self.at_least_version("7.6") and options.get("xpack_secure"):
-            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login\_details:\_`{}/{}`.\_" \
-                "Further\_details\_[here]({}).".format(
+            self.environment["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"] = "Login\\_details:\\_`{}/{}`.\\_" \
+                "Further\\_details\\_[here]({}).".format(
                     self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"],
                     "https://github.com/elastic/apm-integration-testing#logging-in")
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -902,7 +902,7 @@ class LocalTest(unittest.TestCase):
                     STATUS_ALLOWANONYMOUS: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
-                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login details `kibana_system_user/changeme`. Further details [here](https://github.com/elastic/apm-integration-testing#logging-in).'
+                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login\_details:\_`kibana_system_user/changeme`.\_Further\_details\_[here](https://github.com/elastic/apm-integration-testing#logging-in).'
                 }
                 healthcheck:
                     interval: 10s

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -918,7 +918,7 @@ class LocalTest(unittest.TestCase):
                     STATUS_ALLOWANONYMOUS: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
-                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login\_details:\_`kibana_system_user/changeme`.\_Further\_details\_[here](https://github.com/elastic/apm-integration-testing#logging-in).'
+                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`kibana_system_user/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'
                 }
                 healthcheck:
                     interval: 10s

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -901,7 +901,7 @@ class LocalTest(unittest.TestCase):
                     STATUS_ALLOWANONYMOUS: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
-                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login details kibana_system_user/changeme'
+                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login details `kibana_system_user/changeme`. Further details [here](https://github.com/elastic/apm-integration-testing#logging-in).'
                 }
                 healthcheck:
                     interval: 10s

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -900,7 +900,8 @@ class LocalTest(unittest.TestCase):
                     SERVER_NAME: kibana.example.org,
                     STATUS_ALLOWANONYMOUS: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
-                    XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'
+                    XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
+                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login details kibana_system_user/changeme'
                 }
                 healthcheck:
                     interval: 10s

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -985,7 +985,7 @@ class KibanaServiceTest(ServiceTest):
 
     def test_kibana_login_assistance_message(self):
         kibana = Kibana(version="7.6.0", xpack_secure=True, kibana_version="7.6.0").render()["kibana"]
-        self.assertIn("Login details `kibana_system_user/changeme`.", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
+        self.assertIn("Login\_details:\_`kibana_system_user/changeme`.", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
 
     def test_kibana_login_assistance_message_wihtout_xpack(self):
         kibana = Kibana(version="7.6.0", xpack_secure=False, kibana_version="7.6.0").render()["kibana"]

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -957,8 +957,12 @@ class KibanaServiceTest(ServiceTest):
         self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
 
     def test_kibana_login_assistance_message(self):
-        kibana = Kibana(version="7.6.0", kibana_snapshot=True, kibana_version="7.6.0").render()["kibana"]
-        self.assertEqual("Login details kibana_system_user/changeme", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
+        kibana = Kibana(version="7.6.0", xpack_secure=True, kibana_version="7.6.0").render()["kibana"]
+        self.assertEquals("Login details kibana_system_user/changeme", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
+
+    def test_kibana_login_assistance_message_wihtout_xpack(self):
+        kibana = Kibana(version="7.6.0", xpack_secure=False, kibana_version="7.6.0").render()["kibana"]
+        self.assertNotIn("XPACK_SECURITY_LOGINASSISTANCEMESSAGE", kibana['environment'])
 
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -956,6 +956,9 @@ class KibanaServiceTest(ServiceTest):
         kibana = Kibana(version="7.3.0", kibana_snapshot=True, kibana_version="7.3.0").render()["kibana"]
         self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
 
+    def test_kibana_login_assistance_message(self):
+        kibana = Kibana(version="7.6.0", kibana_snapshot=True, kibana_version="7.6.0").render()["kibana"]
+        self.assertEqual("Login details kibana_system_user/changeme", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
 
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -985,7 +985,7 @@ class KibanaServiceTest(ServiceTest):
 
     def test_kibana_login_assistance_message(self):
         kibana = Kibana(version="7.6.0", xpack_secure=True, kibana_version="7.6.0").render()["kibana"]
-        self.assertIn("Login\_details:\_`kibana_system_user/changeme`.", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
+        self.assertIn("Login&#32;details:&#32;`kibana_system_user/changeme`.", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
 
     def test_kibana_login_assistance_message_wihtout_xpack(self):
         kibana = Kibana(version="7.6.0", xpack_secure=False, kibana_version="7.6.0").render()["kibana"]

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -958,7 +958,7 @@ class KibanaServiceTest(ServiceTest):
 
     def test_kibana_login_assistance_message(self):
         kibana = Kibana(version="7.6.0", xpack_secure=True, kibana_version="7.6.0").render()["kibana"]
-        self.assertEquals("Login details kibana_system_user/changeme", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
+        self.assertIn("Login details `kibana_system_user/changeme`.", kibana['environment']["XPACK_SECURITY_LOGINASSISTANCEMESSAGE"])
 
     def test_kibana_login_assistance_message_wihtout_xpack(self):
         kibana = Kibana(version="7.6.0", xpack_secure=False, kibana_version="7.6.0").render()["kibana"]


### PR DESCRIPTION
## What does this PR do?

Enable a customized message on the Kibana login page.

## Why is it important?

Help to know the login details easily.

## Related issues

Caused by https://github.com/elastic/kibana/pull/51557
Closes https://github.com/elastic/apm-integration-testing/issues/677
Blocked by https://github.com/elastic/kibana/issues/53800

## How to test

```bash
python scripts/compose.py start 8.0.0   --build-parallel --no-apm-server-dashboards --no-apm-server-self-instrument --force-build
open http://localhost:5601
docker logs -f localtesting_8.0.0_kibana
```

## UI

![image](https://user-images.githubusercontent.com/2871786/72347306-bd488c80-36cf-11ea-8722-b150b7be8230.png)


