### PR TITLE
ci: remove 8 Stack version temporarily on ECK test

### DIFF
--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -58,7 +58,7 @@ pipeline {
         axes {
           axis {
               name 'ELASTIC_STACK_VERSION'
-              values '8.0.0-SNAPSHOT', '7.7.0-SNAPSHOT', '7.6.1-SNAPSHOT'
+              values '7.7.0-SNAPSHOT', '7.6.1-SNAPSHOT'
           }
         }
         stages {


### PR DESCRIPTION
## What does this PR do?

It disables the Elastic Stack 8.0.0-SNAPSHOT tests on ECK

## Why is it important?

The deploy of Elastic Stack 8.0.0-SNAPSHOT it is failing and the tests are not running until we check what happens and where is the issue we disable the tests for 8
