### PR TITLE
Adapt Elasticsearch user roles

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -9,7 +9,7 @@ apm_server:
       privileges: ['sourcemap:write', 'event:write', 'config_agent:read']
       resources: '*'
 beats:
-  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm', 'manage_security', 'manage_api_key']
   indices:
     - names: ['filebeat-*', 'shrink-filebeat-*']
       privileges: ['all']

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -1,6 +1,6 @@
 apm_server:apm_server_user
 apm_system:apm_server_user
-apm_user:apm_user_ro
+apm_user:apm_server_user,apm_user_ro
 beats:beats_user
 beats_system:beats_user,filebeat_user,heartbeat_user,metricbeat_user
 filebeat:filebeat_user


### PR DESCRIPTION
## What does this PR do?
Add built-in apm_user role to apm_server_user.
Add manage_security and manage_api_key role to beats user.


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

The main purpose of adding these privileges is to keep them in-sync with
APM Server for easier testing.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
no dedicated issue
