### PR TITLE
Introdce APM_SERVICE_VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docker-info/
 # For the BATS testing
 bats-core/
 target/
+.tags*

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -58,6 +58,7 @@ def _load_image(cache_dir, url):
         f.write(new_etag)
     return True
 
+
 def generated_version():
     """Generates a service version randomly."""
     return uuid.uuid4()

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import uuid
 
 try:
     from urllib.request import urlopen, urlretrieve, Request
@@ -56,6 +57,10 @@ def _load_image(cache_dir, url):
     with open(etag_cache_file, mode='w') as f:
         f.write(new_etag)
     return True
+
+def generated_version():
+    """Generates a service version randomly."""
+    return uuid.uuid4()
 
 
 def load_images(urls, cache_dir):

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -4,9 +4,8 @@
 
 from collections import OrderedDict
 
-from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck, generated_version
+from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck
 from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_JS_SERVER_URL, DEFAULT_SERVICE_VERSION
-
 
 
 class OpbeansService(Service):

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -4,8 +4,9 @@
 
 from collections import OrderedDict
 
-from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck
-from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_JS_SERVER_URL
+from .helpers import add_agent_environment, curl_healthcheck, wget_healthcheck, generated_version
+from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_JS_SERVER_URL, DEFAULT_SERVICE_VERSION
+
 
 
 class OpbeansService(Service):
@@ -16,6 +17,7 @@ class OpbeansService(Service):
         self.opbeans_dt_probability = options.get("opbeans_dt_probability", 0.5)
         if hasattr(self, "DEFAULT_SERVICE_NAME"):
             self.service_name = options.get(self.option_name() + "_service_name", self.DEFAULT_SERVICE_NAME)
+        self.service_version = options.get(self.option_name() + "_service_version", DEFAULT_SERVICE_VERSION)
         self.agent_branch = options.get(self.option_name() + "_agent_branch") or ""
         self.agent_repo = options.get(self.option_name() + "_agent_repo") or ""
         self.agent_local_repo = options.get(self.option_name() + "_agent_local_repo")
@@ -53,6 +55,12 @@ class OpbeansService(Service):
             default=None,
             dest=cls.option_name() + '_service_environment',
             help=cls.name() + " service.environment value to display."
