### PR TITLE
Ensure TS helper works correctly with arrays

### DIFF
--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/package.json
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.18.0",
     "prettier": "^1.16.4",
     "ts-node": "^8.0.2",
-    "typescript": "^3.3.3333"
+    "typescript": "3.7.4"
   },
   "devDependencies": {
     "@types/node": "^11.9.6",

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/helpers.ts
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/helpers.ts
@@ -25,7 +25,8 @@
 //      };
 //    };
 export type AllowUnknownProperties<T> = T extends object
-  ? { [P in keyof T]: AllowUnknownProperties<T[P]> } & {
+  ? T extends Array<infer U> ? Array<AllowUnknownProperties<U>> : 
+  { [P in keyof T]: AllowUnknownProperties<T[P]> } & {
       [key: string]: unknown;
     }
   : T;

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/yarn.lock
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/yarn.lock
@@ -93,7 +93,7 @@ ts-node@^8.0.2:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-typescript@^3.3.3333:
+typescript@3.7.4:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
   integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==


### PR DESCRIPTION
Previously AllowUnknownProperties incorrectly created a union type of arrays & Record<string, unknown>, which caused tests to fail. This change makes sure the union type applies to the element type, not to the array.

Looks like this started failing because the dependencies were updated in `6bd40ebaf465964711841abf511181e769ecbdd6`. This changed the TS version from 3.3 (which did not have this issue) to 3.7.4 (which does). I've pinned the TS version as well.