### PR TITLE
[7.x] ci(jenkins): walkthrough document to help with the debugging locally (#693)

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -228,5 +228,8 @@ def wrappingup(label){
       allowEmptyResults: true,
       keepLongStdio: true,
       testResults: "**/tests/results/*-junit*.xml")
+    // Let's generate the debug report ...
+    sh(label: 'Generate debug docs', script: '.ci/scripts/generate-debug-docs.sh | tee docs.txt')
+    archiveArtifacts(artifacts: 'docs.txt')
   }
 }

--- a/.ci/scripts/generate-debug-docs.sh
+++ b/.ci/scripts/generate-debug-docs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+gitUrl=$(git remote get-url origin)
+commit=$(git rev-parse HEAD)
+
+echo "Let's generate the details to help to reproduce it locally ..."
+echo ""
+echo ""
+
+echo "# Let's clone the repo"
+echo "git clone ${gitUrl} .apm-its"
+echo "cd .apm-its"
+echo "git checkout ${commit}"
+echo ""
+echo "# Let's run the apm-integration testing for ${NAME}"
+echo "export ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION}"
+echo "export BUILD_OPTS=${BUILD_OPTS}"
+echo "./ci/scripts/${NAME}.sh"
+echo ""
+echo "# Let's save the docker log output as files"
+echo "./scripts/docker-get-logs.sh '${NAME}' || echo 'Failed to get Docker logs'"
+echo "make stop-env || echo 'Failed to stop the environment'"
+echo ""
+echo "# Logs are now stored in the below location docker-info/${NAME}"
+echo "cd docker-info/${NAME}"
+echo "ls -ltrh"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@ node_modules
 **/.vscode/settings.json
 **/obj
 **/bin
+docker-info/
+
+# For the BATS testing
+bats-core/
+target/
+.tags*
+
+# For the docs generation
+.apm-its


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): walkthrough document to help with the debugging locally (#693)