### PR TITLE
Adds Jaeger gRPC instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,16 +204,18 @@ HTTP/Thrift or from a Jaeger agent via gRPC.
 #### HTTP/Thrift
 
 To test HTTP/Thrift with a Jaeger microservice demo, run separately:
-`docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:1.16  all`
+
+    docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:1.16  all
 
 #### gRPC
 
 To test gRPC, run the Jaeger all-in-one (agent) separately: 
-`docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/all-in-one:latest`
+
+    docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/all-in-one:latest
 
 And the Jaeger hotrod demo:
-`docker run --rm -it --network apm-integration-testing -e JAEGER_AGENT_HOST=jaeger-agent -e JAEGER_AGENT_PORT=6831 -p8080-8083:8080-8083 jaegertracing/example-hotrod:latest all`
 
+    docker run --rm -it --network apm-integration-testing -e JAEGER_AGENT_HOST=jaeger-agent -e JAEGER_AGENT_PORT=6831 -p8080-8083:8080-8083 jaegertracing/example-hotrod:latest all
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -199,10 +199,20 @@ Omit `--skip-download` to just download images.
 ### Jaeger
 
 APM Server can work as a drop-in replacement for a Jaeger collector, and ingest traces directly from a Jaeger client via
-HTTP/Thrift or from a Jaeger agent via gRPC.
+HTTP/Thrift or from a Jaeger agent via gRPC. 
 
-To test it with a Jaeger microservice demo, run separately:
+#### HTTP/Thrift
+
+To test HTTP/Thrift with a Jaeger microservice demo, run separately:
 `docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:1.16  all`
+
+#### gRPC
+
+To test gRPC, run the Jaeger all-in-one (agent) separately: 
+`docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/all-in-one:latest`
+
+And the Jaeger hotrod demo:
+`docker run --rm -it --network apm-integration-testing -e JAEGER_AGENT_HOST=jaeger-agent -e JAEGER_AGENT_PORT=6831 -p8080-8083:8080-8083 jaegertracing/example-hotrod:latest all`
 
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ To test HTTP/Thrift with a Jaeger microservice demo, run separately:
 
 #### gRPC
 
-To test gRPC, run the Jaeger all-in-one (agent) separately: 
+To test gRPC, run the Jaeger Agent separately: 
 
     docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/jaeger-agent:latest
 

--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ HTTP/Thrift or from a Jaeger agent via gRPC.
 
 To test HTTP/Thrift with a Jaeger microservice demo, run separately:
 
-    docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:1.16  all
+    docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:latest  all
 
 #### gRPC
 
 To test gRPC, run the Jaeger all-in-one (agent) separately: 
 
-    docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/all-in-one:latest
+    docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/jaeger-agent:latest
 
 And the Jaeger hotrod demo:
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Omit `--skip-download` to just download images.
 ### Jaeger
 
 APM Server can work as a drop-in replacement for a Jaeger collector, and ingest traces directly from a Jaeger client via
-HTTP/Thrift or from a Jaeger agent via gRPC. 
+HTTP/Thrift or from a Jaeger agent via gRPC.
 
 #### HTTP/Thrift
 


### PR DESCRIPTION
My Docker and Jaeger skills are still being perfected, so apologies if there's a simpler/better way to do this. @jalvz added an example for HTTP in https://github.com/elastic/apm-integration-testing/pull/722, and I thought it'd be nice to have one for gRPC too.

<img width="1168" alt="Screen Shot 2020-01-29 at 4 07 35 PM" src="https://user-images.githubusercontent.com/5618806/73408569-7b177180-42b1-11ea-9bb9-41da75d21234.png">
<img width="1186" alt="Screen Shot 2020-01-29 at 4 06 37 PM" src="https://user-images.githubusercontent.com/5618806/73408536-64711a80-42b1-11ea-84d8-6dafc8169a2b.png">

