### PR TITLE
[WIP] feat: use kind instead GCP

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -41,12 +41,10 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
-        dir("${EC_DIR}"){
-          git(branch: 'current',
-            credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-            url: 'git@github.com:elastic/observability-test-environments.git'
-          )
-        }
+        gitCheckout(basedir: "${EC_DIR}", branch: 'current',
+          credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+          repo: 'git@github.com:elastic/observability-test-environments.git'
+        )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -41,10 +41,15 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
-        gitCheckout(basedir: "${EC_DIR}", branch: 'current',
-          credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-          repo: 'git@github.com:elastic/observability-test-environments.git'
-        )
+        dir("${EC_DIR}"){
+          checkout([$class: 'GitSCM', branches: [[name: "current"]],
+            doGenerateSubmoduleConfigurations: false,
+            userRemoteConfigs: [[
+              refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*',
+              credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+              url: 'git@github.com:elastic/observability-test-environments.git']]
+          ])
+        }
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -42,7 +42,7 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         dir("${EC_DIR}"){
-          git(branch: 'master',
+          git(branch: 'current',
             credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
             url: 'git@github.com:elastic/observability-test-environments.git'
           )

--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -78,7 +78,11 @@ pipeline {
                   dir("${EC_DIR}/ansible"){
                     withTestEnv(){
                       sh(label: "Deploy Cluster", script: "make create-cluster")
-                      sh(label: "Rename cluster-info folder", script: "mv build/cluster-info.html cluster-info-${ELASTIC_STACK_VERSION}.html")
+                      sh(label: "Rename cluster-info folder", script: """
+                        if [ -f build/cluster-info.html ]; then
+                          mv build/cluster-info.html cluster-info-${ELASTIC_STACK_VERSION}.html
+                        fi
+                      """)
                       archiveArtifacts(allowEmptyArchive: true, artifacts: 'cluster-info-*')
                     }
                   }

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -260,6 +260,12 @@ def withConfigEnv(Closure body) {
   def apm = readJSON(text: apmJson)
   def kb = readJSON(text: kbJson)
 
+  if(params.environment_file == 'eck-kind.yml'){
+    es.url = 'https://elasticsearch.127.0.0.1.ip.es.io:443'
+    kb.url = 'https://kibana.127.0.0.1.ip.es.io:443'
+    apm.url = 'https://apm.127.0.0.1.ip.es.io:443'
+  }
+
   withEnvMask(vars: [
     [var: 'APM_SERVER_URL', password: apm.url],
     [var: 'ELASTIC_APM_SECRET_TOKEN', password: apm.token],

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -220,7 +220,7 @@ def withTestEnv(Closure body){
     "CONFIG_HOME=${env.WORKSPACE}",
     "VENV=${env.WORKSPACE}/.venv",
     "PATH=${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.VENV}/bin:${ecWs}/bin:${ecWs}/.ci/scripts:${env.PATH}",
-    "CLUSTER_CONFIG_FILE=${ecWs}/tests/environments/eck.yml",
+    "CLUSTER_CONFIG_FILE=${ecWs}/tests/environments/eck-kind.yml",
     "BUILD_NUMBER=${ params.destroy_mode ? params.build_num_to_destroy : env.BUILD_NUMBER}"
   ]){
     withVaultEnv(){

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -44,7 +44,7 @@ pipeline {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         dir("${EC_DIR}"){
-          git(branch: 'master',
+          git(branch: 'current',
             credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
             url: 'git@github.com:elastic/observability-test-environments.git'
           )

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -34,6 +34,7 @@ pipeline {
     booleanParam(name: 'update_docker_images', defaultValue: true, description: 'Enable/Disable the Docker images update.')
     booleanParam(name: 'destroy_mode', defaultValue: false, description: 'Run the script in destroy mode to destroy any cluster provisioned and delete vault secrets.')
     string(name: 'build_num_to_destroy', defaultValue: "", description: "Build number to destroy, it is needed on destroy_mode")
+    choice(choices: ['eck-kind.yml', 'eck.yml'], description: 'Select the file to deploy the test environment (eck-kind.yml - Kind, eck.yml - GCP)', name: 'environment_file')
   }
   stages {
     /**
@@ -227,7 +228,7 @@ def withTestEnv(Closure body){
     "CONFIG_HOME=${env.WORKSPACE}",
     "VENV=${env.WORKSPACE}/.venv",
     "PATH=${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.VENV}/bin:${ecWs}/bin:${ecWs}/.ci/scripts:${env.PATH}",
-    "CLUSTER_CONFIG_FILE=${ecWs}/tests/environments/eck-kind.yml",
+    "CLUSTER_CONFIG_FILE=${ecWs}/tests/environments/${params.environment_file}",
     "BUILD_NUMBER=${ params.destroy_mode ? params.build_num_to_destroy : env.BUILD_NUMBER}"
   ]){
     withVaultEnv(){

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -43,10 +43,15 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
-        gitCheckout(basedir: "${EC_DIR}", branch: 'current',
-          credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-          repo: 'git@github.com:elastic/observability-test-environments.git'
-        )
+        dir("${EC_DIR}"){
+          checkout([$class: 'GitSCM', branches: [[name: "current"]],
+            doGenerateSubmoduleConfigurations: false,
+            userRemoteConfigs: [[
+              refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*',
+              credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+              url: 'git@github.com:elastic/observability-test-environments.git']]
+          ])
+        }
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -95,7 +95,11 @@ pipeline {
                   dir("${EC_DIR}/ansible"){
                     withTestEnv(){
                       sh(label: "Deploy Cluster", script: "make create-cluster")
-                      sh(label: "Rename cluster-info folder", script: "mv build/cluster-info.html cluster-info-${ELASTIC_STACK_VERSION}.html")
+                      sh(label: "Rename cluster-info folder", script: """
+                        if [ -f build/cluster-info.html ]; then
+                          mv build/cluster-info.html cluster-info-${ELASTIC_STACK_VERSION}.html
+                        fi
+                      """)
                       archiveArtifacts(allowEmptyArchive: true, artifacts: 'cluster-info-*')
                     }
                   }

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -43,12 +43,10 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
-        dir("${EC_DIR}"){
-          git(branch: 'current',
-            credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-            url: 'git@github.com:elastic/observability-test-environments.git'
-          )
-        }
+        gitCheckout(basedir: "${EC_DIR}", branch: 'current',
+          credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+          repo: 'git@github.com:elastic/observability-test-environments.git'
+        )
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }


### PR DESCRIPTION
## What does this PR do?

Change the k8s provisioner to kind by default.

## Why is it important?

Kind provisions a k8s cluster on Docker, it does not have an additional cost for us. We can still use GCP by launching the job from Jenkins and selecting the `environment_file` parameter.
