### PR TITLE
ci(jenkins): Agent when required

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -127,13 +127,13 @@ pipeline {
   }
 }
 
-def runJob(agentName, buildOpts = ''){
+def runJob(testName, buildOpts = ''){
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def job
   try {
     job = build(job: "apm-integration-test-downstream/${branch}",
       parameters: [
-      string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
+      string(name: 'INTEGRATION_TEST', value: testName),
       string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
       string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
       string(name: 'MERGE_TARGET', value: "${branch}"),
@@ -145,8 +145,8 @@ def runJob(agentName, buildOpts = ''){
       wait: true)
   } catch(e) {
     job = e
-    error("Downstream job for '${agentName}' failed")
+    error("Downstream job for '${testName}' failed")
   } finally {
-    itsDownstreamJobs["${agentName}"] = job
+    itsDownstreamJobs["${testName}"] = job
   }
 }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -30,7 +30,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
+    choice(name: 'INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the Tests or APM Agent you want to run the integration tests.')
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "8.0.0", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "master", description: "Integration testing Git branch/tag to use")
     string(name: 'MERGE_TARGET', defaultValue: "master", description: "Integration testing Git branch/tag where to merge this code")
@@ -55,9 +55,9 @@ pipeline {
           shallow: false
         )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-        script{
-          currentBuild.displayName = "apm-agent-${params.AGENT_INTEGRATION_TEST} - ${currentBuild.displayName}"
-          currentBuild.description = "Agent ${params.AGENT_INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
+        script {
+          currentBuild.displayName = "apm-${params.INTEGRATION_TEST.equals} - ${currentBuild.displayName}"
+          currentBuild.description = "${params.INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
         }
       }
     }
@@ -67,8 +67,8 @@ pipeline {
     stage("Integration Tests"){
       when {
         expression {
-          return (params.AGENT_INTEGRATION_TEST != 'All'
-            && params.AGENT_INTEGRATION_TEST != 'UI')
+          return (params.INTEGRATION_TEST != 'All'
+            && params.INTEGRATION_TEST != 'UI')
         }
       }
       steps {
@@ -76,7 +76,7 @@ pipeline {
         unstash "source"
         dir("${BASE_DIR}"){
           script {
-            def agentTests = agentMapping.id(params.AGENT_INTEGRATION_TEST)
+            def agentTests = agentMapping.id(params.INTEGRATION_TEST)
             integrationTestsGen = new IntegrationTestingParallelTaskGenerator(
               xKey: agentMapping.agentVar(agentTests),
               yKey: agentMapping.agentVar('server'),
@@ -84,7 +84,7 @@ pipeline {
               yFile: agentMapping.yamlVersionFile('server'),
               exclusionFile: agentMapping.yamlVersionFile(agentTests),
               tag: agentTests,
-              name: params.AGENT_INTEGRATION_TEST,
+              name: params.INTEGRATION_TEST,
               steps: this
               )
             def mapPatallelTasks = integrationTestsGen.generateParallelTests()
@@ -95,7 +95,7 @@ pipeline {
     }
     stage("All") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'All' }
+        expression { return params.INTEGRATION_TEST == 'All' }
       }
       environment {
         TMPDIR = "${WORKSPACE}"
@@ -117,7 +117,7 @@ pipeline {
     }
     stage("UI") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'UI' }
+        expression { return params.INTEGRATION_TEST == 'UI' }
       }
       environment {
         TMPDIR = "${WORKSPACE}/${BASE_DIR}"
@@ -141,7 +141,7 @@ pipeline {
       script{
         if(integrationTestsGen?.results){
           writeJSON(file: 'results.json', json: toJSON(integrationTestsGen.results), pretty: 2)
-          def mapResults = ["${params.AGENT_INTEGRATION_TEST}": integrationTestsGen.results]
+          def mapResults = ["${params.INTEGRATION_TEST}": integrationTestsGen.results]
           def processor = new ResultsProcessor()
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -56,8 +56,14 @@ pipeline {
         )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          currentBuild.displayName = "apm-agent-${params.INTEGRATION_TEST} - ${currentBuild.displayName}"
-          currentBuild.description = "Agent ${params.INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
+          def displayName = "apm-agent-${params.INTEGRATION_TEST}"
+          def description = "Agent ${params.INTEGRATION_TEST}"
+          if (params.INTEGRATION_TEST.equals('All') || params.INTEGRATION_TEST.equals('UI')) {
+            displayName = "${params.INTEGRATION_TEST}"
+            description = "${params.INTEGRATION_TEST}"
+          }
+          currentBuild.displayName = "${displayName} - ${currentBuild.displayName}"
+          currentBuild.description = "${description} - ${params.UPSTREAM_BUILD}"
         }
       }
     }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -56,8 +56,8 @@ pipeline {
         )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          currentBuild.displayName = "apm-${params.INTEGRATION_TEST.equals} - ${currentBuild.displayName}"
-          currentBuild.description = "${params.INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
+          currentBuild.displayName = "apm-agent-${params.INTEGRATION_TEST} - ${currentBuild.displayName}"
+          currentBuild.description = "Agent ${params.INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
         }
       }
     }
@@ -162,7 +162,7 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
   }
 
   /**
-    build a clousure that launch and agent and execute the corresponding test script,
+    build a clousure that launch an agent or test and execute the corresponding test script,
     then store the results.
   */
   public Closure generateStep(x, y){

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -145,11 +145,6 @@ pipeline {
           def processor = new ResultsProcessor()
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
-          catchError(buildResult: 'SUCCESS') {
-            def datafile = readFile(file: "results.json")
-            def json = getVaultSecret(secret: 'secret/apm-team/ci/jenkins-stats-cloud')
-            sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-it-results/_doc/')
-          }
         }
         notifyBuildResult()
       }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -10,8 +10,8 @@ pipeline {
     JOB_GIT_CREDENTIALS = '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
     PIPELINE_LOG_LEVEL = 'INFO'
     REUSE_CONTAINERS = "true"
-    NAME = agentMapping.id(params.AGENT_INTEGRATION_TEST)
-    AGENT_INTEGRATION_TEST = "${params.AGENT_INTEGRATION_TEST}"
+    NAME = agentMapping.id(params.INTEGRATION_TEST)
+    INTEGRATION_TEST = "${params.INTEGRATION_TEST}"
     ELASTIC_STACK_VERSION = "${params.ELASTIC_STACK_VERSION}"
     BUILD_OPTS = "${params.BUILD_OPTS}"
     DETAILS_ARTIFACT = 'docs.txt'
@@ -26,7 +26,7 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
   }
   parameters {
-    choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All', 'Opbeans'], description: 'Name of the APM Agent you want to run the integration tests.')
+    choice(name: 'INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All', 'Opbeans'], description: 'Name of the Tests or APM Agent you want to run the integration tests.')
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "8.0.0", description: "Elastic Stack Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
     string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
@@ -44,7 +44,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{
-          currentBuild.displayName = "apm-agent-${params.AGENT_INTEGRATION_TEST} - ${currentBuild.displayName}"
+          currentBuild.displayName = "apm-agent-${params.INTEGRATION_TEST} - ${currentBuild.displayName}"
         }
       }
     }
