### PR TITLE
Enable experimental flag by default

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -344,6 +344,13 @@ class LocalSetup(object):
         )
 
         parser.add_argument(
+            "--apm-server-experimental-mode",
+            action="store_true",
+            help="start apm-server in experimental mode",
+            default=True,
+        )
+
+        parser.add_argument(
             '--opbeans-apm-js-server-url',
             action='store',
             help='server_url to use for Opbeans frontend service',

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -65,7 +65,7 @@ class ApmServer(StackService, Service):
             "enable_elasticsearch", True) else {}
         self.build = self.options.get("apm_server_build")
 
-        if self.options.get("apm-server-experimental-mode", True) and elf.at_least_version("7.2"):
+        if self.options.get("apm-server-experimental-mode", True) and self.at_least_version("7.2"):
             self.apm_server_command_args.append("apm-server.mode", "experimental")
 
         if self.options.get("apm_server_ilm_disable"):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -66,7 +66,7 @@ class ApmServer(StackService, Service):
         self.build = self.options.get("apm_server_build")
 
         if self.options.get("apm-server-experimental-mode", True) and self.at_least_version("7.2"):
-            self.apm_server_command_args.append("apm-server.mode", "experimental")
+            self.apm_server_command_args.append(("apm-server.mode", "experimental"))
 
         if self.options.get("apm_server_ilm_disable"):
             self.apm_server_command_args.append(("apm-server.ilm.enabled", "false"))

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -65,6 +65,9 @@ class ApmServer(StackService, Service):
             "enable_elasticsearch", True) else {}
         self.build = self.options.get("apm_server_build")
 
+        if self.options.get("apm-server-experimental-mode", True) and elf.at_least_version("7.2"):
+            self.apm_server_command_args.append("apm-server.mode", "experimental")
+
         if self.options.get("apm_server_ilm_disable"):
             self.apm_server_command_args.append(("apm-server.ilm.enabled", "false"))
         elif self.at_least_version("7.2") and not self.at_least_version("7.3") and not self.oss:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -844,7 +844,7 @@ class LocalTest(unittest.TestCase):
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
                     -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
-                    -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true,
+                    -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true, -E, apm-server.mode=experimental,
                     -E, apm-server.kibana.enabled=true, -E, 'apm-server.kibana.host=kibana:5601', -E, apm-server.agent.config.cache.expiration=30s,
                     -E, apm-server.kibana.username=apm_server_user, -E, apm-server.kibana.password=changeme,
                     -E, apm-server.jaeger.http.enabled=true, -E, "apm-server.jaeger.http.host=0.0.0.0:14268",


### PR DESCRIPTION
## What does this PR do?

Create a new flag called `--apm-server-experimental-mode` and enable it by default when starting apm-server.

## Why is it important?

Enables developers to add new fields that get dynamically indexed for developing POCs for new features.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/753


@kuisathaverat is that what you had in mind?