### PR TITLE
fix: change the way we configure the RUM agent

### DIFF
--- a/docker/opbeans/frontend_nginx/default.template
+++ b/docker/opbeans/frontend_nginx/default.template
@@ -8,7 +8,7 @@ server {
     rewrite ^/customers(.*)$ /;
 
     location /api/ {
-        proxy_pass {{ELASTIC_OPBEANS_API_SERVER}};
+        proxy_pass {{ ELASTIC_OPBEANS_API_SERVER }};
         proxy_set_header Host      $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/docker/opbeans/frontend_nginx/entrypoint.sh
+++ b/docker/opbeans/frontend_nginx/entrypoint.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 echo "******************************************************************************************************************************************"
 echo "* You must define ELASTIC_OPBEANS_API_SERVER to reditect all request to http://host:port/api/* (default http://localhost:3000) *"
-echo "* You can define ELASTIC_APM_SERVER_URLS to send the APM request (default http://localhost:8200)                                         *"
+echo "* You can define ELASTIC_APM_JS_BASE_SERVER_URL to send the APM request (default http://localhost:8200)                                         *"
+echo "* You can define ELASTIC_APM_JS_BASE_SERVICE_VERSION to set the service version (default v1.0.0)                                         *"
+echo "* You can define ELASTIC_APM_JS_BASE_SERVICE_NAME to set the service name (default opbeans-rum)                                         *"
 echo "******************************************************************************************************************************************"
 
 ELASTIC_OPBEANS_API_SERVER=${ELASTIC_OPBEANS_API_SERVER:-"http://localhost:3000"}
-ELASTIC_APM_SERVER_URLS=${APM_SERVE:-"http://localhost:8200"}
+ELASTIC_APM_JS_BASE_SERVER_URL=${ELASTIC_APM_JS_BASE_SERVER_URL:-"http://localhost:8200"}
+ELASTIC_APM_JS_BASE_SERVICE_NAME=${ELASTIC_APM_JS_BASE_SERVICE_NAME:-"opbeans-rum"}
+ELASTIC_APM_JS_BASE_SERVICE_VERSION=${ELASTIC_APM_JS_BASE_SERVICE_VERSION:-"$RANDOM"}
 
 echo "ELASTIC_OPBEANS_API_SERVER=${ELASTIC_OPBEANS_API_SERVER}"
-echo "ELASTIC_APM_SERVER_URLS=${ELASTIC_APM_SERVER_URLS}"
+echo "ELASTIC_APM_JS_BASE_SERVER_URL=${ELASTIC_APM_JS_BASE_SERVER_URL}"
+echo "ELASTIC_APM_JS_BASE_SERVICE_VERSION=${ELASTIC_APM_JS_BASE_SERVICE_VERSION}"
+echo "ELASTIC_APM_JS_BASE_SERVICE_NAME=${ELASTIC_APM_JS_BASE_SERVICE_NAME}"
 
-sed "s@{{ELASTIC_OPBEANS_API_SERVER}}@${ELASTIC_OPBEANS_API_SERVER}@g" /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
-sed "s@{{ELASTIC_APM_SERVER_URLS}}@${ELASTIC_APM_SERVER_URLS}@g" /usr/share/nginx/html/rum-config.template > /usr/share/nginx/html/rum-config.js
+sed "s@{{ ELASTIC_OPBEANS_API_SERVER }}@${ELASTIC_OPBEANS_API_SERVER}@g" /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
+sed -e "s@{{ ELASTIC_APM_JS_BASE_SERVER_URL }}@${ELASTIC_APM_JS_BASE_SERVER_URL}@g" \
+    -e "s@{{ ELASTIC_APM_JS_BASE_SERVICE_VERSION }}@${ELASTIC_APM_JS_BASE_SERVICE_VERSION}@g" \
+    -e "s@{{ ELASTIC_APM_JS_BASE_SERVICE_NAME }}@${ELASTIC_APM_JS_BASE_SERVICE_NAME}@g" \
+    /usr/share/nginx/html/rum-config.template > /usr/share/nginx/html/rum-config.js
 
 exec nginx-debug -g 'daemon off;'

--- a/docker/opbeans/frontend_nginx/rum-config.template
+++ b/docker/opbeans/frontend_nginx/rum-config.template
@@ -1,8 +1,13 @@
-window.elasticApmJsBaseServerUrl = '{{ELASTIC_APM_SERVER_URLS}}';
-
 // Disable random failures
 // see https://github.com/elastic/opbeans-frontend/blob/472f914f5529d64ccf4aad0fc4a76ec27fa0a135/src/components/ProductDetail/index.js#L9
 var _mathRamdom = Math.random;
 Math.random = function() {
   return Math.abs(_mathRamdom() - 0.3);
 };
+
+// see https://github.com/elastic/opbeans-frontend/blob/849a7a7/src/rum.js#L40-L55
+var rumConfig = {
+	serverUrl: '{{ ELASTIC_APM_JS_BASE_SERVER_URL }}',
+	serviceName: '{{ ELASTIC_APM_JS_BASE_SERVICE_NAME }}',
+	serviceVersion: '{{ ELASTIC_APM_JS_BASE_SERVICE_VERSION }}'
+}


### PR DESCRIPTION
## What does this PR do?

Change to use runConfig variable to configure the RUM agent in the Opbeans-frontend.

## Why is it important?

The old configuration is limited and only changed the APM Server URL.
