### PR TITLE
ci(jenkins): cache php alpine docker images

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -52,6 +52,9 @@ opbeans/opbeans-node:latest
 opbeans/opbeans-python:latest
 opbeans/opbeans-ruby:latest
 openjdk:10-jre-slim
+php:7-alpine
+php:7.2-alpine
+php:7.3-alpine
 pypy:2
 pypy:3
 python:2.7


### PR DESCRIPTION
## What does this PR do?

Cache PHP  docker images in the CI workers

## Why is it important?

Speed up the build times

## Related issues

Depends on https://github.com/elastic/ecs-logging-php/pull/4