### PR TITLE
opbeans-dotnet: bump sdk version and fail fast

### DIFF
--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -4,7 +4,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS opbeans-dotnet
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS opbeans-dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -20,6 +20,15 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
 
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
+
+  ### Errorlevels might happen when fetching PRs with some errors like: error: cannot lock ref 'refs/remotes/origin/pr/82/head': 'refs/remotes/origin/pr/82' exists; cannot create
+  ### Let's fail if something bad happens when building the agent from the source code
+  set -e
+  # Remove Full Framework projects
+  ## See https://github.com/elastic/apm-agent-dotnet/blob/480be30a699ba276ebd2a7055083e92f9f1e2207/.ci/linux/test.sh#L9-L11
+  dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+  dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+  dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   dotnet restore
   dotnet pack -c Release -o /src/local-packages
 


### PR DESCRIPTION
## What does this PR do?

Bump the sdk version for the opbeans-dotnet docker image and fail fast.

## Why is it important?

Leftover

## Related issues

See https://github.com/elastic/apm-integration-testing/pull/793