@@ -56,12 +56,12 @@ pipeline {
         TMPDIR = "${WORKSPACE}"
         ENABLE_ES_DUMP = "true"
         PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
-        APP = agentMapping.app(params.AGENT_INTEGRATION_TEST)
+        APP = agentMapping.app(params.INTEGRATION_TEST)
       }
       when {
         expression {
-          return (params.AGENT_INTEGRATION_TEST != 'All' &&
-                  params.AGENT_INTEGRATION_TEST != 'Opbeans')
+          return (params.INTEGRATION_TEST != 'All' &&
+                  params.INTEGRATION_TEST != 'Opbeans')
         }
       }
       steps {
@@ -79,7 +79,7 @@ pipeline {
     }
     stage("All") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'All' }
+        expression { return params.INTEGRATION_TEST == 'All' }
       }
       environment {
         TMPDIR = "${WORKSPACE}"
@@ -101,7 +101,7 @@ pipeline {
     }
     stage("UI") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'UI' }
+        expression { return params.INTEGRATION_TEST == 'UI' }
       }
       environment {
         TMPDIR = "${WORKSPACE}/${BASE_DIR}"
@@ -126,7 +126,7 @@ pipeline {
     }
     stage("Opbeans") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'Opbeans' }
+        expression { return params.INTEGRATION_TEST == 'Opbeans' }
       }
       environment {
         TMPDIR = "${WORKSPACE}"

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -44,7 +44,11 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script{
-          currentBuild.displayName = "apm-agent-${params.INTEGRATION_TEST} - ${currentBuild.displayName}"
+          def displayName = "apm-agent-${params.INTEGRATION_TEST}"
+          if (params.INTEGRATION_TEST.equals('All') || params.INTEGRATION_TEST.equals('UI') || params.INTEGRATION_TEST.equals('Opbeans')) {
+            displayName = "${params.INTEGRATION_TEST}"
+          }
+          currentBuild.displayName = "${displayName} - ${currentBuild.displayName}"
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Use agent prefix when an agent test is executed, otherwise avoid the agent name in the emails and so on.
Rename params
Avoid sending data to ES for the downstream jobs.


## Why is it important?

Avoid any misleading when running UI tests in the APM-ITs.


## Related issues
Closes #ISSUE