### PR TITLE
feat: document how to bump Elastic Stack version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ This repo is tested with Python 3 but best effort is made to make starting/stopp
   ```sh
   sudo apt-get install python3
   ```
+## Update Elastic Stack on new releases
+
+Every time there is  anew Elastic Stack release we have to update the configuration files to test the new release. These are the changes we have to make:
+
+* Update `ELASTIC_STACK_VERSION` param on Jenkinsfiles (.ci/\*.groovy and .ci/Jenkinsfile files
+* Update `.ci/scripts/7.0-upgrade.sh` Elastic stack used for the update (on branch 7.x)
+* Update `SUPPORTED_VERSIONS`
+  * Master branch [cli.py](https://github.com/elastic/apm-integration-testing/blob/master/scripts/modules/cli.py#L58-L76)
+  * 7.x branch [compose.py](https://github.com/elastic/apm-integration-testing/blob/7.x/scripts/compose.py#L2115-L2131)
+* Update [APM server versions](https://github.com/elastic/apm-integration-testing/blob/master/tests/versions/apm_server.yml)
 
 ## Running Local Enviroments
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This repo is tested with Python 3 but best effort is made to make starting/stopp
   ```
 ## Update Elastic Stack on new releases
 
-Every time there is  anew Elastic Stack release we have to update the configuration files to test the new release. These are the changes we have to make:
+Every time there is a new Elastic Stack release we have to update the configuration files to test the new release. These are the changes we have to make:
 
-* Update `ELASTIC_STACK_VERSION` param on Jenkinsfiles (.ci/\*.groovy and .ci/Jenkinsfile files
+* Update `ELASTIC_STACK_VERSION` param on Jenkinsfiles (.ci/\*.groovy and .ci/Jenkinsfile files).
 * Update `.ci/scripts/7.0-upgrade.sh` Elastic stack used for the update (on branch 7.x)
 * Update `SUPPORTED_VERSIONS`
   * Master branch [cli.py](https://github.com/elastic/apm-integration-testing/blob/master/scripts/modules/cli.py#L58-L76)


### PR DESCRIPTION
## What does this PR do?

It adds some instruction about how to bump the Elastic Stack version

## Why is it important?

This process is something that we have to make with ever Elastic Stack release, it should be documented.

## Related issues
related to #729
