### PR TITLE
test: enclose versions between quotes

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,8 +1,8 @@
 APM_SERVER:
-  - master
-  - 7.6
-  - 7.5;--release
-  - 7.4;--release
-  - 7.3;--release
-  - 7.2;--release
-  - 7.1;--release
+  - 'master'
+  - '7.6'
+  - '7.5;--release'
+  - '7.4;--release'
+  - '7.3;--release'
+  - '7.2;--release'
+  - '7.1;--release'


### PR DESCRIPTION
## What does this PR do?

it encloses the versions between quotes.

## Why is it important?

It force to read versions as strings, it fixes the issue related to a toJSON transformation.
