### PR TITLE
Add kibana_user role to apm_server_user

### DIFF
--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -7,6 +7,6 @@ filebeat:filebeat_user
 heartbeat:heartbeat_user
 ingest_admin:apm_server_user
 kibana_system:kibana_system_user
-kibana_user:apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
+kibana_user:apm_server_user,apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
 metricbeat:metricbeat_user
 superuser:admin


### PR DESCRIPTION
Required for agent config management to work.
