### PR TITLE
feat: moving to Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ test-agent-%: venv
 test-compose: venv
 	pytest scripts/tests/*_tests.py -v -s $(JUNIT_OPT)/compose-junit.xml
 
+test-compose-2:
+	virtualenv --python=python2.7 venv2
+	./venv2/bin/pip2 install mock pytest pyyaml
+	./venv2/bin/pytest --noconftest scripts/tests/*_tests.py
+
 test-kibana: venv
 	pytest tests/kibana/test_integration.py -v -s $(JUNIT_OPT)/kibana-junit.xml
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
+	test -d $(VENV) || virtualenv -q --python=$(PYTHON) $(VENV);\
 	source $(VENV)/bin/activate || exit 1;\
 	pip install -q -r requirements.txt;\
 	touch $(VENV);\

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	$(PYTHON) -m venv $(VENV);\
-	source $(VENV)/bin/activate;\
+	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
+	source $(VENV)/bin/activate || exit 1;\
 	pip install -q -r requirements.txt;\
 	touch $(VENV);\
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 SHELL := /bin/bash
-PYTHON ?= python
-PYTHON3 ?= python3
+PYTHON ?= python3
 VENV ?= ./venv
 
 COMPOSE_ARGS ?=
@@ -17,7 +16,8 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
+	$(PYTHON) -m venv $(VENV);\
+	source $(VENV)/bin/activate;\
 	pip install -q -r requirements.txt;\
 	touch $(VENV);\
 
@@ -50,11 +50,6 @@ test-agent-%: venv
 
 test-compose: venv
 	pytest scripts/tests/*_tests.py -v -s $(JUNIT_OPT)/compose-junit.xml
-
-test-compose-2:
-	virtualenv --python=python2.7 venv2
-	./venv2/bin/pip2 install mock pytest pyyaml
-	./venv2/bin/pytest --noconftest scripts/tests/*_tests.py
 
 test-kibana: venv
 	pytest tests/kibana/test_integration.py -v -s $(JUNIT_OPT)/kibana-junit.xml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The basic requirements for starting a local environment are:
 - Docker
 - Python (version 3 preferred)
 
-This repo is tested with Python 3 but best effort is made to make starting/stopping environments work with Python 2.7.
+This repo is tested with Python 3 but best effort is made to make starting/stopping environments work with Python 2.7, to change the default `PYTHON` version you have to set `PYTHON` environment variable to something like `PYTHON=python2`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The basic requirements for starting a local environment are:
 - Docker
 - Python (version 3 preferred)
 
-This repo is tested with Python 3 but best effort is made to make starting/stopping environments work with Python 2.7, to change the default `PYTHON` version you have to set `PYTHON` environment variable to something like `PYTHON=python2`.
+This repo is tested with Python 3 but best effort is made to make starting/stopping environments work with Python 2.7. To change the default `PYTHON` version you have to set `PYTHON` environment variable to something like `PYTHON=python2`.
 
 ### Docker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ texttable==0.9.1
 timeout-decorator==0.4.0
 tornado==5.1
 urllib3==1.24.1
-virtualenv==16.0.0
 virtualenv==16.7.9
 waiting==1.4.1
 webium==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyYAML==3.13
 attrs==17.3.0
 backports-abc==0.5
 cached-property==1.5.1
@@ -29,7 +30,6 @@ pytest-random-order==0.5.4
 pytest-selenium==1.11.3
 pytest-variables==1.7.0
 pytest==3.3.1
-PyYAML==3.13
 requests==2.20.1
 selenium==3.8.0
 singledispatch==3.4.0.3
@@ -38,7 +38,7 @@ texttable==0.9.1
 timeout-decorator==0.4.0
 tornado==5.1
 urllib3==1.24.1
-virtualenv==16.7.9
+virtualenv==16.0.0
 waiting==1.4.1
 webium==1.2.1
 websocket-client==0.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# must be >= 1.23.0 for build --parallel
 attrs==17.3.0
 backports-abc==0.5
 cached-property==1.5.1
@@ -6,6 +5,7 @@ certifi==2017.11.5
 chardet==3.0.4
 coverage==4.5.1
 docker-compose-wait==1.0.0
+# must be >= 1.23.0 for build --parallel
 docker-compose==1.23.1
 docker-pycreds==0.3.0
 docker==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==3.13
+# must be >= 1.23.0 for build --parallel
 attrs==17.3.0
 backports-abc==0.5
 cached-property==1.5.1
@@ -6,7 +6,6 @@ certifi==2017.11.5
 chardet==3.0.4
 coverage==4.5.1
 docker-compose-wait==1.0.0
-# must be >= 1.23.0 for build --parallel
 docker-compose==1.23.1
 docker-pycreds==0.3.0
 docker==3.5.1
@@ -30,6 +29,7 @@ pytest-random-order==0.5.4
 pytest-selenium==1.11.3
 pytest-variables==1.7.0
 pytest==3.3.1
+PyYAML==3.13
 requests==2.20.1
 selenium==3.8.0
 singledispatch==3.4.0.3
@@ -39,6 +39,7 @@ timeout-decorator==0.4.0
 tornado==5.1
 urllib3==1.24.1
 virtualenv==16.0.0
+virtualenv==16.7.9
 waiting==1.4.1
 webium==1.2.1
 websocket-client==0.54.0


### PR DESCRIPTION
## What does this PR do?

Move the Makefile to use Python3

## Why is it important?

Python 2.7 does not have support anymore.

## Related issues
Related to #726

