### PR TITLE
enable apikey for the apm-server and agents with a side container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ target/
 
 # For the docs generation
 .apm-its
+
+# .env-api-key is created on the fly for the apiKey
+.env-api-key

--- a/docker/features/Dockerfile
+++ b/docker/features/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.7
+RUN apk add --no-cache curl jq
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/features/entrypoint.sh
+++ b/docker/features/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -xe
+
+## Support to run Agents using an ApiKey
+if [ -n "${ELASTIC_APM_API_KEY}" ] ; then
+  curl -s -u admin:changeme -X PUT "elasticsearch:9200/_security/privilege" -H 'Content-Type: application/json' -d'
+  {
+    "properties": {
+      "email": {
+        "type": "keyword"
+      }
+    }
+  }
+  {
+  "apm": {
+      "write_sourcemap": {
+        "actions": [ "sourcemap:write" ]
+      },
+      "write_event": {
+        "actions": [ "event:write" ]
+      },
+      "read_agent_config": {
+        "actions": [ "config_agent:read" ]
+      }
+    }
+  }
+  '
+
+  apiKey=$(curl -s -u admin:changeme "elasticsearch:9200/_security/api_key" -H 'Content-Type: application/json' -d'
+  {
+    "name": "apm-backend",
+    "role_descriptors": {
+      "apm-backend": {
+        "applications": [
+          {
+            "application": "apm",
+            "privileges": ["*"],
+            "resources": ["*"]
+          }
+        ]
+      }
+    }
+  }
+  ' | jq '(.id + ":" +.api_key)')
+
+  # shellcheck disable=SC2039
+  ELASTIC_APM_API_KEY=$(echo -n "${apiKey}" | base64)
+
+  echo ELASTIC_APM_API_KEY="${ELASTIC_APM_API_KEY}" > /usr/share/.env-api-key
+fi
+
+## Notify to the healthcheck.
+touch /tmp/ready
+
+## Keep running the container to notify the dependent services.
+tail -f /dev/null

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -16,8 +16,13 @@ class AgentRUMJS(Service):
         self.agent_branch = options.get("rum_agent_branch", self.DEFAULT_AGENT_BRANCH)
         self.agent_repo = options.get("rum_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
 
     @classmethod
@@ -83,8 +88,13 @@ class AgentGoNetHttp(Service):
         self.agent_version = options.get("go_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_repo = options.get("go_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
 
     @add_agent_environment([
@@ -127,10 +137,14 @@ class AgentNodejsExpress(Service):
         super(AgentNodejsExpress, self).__init__(**options)
         self.agent_package = options.get("nodejs_agent_package", self.DEFAULT_AGENT_PACKAGE)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
-
     @classmethod
     def add_arguments(cls, parser):
         super(AgentNodejsExpress, cls).add_arguments(parser)
@@ -172,8 +186,13 @@ class AgentPython(Service):
         super(AgentPython, self).__init__(**options)
         self.agent_package = options.get("python_agent_package", self.DEFAULT_AGENT_PACKAGE)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
 
     @classmethod
@@ -284,8 +303,13 @@ class AgentRubyRails(Service):
         self.agent_version_state = options.get("ruby_agent_version_state", self.DEFAULT_AGENT_VERSION_STATE)
         self.agent_repo = options.get("ruby_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
 
     @add_agent_environment([
@@ -356,8 +380,13 @@ class AgentJavaSpring(Service):
         self.agent_release = options.get("java_agent_release", self.DEFAULT_AGENT_RELEASE)
         self.agent_repo = options.get("java_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
 
     @add_agent_environment([
@@ -421,8 +450,13 @@ class AgentDotnet(Service):
         self.agent_release = options.get("dotnet_agent_release", self.DEFAULT_AGENT_RELEASE)
         self.agent_repo = options.get("dotnet_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
             self.depends_on = {
-                "apm-server": {"condition": "service_healthy"},
+                service_name: {"condition": "service_healthy"},
             }
 
     @add_agent_environment([

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -19,6 +19,7 @@ class AgentRUMJS(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -58,6 +59,7 @@ class AgentRUMJS(Service):
                 "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
                 "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             },
+            env_file=self.env_file,
             depends_on=self.depends_on,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "rum", path="/"),
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
@@ -91,6 +93,7 @@ class AgentGoNetHttp(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -119,6 +122,7 @@ class AgentGoNetHttp(Service):
                 "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
                 "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             },
+            env_file=self.env_file,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "gonethttpapp"),
             depends_on=self.depends_on,
             image=None,
@@ -140,6 +144,7 @@ class AgentNodejsExpress(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -174,6 +179,7 @@ class AgentNodejsExpress(Service):
                 "EXPRESS_SERVICE_NAME": "expressapp",
                 "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             },
+            env_file=self.env_file,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
 
@@ -189,6 +195,7 @@ class AgentPython(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -230,6 +237,7 @@ class AgentPythonDjango(AgentPython):
                 "DJANGO_PORT": self.SERVICE_PORT,
                 "DJANGO_SERVICE_NAME": "djangoapp",
             },
+            env_file=self.env_file,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "djangoapp"),
             depends_on=self.depends_on,
             image=None,
@@ -262,6 +270,7 @@ class AgentPythonFlask(AgentPython):
                 "FLASK_SERVICE_NAME": "flaskapp",
                 "GUNICORN_CMD_ARGS": "-w 4 -b 0.0.0.0:{}".format(self.SERVICE_PORT),
             },
+            env_file=self.env_file,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "flaskapp"),
             depends_on=self.depends_on,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
@@ -306,6 +315,7 @@ class AgentRubyRails(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -340,6 +350,7 @@ class AgentRubyRails(Service):
                 "RUBY_AGENT_VERSION": self.agent_version,
                 "RUBY_AGENT_REPO": self.agent_repo,
             },
+            env_file=self.env_file,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "railsapp", retries=60),
             depends_on=self.depends_on,
             image=None,
@@ -383,6 +394,7 @@ class AgentJavaSpring(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -413,6 +425,7 @@ class AgentJavaSpring(Service):
                 "ELASTIC_APM_SERVICE_NAME": "springapp",
                 "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             },
+            env_file=self.env_file,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "javaspring"),
             depends_on=self.depends_on,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
@@ -453,6 +466,7 @@ class AgentDotnet(Service):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -483,6 +497,7 @@ class AgentDotnet(Service):
                 "ELASTIC_APM_SERVICE_NAME": "dotnetapp",
                 "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
             },
+            env_file=self.env_file,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "dotnetapp"),
             depends_on=self.depends_on,
             image=None,

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -17,7 +17,7 @@ class AgentRUMJS(Service):
         self.agent_repo = options.get("rum_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -91,7 +91,7 @@ class AgentGoNetHttp(Service):
         self.agent_repo = options.get("go_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -142,7 +142,7 @@ class AgentNodejsExpress(Service):
         self.agent_package = options.get("nodejs_agent_package", self.DEFAULT_AGENT_PACKAGE)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -193,7 +193,7 @@ class AgentPython(Service):
         self.agent_package = options.get("python_agent_package", self.DEFAULT_AGENT_PACKAGE)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -313,7 +313,7 @@ class AgentRubyRails(Service):
         self.agent_repo = options.get("ruby_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -392,7 +392,7 @@ class AgentJavaSpring(Service):
         self.agent_repo = options.get("java_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -464,7 +464,7 @@ class AgentDotnet(Service):
         self.agent_repo = options.get("dotnet_agent_repo", self.DEFAULT_AGENT_REPO)
         if options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -116,3 +116,29 @@ class Zookeeper(Service):
             logging=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
+
+
+class Features(Service):
+
+    def _content(self):
+        return dict(
+            build={
+                "context": "docker/features",
+                "dockerfile": "Dockerfile"
+            },
+            container_name="features",
+            environment={
+                "ELASTIC_APM_API_KEY": "true"
+            },
+            healthcheck={
+                "interval": "2s",
+                "retries": 10,
+                "test": [
+                    "CMD-SHELL",
+                    "[ -f /tmp/ready ] && echo 'found' || exit 1"
+                ]
+            },
+            depends_on={"apm-server": {"condition": "service_healthy"}} if self.options.get(
+                "enable_apm_server", True) else {},
+            volumes=["./:/usr/share"]
+        )

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -25,7 +25,7 @@ from .elastic_stack import (  # noqa: F401
     ApmServer, Elasticsearch, Kibana
 )
 from .aux_services import (  # noqa: F401
-    Kafka, Logstash, Postgres, Redis, Zookeeper
+    Kafka, Logstash, Postgres, Redis, Zookeeper, Features
 )
 from .opbeans import (  # noqa: F401
     OpbeansNode, OpbeansRuby, OpbeansPython, OpbeansDotnet,

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -113,6 +113,7 @@ class OpbeansDotnet(OpbeansService):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -146,6 +147,7 @@ class OpbeansDotnet(OpbeansService):
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
                 "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
+            env_file=self.env_file,
             depends_on=depends_on,
             image=None,
             labels=None,
@@ -201,6 +203,7 @@ class OpbeansGo(OpbeansService):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -240,6 +243,7 @@ class OpbeansGo(OpbeansService):
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
                 "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
+            env_file=self.env_file,
             depends_on=depends_on,
             image=None,
             labels=None,
@@ -304,6 +308,7 @@ class OpbeansJava(OpbeansService):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -343,6 +348,7 @@ class OpbeansJava(OpbeansService):
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
                 "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
+            env_file=self.env_file,
             depends_on=depends_on,
             image=None,
             labels=None,
@@ -406,6 +412,7 @@ class OpbeansNode(OpbeansService):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -446,6 +453,7 @@ class OpbeansNode(OpbeansService):
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
                 "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
+            env_file=self.env_file,
             depends_on=depends_on,
             image=None,
             labels=None,
@@ -516,6 +524,7 @@ class OpbeansPython(OpbeansService):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -556,6 +565,7 @@ class OpbeansPython(OpbeansService):
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
                 "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
+            env_file=self.env_file,
             depends_on=depends_on,
             image=None,
             labels=None,
@@ -619,6 +629,7 @@ class OpbeansRuby(OpbeansService):
             ## TODO: define the api key variable
             if options.get("enable_api_key", True):
                 service_name = "features"
+                self.env_file = [ ".env-api-key" ]
             else:
                 service_name = "apm-server"
             self.depends_on = {
@@ -654,6 +665,7 @@ class OpbeansRuby(OpbeansService):
                 "OPBEANS_DT_PROBABILITY={:.2f}".format(self.opbeans_dt_probability),
                 "ELASTIC_APM_ENVIRONMENT={}".format(self.service_environment),
             ],
+            env_file=self.env_file,
             depends_on=depends_on,
             image=None,
             labels=None,
@@ -706,6 +718,7 @@ class OpbeansRum(Service):
                 "OPBEANS_BASE_URL=http://{}:{}".format(self.backend_service, self.backend_port),
                 "ELASTIC_APM_VERIFY_SERVER_CERT={}".format(str(not self.options.get("no_verify_server_cert")).lower()),
             ],
+            env_file=self.env_file,
             image=None,
             labels=None,
             healthcheck=curl_healthcheck(self.SERVICE_PORT, path="/"),
@@ -759,6 +772,7 @@ class OpbeansLoadGenerator(Service):
                 "OPBEANS_URLS={}".format(','.join('{0}:http://{0}:3000'.format(s) for s in sorted(self.loadgen_services))),  # noqa: E501
                 "OPBEANS_RPMS={}".format(','.join('{}:{}'.format(k, v) for k, v in sorted(self.loadgen_rpms.items())))
             ],
+            env_file=self.env_file,
             labels=None,
         )
         return content

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -110,7 +110,14 @@ class OpbeansDotnet(OpbeansService):
     def _content(self):
         depends_on = {}
         if self.options.get("enable_apm_server", True):
-            depends_on["apm-server"] = {"condition": "service_healthy"}
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
+            self.depends_on = {
+                service_name: {"condition": "service_healthy"},
+            }
         if self.options.get("enable_elasticsearch", True):
             depends_on["elasticsearch"] = {"condition": "service_healthy"}
 
@@ -191,7 +198,14 @@ class OpbeansGo(OpbeansService):
         }
 
         if self.options.get("enable_apm_server", True):
-            depends_on["apm-server"] = {"condition": "service_healthy"}
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
+            self.depends_on = {
+                service_name: {"condition": "service_healthy"},
+            }
         if self.options.get("enable_elasticsearch", True):
             depends_on["elasticsearch"] = {"condition": "service_healthy"}
 
@@ -287,7 +301,14 @@ class OpbeansJava(OpbeansService):
         }
 
         if self.options.get("enable_apm_server", True):
-            depends_on["apm-server"] = {"condition": "service_healthy"}
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
+            self.depends_on = {
+                service_name: {"condition": "service_healthy"},
+            }
         if self.options.get("enable_elasticsearch", True):
             depends_on["elasticsearch"] = {"condition": "service_healthy"}
 
@@ -382,7 +403,14 @@ class OpbeansNode(OpbeansService):
         }
 
         if self.options.get("enable_apm_server", True):
-            depends_on["apm-server"] = {"condition": "service_healthy"}
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
+            self.depends_on = {
+                service_name: {"condition": "service_healthy"},
+            }
 
         content = dict(
             build=dict(
@@ -485,7 +513,14 @@ class OpbeansPython(OpbeansService):
         }
 
         if self.options.get("enable_apm_server", True):
-            depends_on["apm-server"] = {"condition": "service_healthy"}
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
+            self.depends_on = {
+                service_name: {"condition": "service_healthy"},
+            }
         if self.options.get("enable_elasticsearch", True):
             depends_on["elasticsearch"] = {"condition": "service_healthy"}
 
@@ -581,7 +616,14 @@ class OpbeansRuby(OpbeansService):
         }
 
         if self.options.get("enable_apm_server", True):
-            depends_on["apm-server"] = {"condition": "service_healthy"}
+            ## TODO: define the api key variable
+            if options.get("enable_api_key", True):
+                service_name = "features"
+            else:
+                service_name = "apm-server"
+            self.depends_on = {
+                service_name: {"condition": "service_healthy"},
+            }
         if self.options.get("enable_elasticsearch", True):
             depends_on["elasticsearch"] = {"condition": "service_healthy"}
 

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -111,7 +111,7 @@ class OpbeansDotnet(OpbeansService):
         depends_on = {}
         if self.options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -201,7 +201,7 @@ class OpbeansGo(OpbeansService):
 
         if self.options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -306,7 +306,7 @@ class OpbeansJava(OpbeansService):
 
         if self.options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -410,7 +410,7 @@ class OpbeansNode(OpbeansService):
 
         if self.options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -522,7 +522,7 @@ class OpbeansPython(OpbeansService):
 
         if self.options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:
@@ -627,7 +627,7 @@ class OpbeansRuby(OpbeansService):
 
         if self.options.get("enable_apm_server", True):
             ## TODO: define the api key variable
-            if options.get("enable_api_key", True):
+            if options.get("enable_features", False):
                 service_name = "features"
                 self.env_file = [ ".env-api-key" ]
             else:

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -48,6 +48,8 @@ class Service(object):
 
         self.depends_on = {}
 
+        self.env_file = []
+
     @property
     def bc(self):
         return self._bc


### PR DESCRIPTION
env_file is missing yet but it does not support runtime env variables


## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues

Relates to https://github.com/elastic/apm-integration-testing/issues/781