### PR TITLE
fix: set MERGE_TARGET as branch instead of INTEGRATION_TESTING_VERSION

### DIFF
--- a/.ci/scripts/ui.sh
+++ b/.ci/scripts/ui.sh
@@ -3,4 +3,4 @@
 
 cd scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs
 yarn
-yarn setup elastic "${INTEGRATION_TESTING_VERSION}" elastic "${INTEGRATION_TESTING_VERSION}" && yarn lint
+yarn setup elastic "${MERGE_TARGET}" elastic "${MERGE_TARGET}" && yarn lint


### PR DESCRIPTION
## What does this PR do?

Set the correct branch name to use.

## Why is it important?

When we call the downstream job `INTEGRATION_TESTING_VERSION` point to a commit, this commit is from the integration testing repository so it does not exist on APM Server or Kibana. The correct value is `MERGE_TARGET`.

Notes: we will backport it to 7.x branch with the [backport tool](https://www.npmjs.com/package/backport)

