### PR TITLE
chore: use node:12 for RUM images

### DIFF
--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:12-slim
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer

--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -4,7 +4,7 @@ FROM node:12-slim
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
 RUN apt-get update \
-    && apt-get install wget gnupg -y \
+    && apt-get install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \

--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -3,12 +3,12 @@ FROM node:12-slim
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
+RUN apt-get -qq update \
+    && apt-get -qq install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt-get -qq update \
+    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:12-slim
 
 ARG RUM_AGENT_BRANCH=master
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -4,13 +4,12 @@ ARG RUM_AGENT_BRANCH=master
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
-RUN apt-get -qq update \
-    && apt-get -qq install -yq libgconf-2-4 \
-    && apt-get -qq install -y curl git --no-install-recommends \
-    && curl -L https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN apt-get update \
+    && apt-get install -y wget gnupg git \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get -qq update \
-    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get -qq purge --auto-remove -y \

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -5,11 +5,12 @@ ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
 RUN apt-get -qq update \
+    && apt-get -qq install -yq libgconf-2-4 \
     && apt-get -qq install -y wget gnupg git \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get -qq update \
-    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf python g++ build-essential \
+    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get -qq purge --auto-remove -y \

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -4,12 +4,12 @@ ARG RUM_AGENT_BRANCH=master
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
-RUN apt-get update \
-    && apt-get install -y wget gnupg git \
+RUN apt-get -qq update \
+    && apt-get -qq install -y wget gnupg git \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt-get -qq update \
+    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf python g++ build-essential \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get -qq purge --auto-remove -y \


### PR DESCRIPTION
+ Use Node.js 12 image instead of 8 as new packages are already deprecating support for 8 and the build fails with latest RUM master. 