### PR TITLE
fix: no set xpack.apm.serviceMapEnabled on Kibana OSS

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -690,11 +690,12 @@ class Kibana(StackService, Service):
                         "Login&#32;details:&#32;`{}/{}`.&#32;Further&#32;details&#32;[here]({}).").format(
                         self.environment["ELASTICSEARCH_USERNAME"], self.environment["ELASTICSEARCH_PASSWORD"],
                         "https://github.com/elastic/apm-integration-testing#logging-in")
+            if self.at_least_version("7.6"):
+                if not options.get("no_kibana_apm_servicemaps"):
+                    self.environment["XPACK_APM_SERVICEMAPENABLED"] = "true"
         urls = self.options.get("kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS]
         self.environment["ELASTICSEARCH_URL"] = ",".join(urls)
-        if self.at_least_version("7.6"):
-            if not options.get("no_kibana_apm_servicemaps"):
-                self.environment["XPACK_APM_SERVICEMAPENABLED"] = "true"
+
 
     @classmethod
     def add_arguments(cls, parser):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -696,7 +696,6 @@ class Kibana(StackService, Service):
         urls = self.options.get("kibana_elasticsearch_urls") or [self.DEFAULT_ELASTICSEARCH_HOSTS]
         self.environment["ELASTICSEARCH_URL"] = ",".join(urls)
 
-
     @classmethod
     def add_arguments(cls, parser):
         parser.add_argument(


### PR DESCRIPTION
## What does this PR do?

It defines `XPACK_APM_SERVICEMAPENABLED` only on no OSS Kibana 

## Why is it important?

`XPACK_APM_SERVICEMAPENABLED` does not work on Kibana OSS

## Related issues
Closes #749
