### PR TITLE
docker/apm-server: don't copy fields.yml

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -30,7 +30,6 @@ FROM ${apm_server_base_image}
 ENV SRC=/go/src/github.com/elastic/apm-server
 COPY --from=build ${SRC}/apm-server /usr/share/apm-server/apm-server
 COPY --from=build ${SRC}/apm-server.yml /usr/share/apm-server/apm-server.yml
-COPY --from=build ${SRC}/fields.yml /usr/share/apm-server/fields.yml
 
 CMD ./apm-server -e -d "*"
 


### PR DESCRIPTION
## What does this PR do?

fields.yml file is not required, as it gets embedded in the binary. This PR stops copying fields.yml into the Docker image used for integration testing.

## Why is it important?

I'm moving where fields.yml gets built in apm-server, which causes this to break -- may as well
just stop copying it in since it's not needed.

## Related issues

None.