### PR TITLE
fix: install python3-virtualenv

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -7,7 +7,7 @@ RUN apt -qq remove -y python2 && apt -qq autoremove -y
 
 # install make update prerequisites
 RUN apt-get -qq update \
-    && apt-get -qq install -y python3 python3-pip python3-venv
+    && apt-get -qq install -y python3 python3-pip python3-venv python3-virtualenv
 
 RUN pip3 install --upgrade pip
 


### PR DESCRIPTION
## What does this PR do?

it installs python3-virtualenv package.

## Why is it important?

There is a failure on the build of the APM Server related to an error trying to execute virtualenv.

## Related issues
Closes elastic/apm-integration-testing#772
