### PR TITLE
Upgrade APM Server to python 3

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -4,7 +4,10 @@ ARG go_version=1.13
 FROM golang:${go_version} AS build
 
 # install make update prerequisites
-RUN apt-get -qq update && apt-get -qq install -y python-virtualenv
+RUN apt-get -qq update \
+    && apt-get -qq install -y python3 python3-pip python3-venv
+
+RUN pip3 install --upgrade pip
 
 ARG apm_server_branch_or_commit=master
 ARG apm_server_repo=https://github.com/elastic/apm-server.git

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -3,6 +3,8 @@ ARG go_version=1.13
 
 FROM golang:${go_version} AS build
 
+RUN apt -qq remove -y python2 && apt -qq autoremove -y
+
 # install make update prerequisites
 RUN apt-get -qq update \
     && apt-get -qq install -y python3 python3-pip python3-venv


### PR DESCRIPTION
## What does this PR do?

Upgrades APM Server tooling and tests from using `python2` to `python3`

## Why is it important?

APM Server is upgraded to python3 in https://github.com/elastic/apm-server/pull/3357, therefore the integration testing repo also needs to be changed. 

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->


