### PR TITLE
ci(jenkins): print map with the ITs downstream results

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -140,6 +140,7 @@ pipeline {
     cleanup {
       script{
         if(integrationTestsGen?.results){
+          log(level: 'INFO', text: "integrationTestsGen -> ${integrationTestsGen.results.toString()}")
           writeJSON(file: 'results.json', json: toJSON(integrationTestsGen.results), pretty: 2)
           def mapResults = ["${params.AGENT_INTEGRATION_TEST}": integrationTestsGen.results]
           def processor = new ResultsProcessor()


### PR DESCRIPTION
## What does this PR do?

Print the results before transforming them to JSON

## Why is it important?

To debug

```
[2020-01-24T09:03:08.367Z] Error when executing cleanup post condition:
[2020-01-24T09:03:08.367Z] java.lang.IllegalArgumentException: You have to provided a JSON object to save for writeJSON.
[2020-01-24T09:03:08.367Z] 	at org.jenkinsci.plugins.pipeline.utility.steps.json.WriteJSONStepExecution.run(WriteJSONStepExecution.java:64)
[2020-01-24T09:03:08.367Z] 	at org.jenkinsci.plugins.pipeline.utility.steps.json.WriteJSONStepExecution.run(WriteJSONStepExecution.java:49)
[2020-01-24T09:03:08.367Z] 	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
[2020-01-24T09:03:08.367Z] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2020-01-24T09:03:08.367Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2020-01-24T09:03:08.367Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2020-01-24T09:03:08.367Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2020-01-24T09:03:08.367Z] 	at java.lang.Thread.run(Thread.java:748)

```

## Related issues
Closes #ISSUE