### PR TITLE
ci(jenkins): env variables for pre-commit are not required

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -67,10 +67,6 @@ pipeline {
         stage('Sanity checks') {
           agent { label 'linux && immutable' }
           options { skipDefaultCheckout() }
-          environment {
-            PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
-            HOME = "${env.WORKSPACE}"
-          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable && docker' }
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     NOTIFY_TO = credentials('notify-to')


### PR DESCRIPTION
## What does this PR do?

Remove unnecessary env variables

## Why is it important?

Simplify the pipeline 

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/325