### PR TITLE
Set xpack.encryptedSavedObjects.encryptionKey by default.

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -693,6 +693,7 @@ class Kibana(StackService, Service):
                 self.environment["XPACK_XPACK_MAIN_TELEMETRY_ENABLED"] = "false"
             if self.at_least_version("7.7"):
                 self.environment["XPACK_SECURITY_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
+                self.environment["XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
             if options.get("xpack_secure"):
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
                 self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -921,6 +921,7 @@ class LocalTest(unittest.TestCase):
                     XPACK_APM_SERVICEMAPENABLED: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_SECURITY_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
+                    XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
                     XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'
                 }

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -998,13 +998,15 @@ class KibanaServiceTest(ServiceTest):
         kibana = Kibana(version="7.6.0", xpack_secure=False, kibana_version="7.6.0").render()["kibana"]
         self.assertNotIn("XPACK_SECURITY_LOGINASSISTANCEMESSAGE", kibana['environment'])
 
-    def test_kibana_encryption_key_in_7_6(self):
+    def test_kibana_encryption_keys_in_7_6(self):
         kibana = Kibana(version="7.6.0", kibana_version="7.6.0").render()["kibana"]
         self.assertNotIn("XPACK_SECURITY_ENCRYPTIONKEY", kibana['environment'])
+        self.assertNotIn("XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY", kibana['environment'])
 
-    def test_kibana_encryption_key_in_7_7(self):
+    def test_kibana_encryption_keys_in_7_7(self):
         kibana = Kibana(version="7.7.0", kibana_version="7.7.0").render()["kibana"]
         self.assertIn("XPACK_SECURITY_ENCRYPTIONKEY", kibana['environment'])
+        self.assertIn("XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY", kibana['environment'])
 
 
 class LogstashServiceTest(ServiceTest):


### PR DESCRIPTION


## What does this PR do?
From 7.7 on set the encryption key to enable detection engine by default.
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
To be able to test APM related detection engine rules in the SIEM app.
<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #752 
