### PR TITLE
feat: flag to set the Kibana URL for the APM Server

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -76,7 +76,7 @@ class ApmServer(StackService, Service):
             self.apm_server_command_args.extend([
                 ("apm-server.kibana.enabled", "true"),
                 ("apm-server.kibana.host",
-                    "{}".format(self.options.get("apm_server_kibana_url")))])
+                    self.options.get("apm_server_kibana_url", ""))])
             agent_config_poll = self.options.get("agent_config_poll", "30s")
             self.apm_server_command_args.append(("apm-server.agent.config.cache.expiration", agent_config_poll))
             if self.options.get("xpack_secure"):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -47,7 +47,7 @@ class ApmServer(StackService, Service):
             ("apm-server.write_timeout", "1m"),
             ("logging.json", "true"),
             ("logging.metrics.enabled", "false"),
-            ("setup.kibana.host", self.DEFAULT_KIBANA_HOST),
+            ("setup.kibana.host", "{}".format(self.options.get("apm_server_kibana_url"))),
             ("setup.template.settings.index.number_of_replicas", "0"),
             ("setup.template.settings.index.number_of_shards", "1"),
             ("setup.template.settings.index.refresh_interval", "1ms"),
@@ -371,6 +371,11 @@ class ApmServer(StackService, Service):
             "--apm-server-acm-disable",
             action="store_true",
             help="disable Agent Config Management",
+        )
+        parser.add_argument(
+            "--apm-server-kibana-url",
+            default=cls.DEFAULT_KIBANA_HOST,
+            help="Change the default kibana URL (kibana:5601)",
         )
 
     def build_candidate_manifest(self):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -376,7 +376,8 @@ class ApmServer(StackService, Service):
         parser.add_argument(
             "--apm-server-kibana-url",
             default=cls.DEFAULT_KIBANA_HOST,
-            help="Change the default kibana URL (kibana:5601)",
+            help="Change the default kibana URL (kibana:5601)"
+        )
         parser.add_argument(
             "--apm-server-index-refresh-interval",
             default="1ms",

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -47,7 +47,7 @@ class ApmServer(StackService, Service):
             ("apm-server.write_timeout", "1m"),
             ("logging.json", "true"),
             ("logging.metrics.enabled", "false"),
-            ("setup.kibana.host", "{}".format(self.options.get("apm_server_kibana_url"))),
+            ("apm-server.kibana.host", "{}".format(self.options.get("apm_server_kibana_url"))),
             ("setup.template.settings.index.number_of_replicas", "0"),
             ("setup.template.settings.index.number_of_shards", "1"),
             ("setup.template.settings.index.refresh_interval", "1ms"),

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -47,7 +47,6 @@ class ApmServer(StackService, Service):
             ("apm-server.write_timeout", "1m"),
             ("logging.json", "true"),
             ("logging.metrics.enabled", "false"),
-            ("apm-server.kibana.host", "{}".format(self.options.get("apm_server_kibana_url"))),
             ("setup.template.settings.index.number_of_replicas", "0"),
             ("setup.template.settings.index.number_of_shards", "1"),
             ("setup.template.settings.index.refresh_interval", "1ms"),
@@ -75,7 +74,8 @@ class ApmServer(StackService, Service):
         elif self.at_least_version("7.3"):
             self.apm_server_command_args.extend([
                 ("apm-server.kibana.enabled", "true"),
-                ("apm-server.kibana.host", self.DEFAULT_KIBANA_HOST)])
+                ("apm-server.kibana.host",
+                    "{}".format(self.options.get("apm_server_kibana_url")))])
             agent_config_poll = self.options.get("agent_config_poll", "30s")
             self.apm_server_command_args.append(("apm-server.agent.config.cache.expiration", agent_config_poll))
             if self.options.get("xpack_secure"):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -675,7 +675,7 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, 'apm-server.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
+                    -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true, -E, setup.dashboards.enabled=true,
                     -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true]
@@ -753,7 +753,7 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, 'apm-server.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
+                    -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true, -E, setup.dashboards.enabled=true,
                     -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true ]
@@ -842,7 +842,7 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.rum.enabled=true, -E, apm-server.rum.event_rate.limit=1000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, 'apm-server.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
+                    -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true,
                     -E, apm-server.kibana.enabled=true, -E, 'apm-server.kibana.host=kibana:5601', -E, apm-server.agent.config.cache.expiration=30s,

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1402,6 +1402,10 @@ class LocalTest(unittest.TestCase):
         self.assertIn("ELASTIC_APM_SERVER_URL=https://apm-server:8200", opbeans_python["environment"])
         self.assertIn("ELASTIC_APM_JS_SERVER_URL=https://apm-server:8200", opbeans_python["environment"])
 
+    def test_apm_server_kibana_url(self):
+      apmServer = ApmServer(apm_server_kibana_url="http://kibana.example.com:5601").render()["apm-server"]
+      self.assertIn("setup.kibana.host=http://kibana.example.com:5601", apmServer["command"])
+
     def test_parse(self):
         cases = [
             ("6.3", [6, 3]),

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -675,7 +675,7 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, 'setup.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
+                    -E, 'apm-server.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true, -E, setup.dashboards.enabled=true,
                     -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true]
@@ -753,7 +753,7 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, 'setup.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
+                    -E, 'apm-server.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true, -E, setup.dashboards.enabled=true,
                     -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true ]
@@ -842,7 +842,7 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.rum.enabled=true, -E, apm-server.rum.event_rate.limit=1000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, 'setup.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
+                    -E, 'apm-server.kibana.host=kibana:5601', -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true,
                     -E, apm-server.kibana.enabled=true, -E, 'apm-server.kibana.host=kibana:5601', -E, apm-server.agent.config.cache.expiration=30s,
@@ -1404,7 +1404,7 @@ class LocalTest(unittest.TestCase):
 
     def test_apm_server_kibana_url(self):
       apmServer = ApmServer(apm_server_kibana_url="http://kibana.example.com:5601").render()["apm-server"]
-      self.assertIn("setup.kibana.host=http://kibana.example.com:5601", apmServer["command"])
+      self.assertIn("apm-server.kibana.host=http://kibana.example.com:5601", apmServer["command"])
 
     def test_parse(self):
         cases = [

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -697,8 +697,6 @@ class ApmServerServiceTest(ServiceTest):
         apm_server = ApmServer(version="7.3").render()["apm-server"]
         self.assertTrue("apm-server.kibana.enabled=true" in apm_server["command"],
                         "APM Server Kibana enabled by default")
-        self.assertTrue("apm-server.kibana.host=kibana:5601" in apm_server["command"],
-                        "APM Server Kibana host set by default")
 
         apm_server = ApmServer(version="7.3", apm_server_acm_disable=True).render()["apm-server"]
         self.assertTrue("apm-server.kibana.enabled=false" in apm_server["command"],


### PR DESCRIPTION
## What does this PR do?

It adds a new flag `--apm-server-kibana-url` to set the Kibana URL for the APM Server

## Why is it important?

Until now it was not possible you ave to change the docker-compose file manually.

## Related issues
Closes elastic/apm-integration-testing#502
