### PR TITLE
feat: test APM Server with TLS and a Token configured

### DIFF
--- a/.ci/scripts/all.sh
+++ b/.ci/scripts/all.sh
@@ -6,6 +6,23 @@ test -z "$srcdir" && srcdir=.
 # shellcheck disable=SC1090
 . "${srcdir}/common.sh"
 
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --with-agent-dotnet --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --with-agent-python-django --with-agent-python-flask --force-build --no-xpack-secure"
+APM_SECRET_TOKEN=${APM_SECRET_TOKEN:-"SuPeRsEcReT"}
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS}\
+  --no-apm-server-dashboards \
+  --no-apm-server-self-instrument \
+  --with-agent-rumjs \
+  --with-agent-dotnet \
+  --with-agent-go-net-http \
+  --with-agent-nodejs-express \
+  --with-agent-ruby-rails \
+  --with-agent-java-spring \
+  --with-agent-python-django \
+  --with-agent-python-flask \
+  --force-build \
+  --no-xpack-secure \
+  --apm-server-enable-tls \
+  --no-verify-server-cert \
+  --apm-server-secret-token=SuPeRsEcReT"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
-runTests env-agent-all docker-test-all
+PYTHONHTTPSVERIFY=0 APM_SERVER_URL="https://apm-server:8200" runTests env-agent-all docker-test-all

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GO_NETHTTP_URL ?= "http://gonethttpapp:8080"
 JAVA_SPRING_URL ?= "http://javaspring:8090"
 RAILS_URL ?= "http://railsapp:8020"
 RUM_URL ?= "http://rum:8000"
+APM_SECRET_TOKEN ?= SuPeRsEcReT
 
 # Make sure we run local versions of everything, particularly commands
 # installed into our virtualenv with pip eg. `docker-compose`.
@@ -125,6 +126,7 @@ dockerized-test:
 	  -e RUM_URL=$(RUM_URL) \
 	  -e PYTHONDONTWRITEBYTECODE=1 \
 	  -e ENABLE_ES_DUMP=$(ENABLE_ES_DUMP) \
+	  -e APM_SECRET_TOKEN=${APM_SECRET_TOKEN} \
 	  -v "$(PWD)/$(JUNIT_RESULTS_DIR)":"/app/$(JUNIT_RESULTS_DIR)" \
 	  --rm \
 	  --entrypoint make \

--- a/tests/fixtures/default.py
+++ b/tests/fixtures/default.py
@@ -25,6 +25,7 @@ JAVA_SPRING_SERVICE_NAME = "springapp"
 JAVA_SPRING_URL = "http://localhost:8090"
 RUM_SERVICE_NAME = "rumapp"
 RUM_URL = "http://localhost:8000"
+APM_SECRET_TOKEN = "SuPeRsEcReT"
 
 
 def from_env(var):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from timeout_decorator import TimeoutError
+from tests.fixtures import default
 import requests
 
 
@@ -20,7 +21,8 @@ def check_server_transaction(endpoint, elasticsearch, payload, headers=None, ct=
     elasticsearch.clean()
     if headers is None:
         headers = {'Content-Type': 'application/x-ndjson'}
-    r = requests.post(endpoint.url, data=payload, headers=headers)
+    headers['Authorization'] = 'Bearer {}'.format(default.from_env("APM_SECRET_TOKEN"))
+    r = requests.post(endpoint.url, data=payload, headers=headers, verify=False)
     check_request_response(r, endpoint)
     check_elasticsearch_count(elasticsearch, ct)
 


### PR DESCRIPTION
## What does this PR do?

It adds the flags needed to configure the APM Server to use TLS and a Token.

## Why is it important?

This will test the security configuration on the APM Server and Agents, the flags are added to the `ALL` test so it applies to all agents.

## Related issues
Closes elastic/apm-integration-testing#13 elastic/apm-integration-testing#221
