### PR TITLE
dotnet: sdk version and fail-fast

### DIFF
--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -3,7 +3,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS build
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -21,6 +21,11 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   ### Errorlevels might happen when fetching PRs with some errors like: error: cannot lock ref 'refs/remotes/origin/pr/82/head': 'refs/remotes/origin/pr/82' exists; cannot create
   ### Let's fail if something bad happens when building the agent from the source code
   set -e
+  # Remove Full Framework projects
+  ## See https://github.com/elastic/apm-agent-dotnet/blob/480be30a699ba276ebd2a7055083e92f9f1e2207/.ci/linux/test.sh#L9-L11
+  dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+  dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+  dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   dotnet restore
   dotnet pack -c Release -o /src/local-packages
 

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -x
 
 CSPROJ="TestAspNetCoreApp.csproj"
 
@@ -17,6 +17,10 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
 
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
+
+  ### Errorlevels might happen when fetching PRs with some errors like: error: cannot lock ref 'refs/remotes/origin/pr/82/head': 'refs/remotes/origin/pr/82' exists; cannot create
+  ### Let's fail if something bad happens when building the agent from the source code
+  set -e
   dotnet restore
   dotnet pack -c Release -o /src/local-packages
 

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set -ex
 
 CSPROJ="TestAspNetCoreApp.csproj"
 


### PR DESCRIPTION
## What does this PR do?

Bump version for the required sdk version.


## Why is it important?

See https://github.com/elastic/apm-agent-dotnet/pull/778#issuecomment-601170586

## Related issues
Closes #ISSUE

## Test

```
python scripts/compose.py start 8.0.0 --dotnet-agent-version 85ea77d8b88f82dc464810ee923a3f8392955a0f --opbeans-dotnet-agent-branch 85ea77d8b88f82dc464810ee923a3f8392955a0f --build-parallel   --with-agent-dotnet   --no-apm-server-dashboards   --no-apm-server-self-instrument   --apm-server-agent-config-poll=1s   --force-build --no-xpack-secure

```

```
Step 13/13 : ENTRYPOINT ["dotnet", "TestAspNetCoreApp.dll", "--urls=http://0.0.0.0:8100"]
 ---> Running in 06ec0333fa7e
Removing intermediate container 06ec0333fa7e
 ---> 7129a6161461
Successfully built 7129a6161461
Building agent-dotnet ... done
Pulling elasticsearch ... done
Pulling kibana        ... done
Pulling apm-server    ... done
localtesting_8.0.0_elasticsearch is up-to-date
localtesting_8.0.0_kibana is up-to-date
localtesting_8.0.0_apm-server is up-to-date
Recreating dotnetapp ... done

curl -v 127.0.0.1:8100
* Rebuilt URL to: 127.0.0.1:8100/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8100 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8100
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Thu, 19 Mar 2020 15:58:22 GMT
< Server: Kestrel
< Transfer-Encoding: chunked
< 
* Connection #0 to host 127.0.0.1 left intact
OK
```