### PR TITLE
[7.x] ci(docs): generate debug docs with the data (#814)

### DIFF
--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -96,6 +96,9 @@ pipeline {
       environment {
         TMPDIR = "${WORKSPACE}"
         REUSE_CONTAINERS = "true"
+        ENABLE_ES_DUMP = "true"
+        PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
+        NAME = 'all'
       }
       steps {
         deleteDir()
@@ -117,6 +120,7 @@ pipeline {
       environment {
         TMPDIR = "${WORKSPACE}/${BASE_DIR}"
         HOME = "${WORKSPACE}/${BASE_DIR}"
+        NAME = 'ui'
       }
       steps {
         deleteDir()
@@ -143,6 +147,7 @@ pipeline {
         TMPDIR = "${WORKSPACE}"
         ENABLE_ES_DUMP = "true"
         PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
+        NAME = 'opbeans'
       }
       steps {
         deleteDir()

--- a/.ci/scripts/generate-debug-docs.sh
+++ b/.ci/scripts/generate-debug-docs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+gitUrl=$(git remote get-url origin)
+commit=$(git rev-parse HEAD)
+
+echo "Let's generate the details to help to reproduce it locally ..."
+echo ""
+echo ""
+
+echo "# Let's clone the repo"
+echo "git clone ${gitUrl} .apm-its"
+echo "cd .apm-its"
+echo "git checkout ${commit}"
+echo ""
+echo "# Let's run the apm-integration testing for ${NAME}"
+echo "export ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION}"
+echo "export BUILD_OPTS=${BUILD_OPTS}"
+echo ".ci/scripts/${NAME}.sh"
+echo ""
+echo "# Let's save the docker log output as files"
+echo "./scripts/docker-get-logs.sh '${NAME}' || echo 'Failed to get Docker logs'"
+echo "make stop-env || echo 'Failed to stop the environment'"
+echo ""
+echo "# Logs are now stored in the below location docker-info/${NAME}"
+echo "cd docker-info/${NAME}"
+echo "ls -ltrh"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(docs): generate debug docs with the data (#814)