### PR TITLE
Opbeans java infer spans

### DIFF
--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -265,11 +265,18 @@ class OpbeansJava(OpbeansService):
             default=cls.DEFAULT_OPBEANS_VERSION,
             help=cls.name() + " version for the docker image of opbeans java"
         )
+        # only support by the java agent for now
+        parser.add_argument(
+            '--' + cls.name() + '-infer-spans',
+            action="store_true",
+            help=cls.name() + " enable inferred span collection"
+        )
 
     def __init__(self, **options):
         super(OpbeansJava, self).__init__(**options)
         self.opbeans_image = options.get('opbeans_java_image')
         self.opbeans_version = options.get('opbeans_java_version')
+        self.infer_spans = options.get('opbeans_java_infer_spans')
 
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN")
@@ -325,6 +332,8 @@ class OpbeansJava(OpbeansService):
             content["volumes"] = [
                 "{}:/local-install".format(self.agent_local_repo),
             ]
+        if self.infer_spans:
+            content["environment"].append("ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true")
         return content
 
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -226,8 +226,8 @@ class OpbeansServiceTest(ServiceTest):
 
     def test_opbeans_java_version(self):
         opbeans = OpbeansJava(opbeans_java_version="bar").render()["opbeans-java"]
-        branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_VERSION")]
-        self.assertEqual(branch, ["OPBEANS_JAVA_VERSION=bar"])
+        version = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_VERSION")]
+        self.assertEqual(version, ["OPBEANS_JAVA_VERSION=bar"])
 
     def test_opbeans_node(self):
         opbeans_node = OpbeansNode(version="6.2.4").render()

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -224,6 +224,11 @@ class OpbeansServiceTest(ServiceTest):
         branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_IMAGE")]
         self.assertEqual(branch, ["OPBEANS_JAVA_IMAGE=foo"])
 
+    def test_opbeans_java_infer_spans(self):
+        opbeans = OpbeansJava(opbeans_java_infer_spans=True).render()["opbeans-java"]
+        infer = [e for e in opbeans["environment"] if e.startswith("ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED")]
+        self.assertEqual(infer, ["ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true"])
+
     def test_opbeans_java_version(self):
         opbeans = OpbeansJava(opbeans_java_version="bar").render()["opbeans-java"]
         version = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_VERSION")]

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -224,7 +224,7 @@ class OpbeansServiceTest(ServiceTest):
         branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_IMAGE")]
         self.assertEqual(branch, ["OPBEANS_JAVA_IMAGE=foo"])
 
-    def test_opbeans_java_image(self):
+    def test_opbeans_java_version(self):
         opbeans = OpbeansJava(opbeans_java_version="bar").render()["opbeans-java"]
         branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_VERSION")]
         self.assertEqual(branch, ["OPBEANS_JAVA_VERSION=bar"])


### PR DESCRIPTION
## What does this PR do?

Adds `--opbeans-java-infer-spans` option to enable [inferred span](https://www.elastic.co/guide/en/apm/agent/java/master/config-profiling.html#config-profiling-inferred-spans-enabled) collection for opbeans java.

<img width="1660" alt="image" src="https://user-images.githubusercontent.com/83483/78926572-4b33d980-7a6b-11ea-9710-d4c78ed80d7a.png">

## Why is it important?

This simplifies development and demo setup for inferred spans.

## Notes

To be flipped to on by default / switch option to `--no-` prefix when the visualization is improved.