### PR TITLE
fix: launch jobs only on cron trigger

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -17,7 +17,7 @@ pipeline {
     LC_ALL = "C.UTF-8"
   }
   triggers {
-    cron 'H H(3-4) * * 1-5'
+    cron 'H H(5-7) * * 1-5'
   }
   options {
     timeout(time: 3, unit: 'HOURS')

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -18,7 +18,7 @@ pipeline {
     PYTHONHTTPSVERIFY = "0"
   }
   triggers {
-    cron 'H H(3-4) * * 1-5'
+    cron 'H H(5-7) * * 1-5'
   }
   options {
     timeout(time: 3, unit: 'HOURS')

--- a/.ci/jobs/apm-it-ec.yml
+++ b/.ci/jobs/apm-it-ec.yml
@@ -13,16 +13,14 @@
         discover-pr-origin: merge-current
         discover-tags: true
         notification-context: 'apm-it-ec'
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         repo: apm-integration-testing
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
         clean:
           after: true
           before: true

--- a/.ci/jobs/apm-it-eck.yml
+++ b/.ci/jobs/apm-it-eck.yml
@@ -13,16 +13,14 @@
         discover-pr-origin: merge-current
         discover-tags: true
         notification-context: 'apm-it-eck'
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         repo: apm-integration-testing
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
         clean:
           after: true
           before: true


### PR DESCRIPTION
## What does this PR do?

It changes the ITs on Ec and ECK to run only when cron trigger them.

## Why is it important?

Those test spin up some infrastructure and are tested against daily snapshots so it does not need to run them so often 
