### PR TITLE
[apm-ui] File names don't match the previous expected ones

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: check-case-conflict
         exclude: ^target/
     -   id: check-executables-have-shebangs
-        exclude: ^target/
+        exclude: (^scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/download-sample-docs.ts$|^target/)
     -   id: check-json
         exclude: ^target/
     -   id: check-merge-conflict

--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/download-sample-docs.ts
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/download-sample-docs.ts
@@ -17,17 +17,17 @@ interface DocType {
 const docTypes: DocType[] = [
   {
     interfaceName: 'SpanRaw',
-    interfacePath: '../apm-ui-interfaces/raw/SpanRaw',
+    interfacePath: '../apm-ui-interfaces/raw/span_raw',
     url: `https://raw.githubusercontent.com/elastic/apm-server/${branch}/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json`
   },
   {
     interfaceName: 'TransactionRaw',
-    interfacePath: '../apm-ui-interfaces/raw/TransactionRaw',
+    interfacePath: '../apm-ui-interfaces/raw/transaction_raw',
     url: `https://raw.githubusercontent.com/elastic/apm-server/${branch}/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json`
   },
   {
     interfaceName: 'ErrorRaw',
-    interfacePath: '../apm-ui-interfaces/raw/ErrorRaw',
+    interfacePath: '../apm-ui-interfaces/raw/error_raw',
     url: `https://raw.githubusercontent.com/elastic/apm-server/${branch}/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json`
   }
 ];


### PR DESCRIPTION
## What does this PR do?

Use the new files. It does not allow backward compatiblity 


## Why is it important?

Fix the APM-ITS for the UI

## Related issues

Leftover from https://github.com/elastic/apm-integration-testing/issues/770