### PR TITLE
Update .NET Agent version in the mini sample app to latest

### DIFF
--- a/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
+++ b/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.1.2" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.3" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
We have some failing tests that made me to look into this. 

[Failing tests](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-test-downstream/detail/master/4005/tests/). 

The latest .NET Agent introduces the `VerifyServerCert` setting, which does not seem to work in these tests. 

My current theory:

Maybe [this script](https://github.com/elastic/apm-integration-testing/blob/master/docker/dotnet/run.sh) does not work.
We try to do: `dotnet add package ${PACKAGE} -v ${DOTNET_AGENT_VERSION}`  (line 27) - that's how we automatically fetch the latest agent. So we have a fixed old version in the sample app which we dynamically update with this command to the latest agent.

But it prints:
```
[2020-02-13T10:00:56.389Z] + dotnet add package Elastic.Apm.NetCoreAll -v
[2020-02-13T10:00:56.959Z] Already on 'master'
[2020-02-13T10:00:56.959Z] Your branch is up to date with 'origin/master'.
[2020-02-13T10:00:57.911Z] Required argument missing for option: --version
[2020-02-13T10:00:57.911Z] Usage: dotnet add <PROJECT> package [options] <PACKAGE_NAME>
```

Meaning replacing the agent with the latest failed as it seems. 

This PR manually adds the latest agent - which is good anyway. ~If this makes the test green, then 
[this script](https://github.com/elastic/apm-integration-testing/blob/master/docker/dotnet/run.sh) probably never worked - so that'll be a follow up then.~ Update: change causing this found, see comment below. 