### PR TITLE
ci(jenkins): report downstream issues

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -131,6 +131,7 @@ def runJob(agentName, buildOpts = ''){
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def job
   try {
+    def quiet = randomNumber(min: 2, max: 15) + 5
     job = build(job: "apm-integration-test-downstream/${branch}",
       parameters: [
       string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
@@ -141,7 +142,7 @@ def runJob(agentName, buildOpts = ''){
       string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
       booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
       propagate: true,
-      quietPeriod: 10,
+      quietPeriod: quiet,
       wait: true)
   } catch(e) {
     job = e

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,13 @@
 #!/usr/bin/env groovy
 @Library('apm@current') _
 
+import groovy.transform.Field
+
+/**
+ This is required to store the build status for the downstream jobs.
+*/
+@Field def itsDownstreamJobs = [:]
+
 pipeline {
   agent { label 'linux && immutable' }
   environment {
@@ -115,28 +122,31 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(downstreamJobs: itsDownstreamJobs)
     }
   }
 }
 
 def runJob(agentName, buildOpts = ''){
-  def branch = env.BRANCH_NAME
-
-  if (env.CHANGE_ID) {
-    branch = env.CHANGE_TARGET
+  def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
+  def job
+  try {
+    job = build(job: "apm-integration-test-downstream/${branch}",
+      parameters: [
+      string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
+      string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
+      string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
+      string(name: 'MERGE_TARGET', value: "${branch}"),
+      string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
+      string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
+      booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
+      propagate: true,
+      quietPeriod: 10,
+      wait: true)
+  } catch(e) {
+    job = e
+    error("Downstream job for '${agentName}' failed")
+  } finally {
+    itsDownstreamJobs["${agentName}"] = job
   }
-
-  def job = build(job: "apm-integration-test-downstream/${branch}",
-    parameters: [
-    string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
-    string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-    string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
-    string(name: 'MERGE_TARGET', value: "${branch}"),
-    string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
-    string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
-    booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
-    propagate: true,
-    quietPeriod: 10,
-    wait: true)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -131,7 +131,6 @@ def runJob(agentName, buildOpts = ''){
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def job
   try {
-    def quiet = randomNumber(min: 2, max: 15) + 5
     job = build(job: "apm-integration-test-downstream/${branch}",
       parameters: [
       string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
@@ -142,7 +141,7 @@ def runJob(agentName, buildOpts = ''){
       string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
       booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
       propagate: true,
-      quietPeriod: quiet,
+      quietPeriod: 10,
       wait: true)
   } catch(e) {
     job = e


### PR DESCRIPTION
## What does this PR do?

Notify to the parentstream the reason for the downstream failures when they are related to a timeout or a test failure in the downstreams.

The notification is reported in the build description. Mitigate the timeout issues.

## Why is it important?

Easy to see timeout issues in the parent jobs or test failures.

## Related issues

Similar implementation to https://github.com/elastic/apm-agent-ruby/pull/682