### PR TITLE
Sort options and separate by newline

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -486,7 +486,7 @@ class LocalSetup(object):
         subprocess.call(cmd, shell=True)
 
     def listoptions_handler(self):
-        print("{}".format(" ".join(self.available_options)))
+        print("{}".format("\n".join(sorted(self.available_options))))
 
     def start_handler(self):
         args = vars(self.args)


### PR DESCRIPTION
## What does this PR do?

This is a tiny DX improvement that makes the options list a bit easier to read.

## Why is it important?

When viewing options, this makes it easier to both grep for what I might want and it makes it a bit easier to scan through since options are now alphabetized.

## Related issues
No issue filed. Minor DX improvement.
