### PR TITLE
Refresh interval

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -50,7 +50,8 @@ class ApmServer(StackService, Service):
             ("setup.kibana.host", self.DEFAULT_KIBANA_HOST),
             ("setup.template.settings.index.number_of_replicas", "0"),
             ("setup.template.settings.index.number_of_shards", "1"),
-            ("setup.template.settings.index.refresh_interval", "1ms"),
+            ("setup.template.settings.index.refresh_interval",
+                self.options.get("apm_server_index_refresh_interval")),
             ("monitoring.elasticsearch" if self.at_least_version("7.2") else "xpack.monitoring.elasticsearch", "true"),
             ("monitoring.enabled" if self.at_least_version("7.2") else "xpack.monitoring.enabled", "true")
         ])
@@ -371,6 +372,11 @@ class ApmServer(StackService, Service):
             "--apm-server-acm-disable",
             action="store_true",
             help="disable Agent Config Management",
+        )
+        parser.add_argument(
+            "--apm-server-index-refresh-interval",
+            default="1ms",
+            help="change the index refresh interval (default 1ms)",
         )
 
     def build_candidate_manifest(self):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -51,7 +51,7 @@ class ApmServer(StackService, Service):
             ("setup.template.settings.index.number_of_replicas", "0"),
             ("setup.template.settings.index.number_of_shards", "1"),
             ("setup.template.settings.index.refresh_interval",
-                self.options.get("apm_server_index_refresh_interval")),
+                "{}".format(self.options.get("apm_server_index_refresh_interval"))),
             ("monitoring.elasticsearch" if self.at_least_version("7.2") else "xpack.monitoring.elasticsearch", "true"),
             ("monitoring.enabled" if self.at_least_version("7.2") else "xpack.monitoring.enabled", "true")
         ])

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1402,6 +1402,10 @@ class LocalTest(unittest.TestCase):
         self.assertIn("ELASTIC_APM_SERVER_URL=https://apm-server:8200", opbeans_python["environment"])
         self.assertIn("ELASTIC_APM_JS_SERVER_URL=https://apm-server:8200", opbeans_python["environment"])
 
+    del test_apm_server_index_refresh_interval(self):
+      apmServer = ApmServer(apm_server_index_refresh_interval="10ms").render()["apm-server"]
+      self.assertIn("setup.template.settings.index.refresh_interval=10ms", apmServer["command"])
+
     def test_parse(self):
         cases = [
             ("6.3", [6, 3]),

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1402,7 +1402,7 @@ class LocalTest(unittest.TestCase):
         self.assertIn("ELASTIC_APM_SERVER_URL=https://apm-server:8200", opbeans_python["environment"])
         self.assertIn("ELASTIC_APM_JS_SERVER_URL=https://apm-server:8200", opbeans_python["environment"])
 
-    del test_apm_server_index_refresh_interval(self):
+    def test_apm_server_index_refresh_interval(self):
       apmServer = ApmServer(apm_server_index_refresh_interval="10ms").render()["apm-server"]
       self.assertIn("setup.template.settings.index.refresh_interval=10ms", apmServer["command"])
 


### PR DESCRIPTION
## What does this PR do?

it adds a new flag `--apm-server-index-refresh-interval` to set the index refresh interval.

## Why is it important?

The team sometimes needs to set different values for this parameter.

## Related issues
Closes #732
