### PR TITLE
Add reference repo for apm-integration-testing

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,7 +34,8 @@ pipeline {
     stage('Checkout'){
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        gitCheckout(basedir: "${BASE_DIR}",
+                    reference: '/var/lib/jenkins/.git-references/apm-integration-testing.git')
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/jobs/apm-integration-test-downstream.yml
+++ b/.ci/jobs/apm-integration-test-downstream.yml
@@ -33,6 +33,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-integration-testing.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -33,6 +33,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-integration-testing.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
@@ -33,6 +33,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-integration-testing.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-integration-tests.yml
+++ b/.ci/jobs/apm-integration-tests.yml
@@ -37,6 +37,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-integration-testing.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'


### PR DESCRIPTION
## What does this PR do?

Adds reference repos.

These correspond to repos and download locations which can be seen in [the Jenkins job which mirrors them](https://apm-ci.elastic.co/job/jenkins-git-fetch-reference/).

## Why is it important?

Makes for more efficient git checkouts.

## Related issues
Refs a private repo
