### PR TITLE
fix: bump Go version to build the APM Server Docker image

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.12
+ARG go_version=1.13
 
 FROM golang:${go_version} AS build
 


### PR DESCRIPTION
## What does this PR do?

Bump the Go version on the APM Server Dockerfile.

## Why is it important?

The APM Server master branch is failing to build because it seems no longer compile with Go 1.12, see the following error:

```
go build -ldflags "-s -X github.com/elastic/apm-server/vendor/github.com/elastic/beats/libbeat/version.buildTime=2020-01-23T09:51:05Z -X github.com/elastic/apm-server/vendor/github.com/elastic/beats/libbeat/version.commit=13b9c57675cd42a8fd5705862dbf1bdf3390fae1"
# github.com/elastic/apm-server/beater/authorization
beater/authorization/apikey.go:116:6: undefined: errors.As
make: *** [_beats/libbeat/scripts/Makefile:121: apm-server] Error 2
```

## Related issues
Closes #724
