### PR TITLE
docker/apm-server: use Go 1.13

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.12
+ARG go_version=1.13
 
 FROM golang:${go_version} AS build
 


### PR DESCRIPTION
## What does this PR do?

Use Go 1.13 to build the apm-server Docker image.

## Why is it important?

APM Server specifies Go 1.13.6 as its minimum version. Increasing to 1.13 enables us to use newer features, such as `errors.As` in https://github.com/elastic/apm-server/pull/3218.

## Related issues

Nil.