### PR TITLE
[7.x] apm-ui: use the new kibana project layout (#769)

### DIFF
--- a/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
+++ b/scripts/kibana/validate-ts-interfaces-against-apm-server-sample-docs/scripts/clone-kibana.sh
@@ -1,9 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
 OWNER=${1:-elastic}
 BRANCH=${2:-master}
 
-echo "Cloning Kibana: $OWNER:$BRANCH"
+echo "Cloning Kibana: ${OWNER}:${BRANCH}"
 
 cd ./tmp
-git clone --depth 1 -b $BRANCH https://github.com/$OWNER/kibana.git
-mv ./kibana/x-pack/legacy/plugins/apm/typings/es_schemas ./apm-ui-interfaces
+git clone --quiet --depth 1 -b "${BRANCH}" "https://github.com/${OWNER}/kibana.git"
+
+### In 7.7 files moved around.
+### The below section keeps backward compatibility.
+oldLocation=./kibana/x-pack/legacy/plugins/apm/typings/es_schemas
+newLocation=./kibana/x-pack/plugins/apm/typings/es_schemas
+location=${oldLocation}
+if [ -d "${newLocation}" ] ; then
+   location=${newLocation}
+fi
+mv "${location}" ./apm-ui-interfaces
 rm -rf kibana


### PR DESCRIPTION
Backports the following commits to 7.x:
 - apm-ui: use the new kibana project layout (#769)