### PR TITLE
[7.x] ci(jenkins): enable opbeans validation in apm agents PRs (#763)

### DIFF
--- a/.ci/scripts/opbeans-app.sh
+++ b/.ci/scripts/opbeans-app.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+# for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
+
+srcdir=$(dirname "$0")
+test -z "$srcdir" && srcdir=.
+# shellcheck disable=SC1090
+. "${srcdir}/common.sh"
+
+AGENT=$1
+APP=$2
+OPBEANS_APP=$3
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+  --with-agent-${APP} \
+  --with-opbeans-${OPBEANS_APP} \
+  --no-apm-server-dashboards \
+  --no-apm-server-self-instrument \
+  --apm-server-agent-config-poll=1s \
+  --force-build --no-xpack-secure"
+export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
+runTests "env-agent-${AGENT}"

--- a/.ci/scripts/opbeans-rum.sh
+++ b/.ci/scripts/opbeans-rum.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+# for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
+
+srcdir=$(dirname "$0")
+test -z "$srcdir" && srcdir=.
+# shellcheck disable=SC1090
+. "${srcdir}/common.sh"
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+  --with-opbeans-go \
+  --no-apm-server-dashboards \
+  --no-apm-server-self-instrument \
+  --apm-server-agent-config-poll=1s \
+  --force-build --no-xpack-secure"
+export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
+runTests "env-agent-go"
+
+## Use the nginx
+docker run -d --rm --name=opbeans-frontend \
+      --network="apm-integration-testing" \
+      -e ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-rum \
+      -e ELASTIC_APM_JS_BASE_SERVER_URL="http://localtesting_${ELASTIC_STACK_VERSION}_apm-server:8200" \
+      -e ELASTIC_OPBEANS_API_SERVER="http://localtesting_${ELASTIC_STACK_VERSION}_opbeans-go:3000"\
+      -p 3000:3000 \
+      docker.elastic.co/observability-ci/it_opbeans-frontend_nginx
+
+## Test the service is up and running
+http_code=$(curl -s -o /dev/null -w "%{http_code}" http://0.0.0.0:3000/dashboard)
+if [ "${http_code}" == "200" ] ; then
+  docker logs opbeans-frontend | grep '/dashboard'
+  docker stop opbeans-frontend || true
+else
+  echo 'ERROR: service is not listening.'
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ Omit `--skip-download` to just download images.
 
 `compose.py` includes unittests, `make test-compose` to run.
 
+### Jaeger
+
+APM Server can work as a drop-in replacement for a Jaeger collector, and ingest traces directly from a Jaeger client via
+HTTP/Thrift or from a Jaeger agent via gRPC.
+
+#### HTTP/Thrift
+
+To test HTTP/Thrift with a Jaeger microservice demo, run separately:
+
+    docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:latest  all
+
+#### gRPC
+
+To test gRPC, run the Jaeger Agent separately:
+
+    docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/jaeger-agent:latest
+
+And the Jaeger hotrod demo:
+
+    docker run --rm -it --network apm-integration-testing -e JAEGER_AGENT_HOST=jaeger-agent -e JAEGER_AGENT_PORT=6831 -p8080-8083:8080-8083 jaegertracing/example-hotrod:latest all
+
 ## Running Tests
 
 Additional dependencies are required for running the integration tests:
@@ -185,14 +206,28 @@ Those scripts shut down any existing testing containers and start a fresh new en
 
 These are the scripts available to execute:
 
-* `all.sh:` runs all test on apm-server and every agent type.
-* `common.sh:` common scripts variables and functions, it does not execute anything.
+* `agent.sh:` runs the tests for the given agent. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `all.sh:` runs all tests on apm-server and every agent type.
+
+* `common.sh:` common scripts variables and functions. It does not execute anything.
+
 * `dotnet.sh:` runs .NET tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
-* `go.sh:` runs Go tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
-* `java.sh:` runs Java tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
-* `kibana.sh:` runs kibana agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
-* `nodejs.sh:` runs Nodejs agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
-* `python.sh:` runs Python agent tests, you can choose the versions to run see the [environment variables](environment-variables) configuration.
+
+* `go.sh:` runs Go tests. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `java.sh:` runs Java tests. Uou can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `kibana.sh:` runs Kibana agent tests. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `nodejs.sh:` runs Nodejs agent tests. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `opbeans.sh:` runs the unit tests for the apm-integration-testing app and validates the linting. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `opbeans-app.sh:` runs the apm-integration-testing app and validates the stack can be started. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
+* `python.sh:` runs Python agent tests. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+
 * `ruby.sh:` runs Ruby agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `server.sh:` runs APM Server tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `unit-tests.sh:` runs the unit tests for the apm-integration-testing app and validate the linting, you can choose the versions to run see the [environment variables](#environment-variables) configuration.

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -8,8 +8,11 @@ CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
 BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent -b "${DOTNET_AGENT_BRANCH}"
+  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent
   cd /src/dotnet-agent || exit
+  git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+  git checkout "${DOTNET_AGENT_BRANCH}"
+
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
   dotnet restore

--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -9,11 +9,10 @@ RUN git clone https://github.com/elastic/opbeans-go.git .
 RUN rm -fr vendor/go.elastic.co/apm
 ARG GO_AGENT_REPO=elastic/apm-agent-go
 ARG GO_AGENT_BRANCH=master
-# adding this file will invalidate the layer cache when the branch head changes
-# it does not work with TAGs
-#ADD https://api.github.com/repos/${GO_AGENT_REPO}/git/refs/heads/${GO_AGENT_BRANCH} version.json
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/go.elastic.co/apm
-RUN (cd /src/go.elastic.co/apm && git checkout ${GO_AGENT_BRANCH})
+RUN (cd /src/go.elastic.co/apm \
+    && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+    && git checkout ${GO_AGENT_BRANCH})
 # Add "replace" stanzas to go.mod to use the local agent repo
 RUN go list -m all | grep apm | cut -d' ' -f1 | xargs -i go mod edit -replace {}=/src/{}
 RUN go build

--- a/docker/opbeans/ruby/entrypoint.sh
+++ b/docker/opbeans/ruby/entrypoint.sh
@@ -13,7 +13,14 @@ elif [[ $RUBY_AGENT_BRANCH ]]; then
         RUBY_AGENT_REPO="elastic/apm-agent-ruby"
     fi
     echo "Installing ${RUBY_AGENT_REPO}:${RUBY_AGENT_BRANCH} from Github"
-    gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b $RUBY_AGENT_BRANCH
+
+    # Support branches/tags and refs
+    set +e
+    if gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b "${RUBY_AGENT_BRANCH}" ; then
+      set -e
+      gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -r "${RUBY_AGENT_BRANCH}"
+    fi
+
 else
     gem install elastic-apm
 fi


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): enable opbeans validation in apm agents PRs (#763)