### PR TITLE
[7.x] dotnet: support dotnet agent version >= 1.3 and < 1.3 (#760)

### DIFF
--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -5,13 +5,14 @@ CSPROJ="TestAspNetCoreApp.csproj"
 
 PACKAGE=Elastic.Apm.NetCoreAll
 CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
 
-  git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent
+  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent
   cd /src/dotnet-agent
   git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
-  git checkout ${DOTNET_AGENT_BRANCH}
+  git checkout "${DOTNET_AGENT_BRANCH}"
   git rev-parse HEAD
 
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
@@ -21,10 +22,18 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
 
   cd /src/aspnetcore
   mv /src/NuGet.Config .
+  # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
+  DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+  if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
+    echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
+    DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+    if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
+      echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1
+    fi
+  fi
 
-  DOTNET_AGENT_VERSION=$(cat ${CSPROJ_VERSION} | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
-  dotnet add package ${PACKAGE} -v ${DOTNET_AGENT_VERSION}
+  dotnet add package ${PACKAGE} -v "${DOTNET_AGENT_VERSION}"
 else
   ### Otherwise: The default NuGet.Config will fail as it's required
   mkdir /src/local-packages
@@ -33,5 +42,9 @@ fi
 cd /src/aspnetcore
 # This is the way to manipulate the csproj with the version of the dotnet agent to be used
 sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.NetCoreAll\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" ${CSPROJ}
+
+# Validate if the version has been updated
+set -e
+grep "Elastic.Apm.NetCoreAll" ${CSPROJ} | grep -i "Version=\"${DOTNET_AGENT_VERSION}\"" || (echo 'ERROR: DOTNET_AGENT_VERSION mismatch' && exit 1)
 dotnet restore
 dotnet publish -c Release -o build


### PR DESCRIPTION
Backports the following commits to 7.x:
 - dotnet: support dotnet agent version >= 1.3 and < 1.3 (#760)