### PR TITLE
fix: apm-server docker container test

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -31,3 +31,8 @@ ENV SRC=/go/src/github.com/elastic/apm-server
 COPY --from=build ${SRC}/apm-server /usr/share/apm-server/apm-server
 COPY --from=build ${SRC}/apm-server.yml /usr/share/apm-server/apm-server.yml
 COPY --from=build ${SRC}/fields.yml /usr/share/apm-server/fields.yml
+
+CMD ./apm-server -e -d "*"
+
+# Add healthcheck for docker/healthcheck metricset to check during testing
+HEALTHCHECK CMD exit 0


### PR DESCRIPTION
## What does this PR do?

It adds CMD and HEALTCHECK directives from the parent container

## Why is it important?

This allow passing the test.

