### PR TITLE
[7.x] ci(jenkins): Backport (#779) (#718) (#694) (#571)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -131,13 +131,13 @@ pipeline {
   }
 }
 
-def runJob(agentName, buildOpts = ''){
+def runJob(testName, buildOpts = ''){
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def job
   try {
     job = build(job: "apm-integration-test-downstream/${branch}",
       parameters: [
-      string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
+      string(name: 'INTEGRATION_TEST', value: testName),
       string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
       string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
       string(name: 'MERGE_TARGET', value: "${branch}"),
@@ -149,8 +149,8 @@ def runJob(agentName, buildOpts = ''){
       wait: true)
   } catch(e) {
     job = e
-    error("Downstream job for '${agentName}' failed")
+    error("Downstream job for '${testName}' failed")
   } finally {
-    itsDownstreamJobs["${agentName}"] = job
+    itsDownstreamJobs["${testName}"] = job
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,11 +1,10 @@
 #!/usr/bin/env groovy
-
 @Library('apm@current') _
 
 pipeline {
-  agent none
+  agent { label 'linux && immutable' }
   environment {
-    BASE_DIR="src/github.com/elastic/apm-integration-testing"
+    BASE_DIR = 'src/github.com/elastic/apm-integration-testing'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     PIPELINE_LOG_LEVEL='INFO'
@@ -34,7 +33,6 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
-      agent { label 'master || immutable' }
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
@@ -42,25 +40,46 @@ pipeline {
       }
     }
 
-    /**
-      Validate UTs and lint the app
-    */
-    stage('Unit Tests'){
-      agent { label 'linux && immutable && docker' }
-      steps {
-        withGithubNotify(context: 'Unit Tests', tab: 'tests') {
-          deleteDir()
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            sh '.ci/scripts/unit-tests.sh'
+    stage('Tests'){
+      parallel {
+        /**
+          Validate UTs and lint the app
+        */
+        stage('Unit Tests'){
+          options { skipDefaultCheckout() }
+          steps {
+            withGithubNotify(context: 'Unit Tests', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh '.ci/scripts/unit-tests.sh'
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true,
+                keepLongStdio: true,
+                testResults: "${BASE_DIR}/**/*junit.xml")
+            }
           }
         }
-      }
-      post {
-        always {
-          junit(allowEmptyResults: true,
-            keepLongStdio: true,
-            testResults: "${BASE_DIR}/**/*junit.xml")
+        stage('Sanity checks') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
+            HOME = "${env.WORKSPACE}"
+          }
+          steps {
+            withGithubNotify(context: 'Sanity checks', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true)
+              }
+            }
+          }
         }
       }
     }
@@ -116,7 +135,7 @@ def runJob(agentName, buildOpts = ''){
     parameters: [
     string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
     string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-    string(name: 'INTEGRATION_TESTING_VERSION', value: env.GIT_BASE_COMMIT),
+    string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
     string(name: 'MERGE_TARGET', value: "${branch}"),
     string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
     string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,13 @@
 #!/usr/bin/env groovy
 @Library('apm@current') _
 
+import groovy.transform.Field
+
+/**
+ This is required to store the build status for the downstream jobs.
+*/
+@Field def itsDownstreamJobs = [:]
+
 pipeline {
   agent { label 'linux && immutable' }
   environment {
@@ -119,28 +126,31 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(downstreamJobs: itsDownstreamJobs)
     }
   }
 }
 
 def runJob(agentName, buildOpts = ''){
-  def branch = env.BRANCH_NAME
-
-  if (env.CHANGE_ID) {
-    branch = env.CHANGE_TARGET
+  def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
+  def job
+  try {
+    job = build(job: "apm-integration-test-downstream/${branch}",
+      parameters: [
+      string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
+      string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
+      string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
+      string(name: 'MERGE_TARGET', value: "${branch}"),
+      string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
+      string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
+      booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
+      propagate: true,
+      quietPeriod: 10,
+      wait: true)
+  } catch(e) {
+    job = e
+    error("Downstream job for '${agentName}' failed")
+  } finally {
+    itsDownstreamJobs["${agentName}"] = job
   }
-
-  def job = build(job: "apm-integration-test-downstream/${branch}",
-    parameters: [
-    string(name: 'AGENT_INTEGRATION_TEST', value: agentName),
-    string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-    string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
-    string(name: 'MERGE_TARGET', value: "${branch}"),
-    string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
-    string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
-    booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
-    propagate: true,
-    quietPeriod: 10,
-    wait: true)
 }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -30,7 +30,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    choice(name: 'AGENT_INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the APM Agent you want to run the integration tests.')
+    choice(name: 'INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the Tests or APM Agent you want to run the integration tests.')
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.6", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "7.x", description: "Integration testing Git branch/tag to use")
     string(name: 'MERGE_TARGET', defaultValue: "7.x", description: "Integration testing Git branch/tag where to merge this code")
@@ -55,9 +55,15 @@ pipeline {
           shallow: false
         )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-        script{
-          currentBuild.displayName = "apm-agent-${params.AGENT_INTEGRATION_TEST} - ${currentBuild.displayName}"
-          currentBuild.description = "Agent ${params.AGENT_INTEGRATION_TEST} - ${params.UPSTREAM_BUILD}"
+        script {
+          def displayName = "apm-agent-${params.INTEGRATION_TEST}"
+          def description = "Agent ${params.INTEGRATION_TEST}"
+          if (params.INTEGRATION_TEST.equals('All') || params.INTEGRATION_TEST.equals('UI')) {
+            displayName = "${params.INTEGRATION_TEST}"
+            description = "${params.INTEGRATION_TEST}"
+          }
+          currentBuild.displayName = "${displayName} - ${currentBuild.displayName}"
+          currentBuild.description = "${description} - ${params.UPSTREAM_BUILD}"
         }
       }
     }
@@ -67,8 +73,8 @@ pipeline {
     stage("Integration Tests"){
       when {
         expression {
-          return (params.AGENT_INTEGRATION_TEST != 'All'
-            && params.AGENT_INTEGRATION_TEST != 'UI')
+          return (params.INTEGRATION_TEST != 'All'
+            && params.INTEGRATION_TEST != 'UI')
         }
       }
       steps {
@@ -76,7 +82,7 @@ pipeline {
         unstash "source"
         dir("${BASE_DIR}"){
           script {
-            def agentTests = agentMapping.id(params.AGENT_INTEGRATION_TEST)
+            def agentTests = agentMapping.id(params.INTEGRATION_TEST)
             integrationTestsGen = new IntegrationTestingParallelTaskGenerator(
               xKey: agentMapping.agentVar(agentTests),
               yKey: agentMapping.agentVar('server'),
@@ -84,7 +90,7 @@ pipeline {
               yFile: agentMapping.yamlVersionFile('server'),
               exclusionFile: agentMapping.yamlVersionFile(agentTests),
               tag: agentTests,
-              name: params.AGENT_INTEGRATION_TEST,
+              name: params.INTEGRATION_TEST,
               steps: this
               )
             def mapPatallelTasks = integrationTestsGen.generateParallelTests()
@@ -95,7 +101,7 @@ pipeline {
     }
     stage("All") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'All' }
+        expression { return params.INTEGRATION_TEST == 'All' }
       }
       environment {
         TMPDIR = "${WORKSPACE}"
@@ -116,7 +122,7 @@ pipeline {
     }
     stage("UI") {
       when {
-        expression { return params.AGENT_INTEGRATION_TEST == 'UI' }
+        expression { return params.INTEGRATION_TEST == 'UI' }
       }
       environment {
         TMPDIR = "${WORKSPACE}/${BASE_DIR}"
@@ -140,15 +146,10 @@ pipeline {
       script{
         if(integrationTestsGen?.results){
           writeJSON(file: 'results.json', json: toJSON(integrationTestsGen.results), pretty: 2)
-          def mapResults = ["${params.AGENT_INTEGRATION_TEST}": integrationTestsGen.results]
+          def mapResults = ["${params.INTEGRATION_TEST}": integrationTestsGen.results]
           def processor = new ResultsProcessor()
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
-          catchError(buildResult: 'SUCCESS') {
-            def datafile = readFile(file: "results.json")
-            def json = getVaultSecret(secret: 'secret/apm-team/ci/jenkins-stats-cloud')
-            sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-it-results/_doc/')
-          }
         }
         notifyBuildResult()
       }
@@ -166,7 +167,7 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
   }
 
   /**
-    build a clousure that launch and agent and execute the corresponding test script,
+    build a clousure that launch an agent or test and execute the corresponding test script,
     then store the results.
   */
   public Closure generateStep(x, y){

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -11,7 +11,7 @@ import groovy.transform.Field
 @Field def integrationTestsGen
 
 pipeline {
-  agent { label 'linux && immutable && docker' }
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/apm-integration-testing"
     REPO="git@github.com:elastic/apm-integration-testing.git"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,52 +36,15 @@ repos:
         types: [yaml]
         exclude: (^.pre-commit-config.yaml$|^.ci/.yamlint.yml$|^target/)
 
--   repo: local
+-   repo: git@github.com:elastic/apm-pipeline-library
+    rev: current
     hooks:
     -   id: check-bash-syntax
-        name: Check Shell scripts syntax corectness
-        language: system
-        entry: bash -n
-        files: \.sh$
-        exclude: ^target/
-    -   id: forbid-abstract-classes-and-traits
-        name: Ensure neither abstract classes nor traits are used
-        language: pygrep
-        entry: "^(abstract|trait) "
-        files: ^src/.*\.groovy$
-        exclude: ^target/
-    -   id: force-JsonSlurperClassic
-        name: Ensure JsonSlurperClassic is used instead of non-serializable JsonSlurper
-        language: pygrep
-        entry: JsonSlurper[^C]
-        files: \.groovy$
-        exclude: ^target/
-    -   id: Jenkinsfile-linter
-        name: Check syntax of the Jenkinsfiles
-        description: Check Jenkinsfile following the scripted-pipeline syntax using Jenkins API
-        files: ^.ci/(.*\.groovy|Jenkinsfile)$
-        entry: .ci/scripts/validate.sh
-        language: script
-        verbose: true
-        exclude: ^target/
-    -   id: forbid-unicode-non-breaking-spaces
-        name: Detect unicode non-breaking space character U+00A0 aka M-BM-
-        language: system
-        entry: perl -ne 'print if $m = /\xc2\xa0/; $t ||= $m; END{{exit $t}}'
+    -   id: check-abstract-classes-and-trait
+    -   id: check-jsonslurper-class
+    -   id: check-jenkins-pipelines
+    -   id: check-unicode-non-breaking-spaces
     -   id: remove-unicode-non-breaking-spaces
-        name: Remove unicode non-breaking space character U+00A0 aka M-BM-
-        language: system
-        entry: perl -pi* -e 's/\xc2\xa0/ /g && ($t = 1) && print STDERR $_; END{{exit
-            $t}}'
-        exclude: ^target/
-    -   id: forbid-en-dashes
-        name: Detect the EXTREMELY confusing unicode character U+2013
-        language: system
-        entry: perl -ne 'print if $m = /\xe2\x80\x93/; $t ||= $m; END{{exit $t}}'
-        exclude: ^target/
+    -   id: check-en-dashes
     -   id: remove-en-dashes
-        name: Remove the EXTREMELY confusing unicode character U+2013
-        language: system
-        entry: perl -pi* -e 's/\xe2\x80\x93/-/g && ($t = 1) && print STDERR $_; END{{exit
-            $t}}'
-        exclude: ^target/
+    -   id: check-jjbb


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): Agent when required (#779)
 - ci(jenkins): report downstream issues (#718)
 - ci(jenkins): simplify the git base commit and avoid docker in the labels (#694)
- feat: use the pre-commit hooks library of apm-pipeline-library (#571)