+        )
+        parser.add_argument(
+            '--' + cls.name() + '-service-version',
+            default=None,
+            dest=cls.option_name() + '_service_version',
+            help=cls.name() + " service version"
         )
         if hasattr(cls, 'DEFAULT_SERVICE_NAME'):
             parser.add_argument(
@@ -121,6 +129,7 @@ class OpbeansDotnet(OpbeansService):
             ),
             environment=[
                 "ELASTIC_APM_SERVICE_NAME={}".format(self.service_name),
+                "ELASTIC_APM_SERVICE_VERSION={}".format(self.service_version),
                 "ELASTIC_APM_SERVER_URLS={}".format(self.apm_server_url),
                 "ELASTIC_APM_JS_SERVER_URL={}".format(self.apm_js_server_url),
                 "ELASTIC_APM_VERIFY_SERVER_CERT={}".format(str(not self.options.get("no_verify_server_cert")).lower()),
@@ -200,6 +209,7 @@ class OpbeansGo(OpbeansService):
             ),
             environment=[
                 "ELASTIC_APM_SERVICE_NAME={}".format(self.service_name),
+                "ELASTIC_APM_SERVICE_VERSION={}".format(self.service_version),
                 "ELASTIC_APM_SERVER_URL={}".format(self.apm_server_url),
                 "ELASTIC_APM_JS_SERVER_URL={}".format(self.apm_js_server_url),
                 "ELASTIC_APM_VERIFY_SERVER_CERT={}".format(str(not self.options.get("no_verify_server_cert")).lower()),
@@ -288,6 +298,7 @@ class OpbeansJava(OpbeansService):
             ),
             environment=[
                 "ELASTIC_APM_SERVICE_NAME={}".format(self.service_name),
+                "ELASTIC_APM_SERVICE_VERSION={}".format(self.service_version),
                 "ELASTIC_APM_APPLICATION_PACKAGES=co.elastic.apm.opbeans",
                 "ELASTIC_APM_SERVER_URL={}".format(self.apm_server_url),
                 "ELASTIC_APM_VERIFY_SERVER_CERT={}".format(str(not self.options.get("no_verify_server_cert")).lower()),
@@ -482,6 +493,7 @@ class OpbeansPython(OpbeansService):
             environment=[
                 "DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans",
                 "ELASTIC_APM_SERVICE_NAME={}".format(self.service_name),
+                "ELASTIC_APM_SERVICE_VERSION={}".format(self.service_version),
                 "ELASTIC_APM_SERVER_URL={}".format(self.apm_server_url),
                 "ELASTIC_APM_JS_SERVER_URL={}".format(self.apm_js_server_url),
                 "ELASTIC_APM_VERIFY_SERVER_CERT={}".format(str(not self.options.get("no_verify_server_cert")).lower()),
@@ -577,6 +589,7 @@ class OpbeansRuby(OpbeansService):
             environment=[
                 "ELASTIC_APM_SERVER_URL={}".format(self.apm_server_url),
                 "ELASTIC_APM_SERVICE_NAME={}".format(self.service_name),
+                "ELASTIC_APM_SERVICE_VERSION={}".format(self.service_version),
                 "ELASTIC_APM_VERIFY_SERVER_CERT={}".format(str(not self.options.get("no_verify_server_cert")).lower()),
                 "DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans-ruby",
                 "REDIS_URL=redis://redis:6379",

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -9,6 +9,7 @@ DEFAULT_APM_SERVER_URL = "http://apm-server:8200"
 DEFAULT_APM_JS_SERVER_URL = "http://localhost:8200"
 DEFAULT_SERVICE_VERSION = "9c2e41c8-fb2f-4b75-a89d-5089fb55fc64"
 
+
 class Service(object):
     """encapsulate docker-compose service definition"""
 

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -7,7 +7,7 @@ from .helpers import resolve_bc, parse_version, _camel_hyphen
 DEFAULT_STACK_VERSION = "8.0"
 DEFAULT_APM_SERVER_URL = "http://apm-server:8200"
 DEFAULT_APM_JS_SERVER_URL = "http://localhost:8200"
-
+DEFAULT_SERVICE_VERSION = "9c2e41c8-fb2f-4b75-a89d-5089fb55fc64"
 
 class Service(object):
     """encapsulate docker-compose service definition"""

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -813,6 +813,17 @@ class LocalTest(unittest.TestCase):
         """)  # noqa: 501
         self.assertDictEqual(got, want)
 
+    def test_version_options(self):
+        docker_compose_yml = stringIO()
+        image_cache_dir = "/foo"
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--with-opbeans-java", "--image-cache-dir", image_cache_dir, "--opbeans-java-service-version", "1.2.3"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.load(docker_compose_yml)
+        self.assertIn('ELASTIC_APM_SERVICE_VERSION=1.2.3', got['services']['opbeans-java']['environment'])
+
     def test_start_master_default(self):
         docker_compose_yml = stringIO()
         image_cache_dir = "/foo"

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -64,6 +64,7 @@ class OpbeansServiceTest(ServiceTest):
                       - "127.0.0.1:3004:3000"
                     environment:
                       - ELASTIC_APM_SERVICE_NAME=opbeans-dotnet
+                      - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                       - ELASTIC_APM_SERVER_URLS=http://apm-server:8200
                       - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                       - ELASTIC_APM_VERIFY_SERVER_CERT=true
@@ -122,6 +123,7 @@ class OpbeansServiceTest(ServiceTest):
                       - "127.0.0.1:3003:3000"
                     environment:
                       - ELASTIC_APM_SERVICE_NAME=opbeans-go
+                      - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                       - ELASTIC_APM_SERVER_URL=http://apm-server:8200
                       - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                       - ELASTIC_APM_VERIFY_SERVER_CERT=true
@@ -182,6 +184,7 @@ class OpbeansServiceTest(ServiceTest):
                       - "127.0.0.1:3002:3000"
                     environment:
                       - ELASTIC_APM_SERVICE_NAME=opbeans-java
+                      - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                       - ELASTIC_APM_APPLICATION_PACKAGES=co.elastic.apm.opbeans
                       - ELASTIC_APM_SERVER_URL=http://apm-server:8200
                       - ELASTIC_APM_VERIFY_SERVER_CERT=true
@@ -321,6 +324,7 @@ class OpbeansServiceTest(ServiceTest):
                     environment:
                         - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans
                         - ELASTIC_APM_SERVICE_NAME=opbeans-python
+                        - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                         - ELASTIC_APM_SERVER_URL=http://apm-server:8200
                         - ELASTIC_APM_JS_SERVER_URL=http://localhost:8200
                         - ELASTIC_APM_VERIFY_SERVER_CERT=true
@@ -408,6 +412,7 @@ class OpbeansServiceTest(ServiceTest):
                     environment:
                       - ELASTIC_APM_SERVER_URL=http://apm-server:8200
                       - ELASTIC_APM_SERVICE_NAME=opbeans-ruby
+                      - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                       - ELASTIC_APM_VERIFY_SERVER_CERT=true
                       - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans-ruby
                       - REDIS_URL=redis://redis:6379


### PR DESCRIPTION
## What does this PR do?

Introduces an option to pass the service version for APM agents.

## Why is it important?

This allows an arbitrary version to be passed in when running tests.

## Related issues
Refs https://github.com/elastic/apm-integration-testing/issues/688
