### PR TITLE
fix: openjdk:10-jre-slim no longer can install packages

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -51,7 +51,7 @@ opbeans/opbeans-loadgen:latest
 opbeans/opbeans-node:latest
 opbeans/opbeans-python:latest
 opbeans/opbeans-ruby:latest
-openjdk:10-jre-slim
+openjdk:11-slim
 php:7-alpine
 php:7.2-alpine
 php:7.3-alpine

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -51,7 +51,7 @@ opbeans/opbeans-loadgen:latest
 opbeans/opbeans-node:latest
 opbeans/opbeans-python:latest
 opbeans/opbeans-ruby:latest
-openjdk:11-slim
+adoptopenjdk:11-jre-hotspot
 php:7-alpine
 php:7.2-alpine
 php:7.3-alpine

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -19,16 +19,14 @@ RUN cd /agent/apm-agent-java \
 COPY maven-package.sh /agent
 RUN ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11-slim
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar /app
 RUN apt-get -qq update \
-  && apt-get -qq install -y curl \
+  && apt-get -qq install -y --no-install-recommends curl \
   && apt-get -qq clean \
   && rm -fr /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 8090
 ENV ELASTIC_APM_API_REQUEST_TIME 50ms
 CMD ["java", "-javaagent:/app/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.max_queue_size=2048", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","/app/target/hello-spring-0.1.jar"]
-
-

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /agent/apm-agent-java \
 COPY maven-package.sh /agent
 RUN ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"
 
-FROM openjdk:11-slim
+FROM adoptopenjdk:11-jre-hotspot
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar /app
 RUN apt-get -qq update \


### PR DESCRIPTION
## What does this PR do?

It changes the openjdk:10-jre-slim Docker image by openjdk:11-slim.

## Why is it important?

Latest changes in Ubuntu force you to upgrade a libcrypt when you install package, this needs to upgrade the libc but it fails, this breaks the Docker image build for openjdk:10-jre-slim Docker image derivates. The simple solution is to move to next openjdk version.

## Related issues
Closes #801
