### PR TITLE
Fix test versions for APM Server

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,6 +1,5 @@
 APM_SERVER:
-  - 'master'
-  - '7.7'
+  - '7.x'
   - '7.6;--release'
   - '7.5;--release'
   - '7.4;--release'


### PR DESCRIPTION


## What does this PR do?
Remove `7.7` as branch does not yet exist.
Change `master` to `7.x` for development branch in integration testing `7.x`.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
To fix tests and run the actual tests against APM Server `7.x` instead of `master` when running in apm-integration-testing `7.x`

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
no issue
