### PR TITLE
fix: RUM health check

### DIFF
--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -1,14 +1,14 @@
-FROM node:10-slim
+FROM node:12-slim
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
-RUN apt-get update \
-    && apt-get install wget gnupg -y \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN apt update -qq  \
+    && apt install gnupg curl -qq -y --no-install-recommends\
+    && curl -sSkfL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt update -qq \
+    && apt install -qq -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/opbeans/rum/tasks.js
+++ b/docker/opbeans/rum/tasks.js
@@ -11,7 +11,7 @@ function sleep(ms) {
 
 async function run() {
   const browser = await puppeteer.launch({
-    args: ['--disable-dev-shm-usage'] // see https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#tips
+    args: ['--disable-dev-shm-usage', '--remote-debugging-port=9222'] // see https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#tips
   })
   const page = await browser.newPage()
   page.on('console', msg => console.log(

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -1,19 +1,19 @@
-FROM node:8-slim
+FROM node:12-slim
 
 ARG RUM_AGENT_BRANCH=master
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
-RUN apt-get -qq update \
-    && apt-get -qq install -yq libgconf-2-4 \
-    && apt-get -qq install -y curl git --no-install-recommends \
-    && curl -L https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN apt -qq update \
+    && apt -qq install -yq libgconf-2-4 \
+    && apt -qq install -y curl git --no-install-recommends \
+    && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get -qq update \
-    && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
+    && apt -qq update \
+    && apt -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get -qq purge --auto-remove -y \
+    && apt -qq purge --auto-remove -y \
     && rm -rf /src/*.deb
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -4,16 +4,14 @@ ARG RUM_AGENT_BRANCH=master
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
-RUN apt -qq update \
-    && apt -qq install -yq libgconf-2-4 \
-    && apt -qq install -y curl git --no-install-recommends \
+RUN apt update -qq \
+    && apt install -qq -y curl git gnupg libgconf-2-4 --no-install-recommends \
     && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt -qq update \
-    && apt -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
+    && apt update -qq \
+    && apt install -qq -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
-    && apt -qq purge --auto-remove -y \
     && rm -rf /src/*.deb
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.


### PR DESCRIPTION
## What does this PR do?

* Bump the node version to 12 on the RUM containers.
* Change `apt-get` to `apt` command
* Fix the health check on the opbeans-rum Docker container.

## Why is it important?

If the port 9222 (chrome remote debugging) is not listening the health does not work.
