### PR TITLE
[7.x] docker/apm-server: don't copy fields.yml (#823) (41631e8e)

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -30,4 +30,8 @@ FROM ${apm_server_base_image}
 ENV SRC=/go/src/github.com/elastic/apm-server
 COPY --from=build ${SRC}/apm-server /usr/share/apm-server/apm-server
 COPY --from=build ${SRC}/apm-server.yml /usr/share/apm-server/apm-server.yml
-COPY --from=build ${SRC}/fields.yml /usr/share/apm-server/fields.yml
+
+CMD ./apm-server -e -d "*"
+
+# Add healthcheck for docker/healthcheck metricset to check during testing
+HEALTHCHECK CMD exit 0


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docker/apm-server: don't copy fields.yml (#823) (41631e8e)

closes https://github.com/elastic/apm-integration-testing/issues/826