### PR TITLE
opbeans-dotnet: support dotnet agent version >= 1.3 and < 1.3

### DIFF
--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -24,6 +24,10 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
   DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+
+  if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
+    echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1
+  fi
   dotnet add package ${PACKAGE} -v "${DOTNET_AGENT_VERSION}"
 else
   ### Otherwise: The default NuGet.Config will fail as it's required

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -27,7 +27,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
 
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-    ## For backward compatibility (only for versions < 1.3.0)
+    echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
     if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
       echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1


### PR DESCRIPTION
## What does this PR do?

If the version for the agent was not resolved as expected then it should fail:

```
+ '[' -z '' ']'
+ echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.'
+ exit 1
ERROR: DOTNET_AGENT_VERSION could not be calculated.
The command '/bin/sh -c ./run.sh' returned a non-zero code: 1
```

If the version for the agent was resolved but doesn't match then it should fail:

```
+ grep Elastic.Apm.NetCoreAll opbeans-dotnet.csproj
+ grep -i 'Version="11.3"'
ERROR: DOTNET_AGENT_VERSION mismatch
+ echo 'ERROR: DOTNET_AGENT_VERSION mismatch'
+ exit 1
The command '/bin/sh -c ./run.sh' returned a non-zero code: 1
```

## Why is it important?

Otherwise, the opbeans will not pick up the expected version but the one defined explicitly.

## Related issues

Closes https://github.com/elastic/apm-integration-testing/issues/758