### PR TITLE
[7.x] fix: set MERGE_TARGET as branch instead of INTEGRATION_TESTING_VERSION (#717)

### DIFF
--- a/.ci/scripts/ui.sh
+++ b/.ci/scripts/ui.sh
@@ -3,4 +3,4 @@
 
 cd scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs
 yarn
-yarn setup elastic "${INTEGRATION_TESTING_VERSION}" elastic "${INTEGRATION_TESTING_VERSION}" && yarn lint
+yarn setup elastic "${MERGE_TARGET}" elastic "${MERGE_TARGET}" && yarn lint


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: set MERGE_TARGET as branch instead of INTEGRATION_TESTING_VERSION  (#717)