### PR TITLE
update docker-compose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,8 @@ certifi==2017.11.5
 chardet==3.0.4
 coverage==4.5.1
 docker-compose-wait==1.0.0
-# must be >= 1.23.0 for build --parallel
-docker-compose==1.23.1
-docker-pycreds==0.3.0
-docker==3.5.1
+docker-compose==1.25.0
+docker==3.7.3
 dockerpty==0.4.1
 docopt==0.6.2
 elasticsearch==6.3.1


### PR DESCRIPTION
## What does this PR do?

Update docker-compose to 1.25.0.
Removes `docker-pycreds` - it doesn't appear to be used and would need an update if kept.

## Why is it important?

resolves logged warning:

```
ERROR: docker-compose 1.23.1 has requirement requests!=2.11.0,!=2.12.2,!=2.18.0,<2.21,>=2.6.1, but you'll have requests 2.22.0 which is incompatible.
```

Also includes a bunch of [enhancements & bug fixes](https://github.com/docker/compose/blob/1.25.0/CHANGELOG.md)