### PR TITLE
feat: return the exit code of docker compose in case of failure

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -401,7 +401,7 @@ class LocalSetup(object):
 
     def run_docker_compose_process(self, docker_compose_cmd):
         try:
-            subprocess.call(docker_compose_cmd)
+            subprocess.check_call(docker_compose_cmd)
         except OSError as err:
             print('ERROR: Docker Compose might be missing. See below for further details.\n')
             raise OSError(err)


### PR DESCRIPTION
## What does this PR do?

It waits for the return code of the docker-compose command and raises an exception if it is no equal 0.

## Why is it important?

The current behavior does not check the return code if the command fails, the exit code of `compose.py` is 0 in any case.

## Related issues
Closes #800
