### PR TITLE
Add Elasticsearch slowlog flag

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import os
 
-from .helpers import curl_healthcheck
+from .helpers import curl_healthcheck, try_to_set_slowlog
 from .service import StackService, Service
 
 
@@ -592,6 +592,8 @@ class Elasticsearch(StackService, Service):
 
         self.environment = self.default_environment + [
             java_opts_env, "path.data=/usr/share/elasticsearch/data/" + data_dir]
+        if options.get("elasticsearch_slow_log"):
+            try_to_set_slowlog()
         if self.at_least_version("8.0"):
             self.environment.append("indices.id_field_data.enabled=true")
         if not self.oss:
@@ -634,6 +636,12 @@ class Elasticsearch(StackService, Service):
             "--elasticsearch-xpack-audit",
             action="store_true",
             help="enable very verbose xpack auditing",
+        )
+
+        parser.add_argument(
+            "--elasticsearch-slow-log",
+            action="store_true",
+            help="enable the Elasticsearch slow log"
         )
 
         class storeDict(argparse.Action):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -593,7 +593,7 @@ class Elasticsearch(StackService, Service):
         self.environment = self.default_environment + [
             java_opts_env, "path.data=/usr/share/elasticsearch/data/" + data_dir]
         if options.get("elasticsearch_slow_log"):
-            try_to_set_slowlog()
+            try_to_set_slowlog(options.get("apm_server_elasticsearch_password"))
         if self.at_least_version("8.0"):
             self.environment.append("indices.id_field_data.enabled=true")
         if not self.oss:

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -82,6 +82,7 @@ def load_images(urls, cache_dir):
 DEFAULT_HEALTHCHECK_INTERVAL = "10s"
 DEFAULT_HEALTHCHECK_RETRIES = 12
 
+
 def _print_done(service_name):
     # 22 chars to ...
     done = '\033[32mdone'
@@ -92,6 +93,7 @@ def _print_done(service_name):
         s = s + ' '
     print("{service}{spaces}{dots} {done}".format(service=service_name, spaces=s, dots=dots, done=done))
 
+
 def try_to_set_slowlog():
     # This is a bit tricky to follow. What we're doing here is forking a "manager"
     # process that will occasionally attempt to configure the slow log. After it
@@ -99,6 +101,7 @@ def try_to_set_slowlog():
     # and terminates itself.
     manager_process = multiprocessing.Process(target=_set_slowlog_json)
     manager_process.start()
+
 
 def _set_slowlog_json():
     this_try = 0
@@ -147,6 +150,7 @@ def _set_slowlog_json():
             if json_ret.get("acknowledged"):
                 _print_done('Configuring slowlog')
                 break
+
 
 def curl_healthcheck(port, host="localhost", path="/healthcheck",
                      interval=DEFAULT_HEALTHCHECK_INTERVAL, retries=DEFAULT_HEALTHCHECK_RETRIES):

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -94,16 +94,16 @@ def _print_done(service_name):
     print("{service}{spaces}{dots} {done}".format(service=service_name, spaces=s, dots=dots, done=done))
 
 
-def try_to_set_slowlog():
+def try_to_set_slowlog(password):
     # This is a bit tricky to follow. What we're doing here is forking a "manager"
     # process that will occasionally attempt to configure the slow log. After it
     # detects that the slowlog has successfully been configured, it declares victory
     # and terminates itself.
-    manager_process = multiprocessing.Process(target=_set_slowlog_json)
+    manager_process = multiprocessing.Process(target=_set_slowlog_json, args=(password,))
     manager_process.start()
 
 
-def _set_slowlog_json():
+def _set_slowlog_json(password):
     this_try = 0
     tries = 30
     while this_try <= tries:
@@ -116,7 +116,7 @@ def _set_slowlog_json():
             "--connect-timeout",
             "1",
             "-u",
-            "admin:changeme",
+            "admin:{}".format(password if password is not None else "changeme"),
             "-s",
             "-X",
             "PUT",
@@ -142,7 +142,6 @@ def _set_slowlog_json():
             "index.search.slowlog.level": "info"\
             }'
         ], stdout=subprocess.PIPE)
-
         if completed_process.returncode != 0 or completed_process.stdout is None:
             continue
         else:

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -12,12 +12,6 @@ import subprocess
 import sys
 import uuid
 import time
-try:
-    import asyncio
-    HAS_ASYNC=True
-except ImportError:
-    # This was probably Python 2
-    HAS_ASYNC=False
 
 try:
     from urllib.request import urlopen, urlretrieve, Request


### PR DESCRIPTION
## What does this PR do?

This adds the capability to pass in a flag called `--elasticsearch-slow-log` and have the slowlog automatically configured for Elasticsearch.

## Why is it important?

Improves ability to debug any issues.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/782
