### PR TITLE
Update test versions for APM Server

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,6 +1,7 @@
 APM_SERVER:
   - 'master'
-  - '7.6'
+  - '7.7'
+  - '7.6;--release'
   - '7.5;--release'
   - '7.4;--release'
   - '7.3;--release'


### PR DESCRIPTION
## What does this PR do?
Updates the test versions for APM Server after `7.6` has been released. 

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
The tests should run against the released versions, and also against the next release version covered in the `7.x` branch. 

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
no dedicated issue created
