### PR TITLE
fix: set branch for UI test

### DIFF
--- a/.ci/scripts/ui.sh
+++ b/.ci/scripts/ui.sh
@@ -3,4 +3,4 @@
 
 cd scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs
 yarn
-yarn setup && yarn lint
+yarn setup elastic "${INTEGRATION_TESTING_VERSION}" elastic "${INTEGRATION_TESTING_VERSION}" && yarn lint


### PR DESCRIPTION
## What does this PR do?

It set the integration test version used as a branch to grab the Kibana and APM Server versions to test.

## Why is it important?

Currently, we only test Kibana/master vs APM Server/Master, this will allow testing different versions, we have to backport it to branch 7.x, there we will test Kibana/7.x vs APM Server 7.x
