### PR TITLE
feat: moving to Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ test-agent-%: venv
 test-compose: venv
 	pytest scripts/tests/*_tests.py -v -s $(JUNIT_OPT)/compose-junit.xml
 
+test-compose-2:
+	virtualenv --python=python2.7 venv2
+	./venv2/bin/pip2 install mock pytest pyyaml
+	./venv2/bin/pytest --noconftest scripts/tests/*_tests.py
+
 test-kibana: venv
 	pytest tests/kibana/test_integration.py -v -s $(JUNIT_OPT)/kibana-junit.xml
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	$(PYTHON) -m venv $(VENV);\
+	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
 	source $(VENV)/bin/activate || exit 1;\
 	pip install -q -r requirements.txt;\
 	touch $(VENV);\

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
+	test -d $(VENV) || virtualenv -q --python=$(PYTHON) $(VENV);\
 	source $(VENV)/bin/activate || exit 1;\
 	pip install -q -r requirements.txt;\
 	touch $(VENV);\

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 SHELL := /bin/bash
-PYTHON ?= python
-PYTHON3 ?= python3
+PYTHON ?= python3
 VENV ?= ./venv
 
 COMPOSE_ARGS ?=
@@ -31,7 +30,8 @@ all: test
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 # make doesn't play nicely with custom VENV, intended only for CI usage
 venv: requirements.txt
-	test -d $(VENV) || virtualenv -q --python=$(PYTHON3) $(VENV);\
+	$(PYTHON) -m venv $(VENV);\
+	source $(VENV)/bin/activate || exit 1;\
 	pip install -q -r requirements.txt;\
 	touch $(VENV);\
 
@@ -68,11 +68,6 @@ test-agent-%: venv
 
 test-compose: venv
 	pytest scripts/tests/*_tests.py -v -s $(JUNIT_OPT)/compose-junit.xml
-
-test-compose-2:
-	virtualenv --python=python2.7 venv2
-	./venv2/bin/pip2 install mock pytest pyyaml
-	./venv2/bin/pytest --noconftest scripts/tests/*_tests.py
 
 test-kibana: venv
 	pytest tests/kibana/test_integration.py -v -s $(JUNIT_OPT)/kibana-junit.xml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The basic requirements for starting a local environment are:
 - Docker compose
 - Python (version 3 preferred)
 
-This repo is tested with Python 3 but best effort is made to make starting/stopping environments work with Python 2.7.
+This repo is tested with Python 3 but best effort is made to make starting/stopping environments work with Python 2.7, to change the default `PYTHON` version you have to set `PYTHON` environment variable to something like `PYTHON=python2`.
 
 ### Docker
 
@@ -38,7 +38,7 @@ This repo is tested with Python 3 but best effort is made to make starting/stopp
 ### Starting an Environment
 
 `./scripts/compose.py` provides a handy cli for starting a testing environment using docker-compose.
-`make venv` creates a virtual environment with all of the python-based dependencies needed to run `./scripts/compose.py` - it requires `virtualenv` in your `PATH`.
+`make venv` creates a virtual environment with all of the python-based dependencies needed to run `./scripts/compose.py`.
 Activate the virtualenv with `source venv/bin/activate` and use `./scripts/compose.py --help` for information on subcommands and arguments. Finally, you can execute the following command to list all available parameter to start the environment `./scripts/compose.py start --help`.
 
 [APM LocalEnv Quickstart](QUICKSTART.md)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repo is tested with Python 3 but best effort is made to make starting/stopp
 ### Starting an Environment
 
 `./scripts/compose.py` provides a handy cli for starting a testing environment using docker-compose.
-`make venv` creates a virtual environment with all of the python-based dependencies needed to run `./scripts/compose.py`.
+`make venv` creates a virtual environment with all of the python-based dependencies needed to run `./scripts/compose.py` - it requires `virtualenv` in your `PATH`.
 Activate the virtualenv with `source venv/bin/activate` and use `./scripts/compose.py --help` for information on subcommands and arguments. Finally, you can execute the following command to list all available parameter to start the environment `./scripts/compose.py start --help`.
 
 [APM LocalEnv Quickstart](QUICKSTART.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-PyYAML==3.13
 attrs==17.3.0
 backports-abc==0.5
 cached-property==1.5.1
@@ -28,6 +27,7 @@ pytest-random-order==0.5.4
 pytest-selenium==1.11.3
 pytest-variables==1.7.0
 pytest==3.3.1
+PyYAML==3.13
 requests==2.22.0
 selenium==3.8.0
 singledispatch==3.4.0.3
@@ -37,6 +37,7 @@ timeout-decorator==0.4.0
 tornado==5.1
 urllib3==1.25.7
 virtualenv==16.0.0
+virtualenv==16.7.9
 waiting==1.4.1
 webium==1.2.1
 websocket-client==0.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ texttable==0.9.1
 timeout-decorator==0.4.0
 tornado==5.1
 urllib3==1.25.7
-virtualenv==16.0.0
 virtualenv==16.7.9
 waiting==1.4.1
 webium==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyYAML==3.13
 attrs==17.3.0
 backports-abc==0.5
 cached-property==1.5.1
@@ -27,7 +28,6 @@ pytest-random-order==0.5.4
 pytest-selenium==1.11.3
 pytest-variables==1.7.0
 pytest==3.3.1
-PyYAML==3.13
 requests==2.22.0
 selenium==3.8.0
 singledispatch==3.4.0.3
@@ -36,7 +36,7 @@ texttable==0.9.1
 timeout-decorator==0.4.0
 tornado==5.1
 urllib3==1.25.7
-virtualenv==16.7.9
+virtualenv==16.0.0
 waiting==1.4.1
 webium==1.2.1
 websocket-client==0.54.0


### PR DESCRIPTION
## What does this PR do?

Move the Makefile to use Python3

## Why is it important?

Python 2.7 does not have support anymore.

## Related issues
Related to #726


