### PR TITLE
apm-ui: use the new kibana project layout

### DIFF
--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
@@ -8,5 +8,14 @@ echo "Cloning Kibana: ${OWNER}:${BRANCH}"
 
 cd ./tmp || true
 git clone --quiet --depth 1 -b "${BRANCH}" "https://github.com/${OWNER}/kibana.git"
-mv ./kibana/x-pack/plugins/apm/typings/es_schemas ./apm-ui-interfaces
+
+### In 7.7 files moved around.
+### The below section keeps backward compatibility.
+oldLocation=./kibana/x-pack/legacy/plugins/apm/typings/es_schemas
+newLocation=./kibana/x-pack/plugins/apm/typings/es_schemas
+location=${oldLocation}
+if [ -d "${newLocation}" ] ; then
+   location=${newLocation}
+fi
+mv "${location}" ./apm-ui-interfaces
 rm -rf kibana

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
@@ -4,6 +4,6 @@ BRANCH=${2:-master}
 echo "Cloning Kibana: $OWNER:$BRANCH"
 
 cd ./tmp
-git clone --depth 1 -b $BRANCH https://github.com/$OWNER/kibana.git
-mv ./kibana/x-pack/legacy/plugins/apm/typings/es_schemas ./apm-ui-interfaces
+git clone --quiet --depth 1 -b $BRANCH https://github.com/$OWNER/kibana.git
+mv ./kibana/x-pack/plugins/apm/typings/es_schemas ./apm-ui-interfaces
 rm -rf kibana

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
@@ -6,7 +6,7 @@ BRANCH=${2:-master}
 
 echo "Cloning Kibana: ${OWNER}:${BRANCH}"
 
-cd ./tmp || true
+cd ./tmp
 git clone --quiet --depth 1 -b "${BRANCH}" "https://github.com/${OWNER}/kibana.git"
 
 ### In 7.7 files moved around.

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
@@ -1,9 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
 OWNER=${1:-elastic}
 BRANCH=${2:-master}
 
-echo "Cloning Kibana: $OWNER:$BRANCH"
+echo "Cloning Kibana: ${OWNER}:${BRANCH}"
 
-cd ./tmp
-git clone --quiet --depth 1 -b $BRANCH https://github.com/$OWNER/kibana.git
+cd ./tmp || true
+git clone --quiet --depth 1 -b "${BRANCH}" "https://github.com/${OWNER}/kibana.git"
 mv ./kibana/x-pack/plugins/apm/typings/es_schemas ./apm-ui-interfaces
 rm -rf kibana


### PR DESCRIPTION
## What does this PR do?

Fixes the current filesystem layout issue with the kibana project.
Reduce the verbose output in the clone
Fixes some linting issues.

## Why is it important?

Fix the apm-its

## Related issues

Leftovers from https://github.com/elastic/kibana/pull/57532
Closes https://github.com/elastic/apm-integration-testing/issues/770

## Questions

- [x] Do we need to support backward compatibility? 
- [ ] Do we need to backport this to the `*.x` branches?