### PR TITLE
Enable APIKey in the agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,3 +397,29 @@ Test all the docker images for the Opbeans
 Test all the docker images for the agents
 
     make -C docker all-agents-tests
+
+
+### Use Cases
+
+Some of the uses cases that are not fully automated and required some manual actions.
+
+#### To run Agents using an ApiKey
+
+Run the script to start only Elasticsearch:
+
+```bash
+python scripts/compose.py start 8.0.0 --no-apm-server --no-kibana
+```
+
+Then, run the script to generate the API key:
+
+```bash
+apiKey=$(scripts/create-api-key.sh)
+echo $apiKey
+```
+
+Finally, run the apm-its with the required services and the flag `--elastic-apm-api-key ${apiKey}`, for instance:
+
+```bash
+python scripts/compose.py start 8.0.0 --with-agent-dotnet --elastic-apm-api-key ${apiKey}
+```

--- a/scripts/create-api-key.sh
+++ b/scripts/create-api-key.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC2034
+privilege=$(curl -s -u admin:changeme -X PUT "localhost:9200/_security/privilege" -H 'Content-Type: application/json' -d'
+{
+"apm": {
+    "write_sourcemap": {
+      "actions": [ "sourcemap:write" ]
+    },
+    "write_event": {
+      "actions": [ "event:write" ]
+    },
+    "read_agent_config": {
+      "actions": [ "config_agent:read" ]
+    }
+  }
+}
+')
+
+apiKey=$(curl -s -u admin:changeme "localhost:9200/_security/api_key" -H 'Content-Type: application/json' -d'
+{
+  "name": "apm-backend",
+  "role_descriptors": {
+    "apm-backend": {
+      "applications": [
+        {
+          "application": "apm",
+          "privileges": ["*"],
+          "resources": ["*"]
+        }
+      ]
+    }
+  }
+}
+' | jq '(.id + ":" +.api_key)')
+
+echo -n "${apiKey}" | base64

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -34,7 +34,7 @@ class AgentRUMJS(Service):
         )
 
     def _content(self):
-        default_environment={
+        default_environment = {
             "ELASTIC_APM_SERVICE_NAME": "rum",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
@@ -97,7 +97,7 @@ class AgentGoNetHttp(Service):
         ("apm_server_url", "ELASTIC_APM_SERVER_URL"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_FLUSH_INTERVAL": "500ms",
             "ELASTIC_APM_SERVICE_NAME": "gonethttpapp",
@@ -155,7 +155,7 @@ class AgentNodejsExpress(Service):
         ("apm_server_url", "ELASTIC_APM_SERVER_URL"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "EXPRESS_PORT": str(self.SERVICE_PORT),
             "EXPRESS_SERVICE_NAME": "expressapp",
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
@@ -217,7 +217,7 @@ class AgentPythonDjango(AgentPython):
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "DJANGO_PORT": self.SERVICE_PORT,
             "DJANGO_SERVICE_NAME": "djangoapp",
         }
@@ -252,7 +252,7 @@ class AgentPythonFlask(AgentPython):
         ("apm_server_url", "APM_SERVER_URL"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "FLASK_SERVICE_NAME": "flaskapp",
             "GUNICORN_CMD_ARGS": "-w 4 -b 0.0.0.0:{}".format(self.SERVICE_PORT),
         }
@@ -317,7 +317,7 @@ class AgentRubyRails(Service):
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
@@ -395,7 +395,7 @@ class AgentJavaSpring(Service):
         ("apm_server_url", "ELASTIC_APM_SERVER_URL"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVICE_NAME": "springapp",
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
@@ -465,7 +465,7 @@ class AgentDotnet(Service):
         ("apm_server_url", "ELASTIC_APM_SERVER_URLS"),
     ])
     def _content(self):
-        default_environment={
+        default_environment = {
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_FLUSH_INTERVAL": "5",

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -388,6 +388,11 @@ class ApmServer(StackService, Service):
             default="1ms",
             help="change the index refresh interval (default 1ms)",
         )
+        parser.add_argument(
+            '--elastic-apm-api-key',
+            dest='elastic_apm_api_key',
+            help='API Key to authenticate against the APM server.'
+        )
 
     def build_candidate_manifest(self):
         version = self.version

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -51,7 +51,7 @@ class Service(object):
         self.apm_api_key = {}
         if self.options.get("elastic_apm_api_key"):
             if self.at_least_version("7.6"):
-                self.apm_api_key = { "ELASTIC_APM_API_KEY" : options.get("elastic_apm_api_key") }
+                self.apm_api_key = {"ELASTIC_APM_API_KEY": options.get("elastic_apm_api_key")}
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
 

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -48,10 +48,10 @@ class Service(object):
 
         self.depends_on = {}
 
-        self.api_key_environment = []
+        self.apm_api_key = {}
         if self.options.get("elastic_apm_api_key"):
             if self.at_least_version("7.6"):
-                self.api_key_environment = ["ELASTIC_APM_API_KEY=" + options.get("elastic_apm_api_key")]
+                self.apm_api_key = { "ELASTIC_APM_API_KEY" : options.get("elastic_apm_api_key") }
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
 

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -48,6 +48,13 @@ class Service(object):
 
         self.depends_on = {}
 
+        self.api_key_environment = []
+        if self.options.get("elastic_apm_api_key"):
+            if self.at_least_version("7.6"):
+                self.api_key_environment = ["ELASTIC_APM_API_KEY=" + options.get("elastic_apm_api_key")]
+            else:
+                print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
+
     @property
     def bc(self):
         return self._bc

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -69,6 +69,14 @@ class AgentServiceTest(ServiceTest):
         agent = AgentGoNetHttp(enable_apm_server=False).render()["agent-go-net-http"]
         self.assertFalse("apm-server" in agent["depends_on"])
 
+    def test_agent_go_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentGoNetHttp(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-go-net-http"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_go_apm_api_key_with_apm_server(self):
+        agent = AgentGoNetHttp(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-go-net-http"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
+
     def test_agent_nodejs_express(self):
         agent = AgentNodejsExpress().render()
         self.assertDictEqual(
@@ -110,6 +118,14 @@ class AgentServiceTest(ServiceTest):
         agent = AgentNodejsExpress(enable_apm_server=False).render()["agent-nodejs-express"]
         self.assertFalse("apm-server" in agent["depends_on"])
 
+    def test_agent_nodejs_express_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentNodejsExpress(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-nodejs-express"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_nodejs_express_apm_api_key_with_apm_server(self):
+        agent = AgentNodejsExpress(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-nodejs-express"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
+
     def test_agent_python_django(self):
         agent = AgentPythonDjango().render()
         self.assertDictEqual(
@@ -147,6 +163,14 @@ class AgentServiceTest(ServiceTest):
         agent = AgentPythonDjango(enable_apm_server=False).render()["agent-python-django"]
         self.assertFalse("apm-server" in agent["depends_on"])
 
+    def test_agent_python_django_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentPythonDjango(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-python-django"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_python_django_apm_api_key_with_apm_server(self):
+        agent = AgentPythonDjango(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-python-django"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
+
     def test_agent_python_flask(self):
         agent = AgentPythonFlask(version="6.2.4").render()
         self.assertDictEqual(
@@ -183,6 +207,14 @@ class AgentServiceTest(ServiceTest):
 
         agent = AgentPythonFlask(enable_apm_server=False).render()["agent-python-flask"]
         self.assertFalse("apm-server" in agent["depends_on"])
+
+    def test_agent_python_flask_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentPythonFlask(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-python-flask"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_python_flask_apm_api_key_with_apm_server(self):
+        agent = AgentPythonFlask(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-python-flask"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
 
     def test_agent_ruby_rails(self):
         agent = AgentRubyRails().render()
@@ -243,6 +275,14 @@ class AgentServiceTest(ServiceTest):
         agent = AgentRubyRails(enable_apm_server=False).render()["agent-ruby-rails"]
         self.assertFalse("apm-server" in agent["depends_on"])
 
+    def test_agent_ruby_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentRubyRails(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-ruby-rails"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_ruby_apm_api_key_with_apm_server(self):
+        agent = AgentRubyRails(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-ruby-rails"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
+
     def test_agent_java_spring(self):
         agent = AgentJavaSpring().render()
         self.assertDictEqual(
@@ -295,6 +335,14 @@ class AgentServiceTest(ServiceTest):
 
         agent = AgentJavaSpring(enable_apm_server=False).render()["agent-java-spring"]
         self.assertFalse("apm-server" in agent["depends_on"])
+
+    def test_agent_java_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentJavaSpring(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-java-spring"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_java_apm_api_key_with_apm_server(self):
+        agent = AgentJavaSpring(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-java-spring"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
 
     def test_agent_dotnet(self):
         agent = AgentDotnet().render()
@@ -351,6 +399,14 @@ class AgentServiceTest(ServiceTest):
 
         agent = AgentDotnet(enable_apm_server=False).render()["agent-dotnet"]
         self.assertFalse("apm-server" in agent["depends_on"])
+
+    def test_agent_dotnet_apm_api_key_with_old_version_apm_server(self):
+        agent = AgentDotnet(version="6.3.100", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-dotnet"]
+        self.assertFalse("ELASTIC_APM_API_KEY" in agent["environment"])
+
+    def test_agent_dotnet_apm_api_key_with_apm_server(self):
+        agent = AgentDotnet(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-dotnet"]
+        self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
 
 
 class ApmServerServiceTest(ServiceTest):


### PR DESCRIPTION
## What does this PR do?

Enable the API key in the agents. For such it's required to:
- prepare the apm-its with running only the Elasticsearch service.
- run the api-key script
- then run the apm-its with all the required flags plus the new flag.

## Why is it important?

This is the approach we can enable it easily without much code.

## Related issues

Closes https://github.com/elastic/apm-integration-testing/issues/781

## Tasks
- [x] Fix linting
- [x] Add UTs

## Test

```
### Start the Elasticsearch instance
$ python scripts/compose.py start 8.0.0 --no-apm-server --no-kibana

### Wait for Elasticsearch to be available
$ sh -x scripts/create-api-key.sh

### Generate the API key
$ apiKey=$(scripts/create-api-key.sh)

### Run all the agents with EKA
$ python scripts/compose.py start 8.0.0  --elastic-apm-api-key ${apiKey} \
   --no-apm-server-dashboards --no-apm-server-self-instrument \
   --with-agent-rumjs \
   --with-agent-java-spring \
   --with-agent-ruby-rails \
   --with-agent-go-net-http \
   --with-agent-nodejs-express
```
