### PR TITLE
fix: bump snapshot version

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -56,7 +56,7 @@ pipeline {
         axes {
           axis {
               name 'ELASTIC_STACK_VERSION'
-              values '8.0.0-SNAPSHOT', '7.7.0-SNAPSHOT', '7.6.1-SNAPSHOT'
+              values '8.0.0-SNAPSHOT', '7.7.0-SNAPSHOT', '7.6.2-SNAPSHOT'
           }
         }
         stages {

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -58,7 +58,7 @@ pipeline {
         axes {
           axis {
               name 'ELASTIC_STACK_VERSION'
-              values '7.7.0-SNAPSHOT', '7.6.1-SNAPSHOT'
+              values '7.7.0-SNAPSHOT', '7.6.2-SNAPSHOT'
           }
         }
         stages {


### PR DESCRIPTION
## What does this PR do?

Update the '7.6.1-SNAPSHOT' to '7.6.2-SNAPSHOT'

## Why is it important?

'7.6.1-SNAPSHOT' is no longer available.
