### PR TITLE
fix: disable telemetry on 7.5+

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -725,7 +725,7 @@ class Kibana(StackService, Service):
             self.environment["XPACK_MONITORING_ENABLED"] = "true"
             if self.at_least_version("6.3"):
                 self.environment["XPACK_XPACK_MAIN_TELEMETRY_ENABLED"] = "false"
-            if self.at_least_version("7.6"):
+            if self.at_least_version("7.5"):
                 self.environment["TELEMETRY_ENABLED"] = "false"
             if self.at_least_version("7.7"):
                 self.environment["XPACK_SECURITY_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -725,6 +725,8 @@ class Kibana(StackService, Service):
             self.environment["XPACK_MONITORING_ENABLED"] = "true"
             if self.at_least_version("6.3"):
                 self.environment["XPACK_XPACK_MAIN_TELEMETRY_ENABLED"] = "false"
+            if self.at_least_version("7.6"):
+                self.environment["TELEMETRY_ENABLED"] = "false"
             if self.at_least_version("7.7"):
                 self.environment["XPACK_SECURITY_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
                 self.environment["XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -923,6 +923,7 @@ class LocalTest(unittest.TestCase):
                     ELASTICSEARCH_USERNAME: kibana_system_user,
                     SERVER_NAME: kibana.example.org,
                     STATUS_ALLOWANONYMOUS: 'true',
+                    TELEMETRY_ENABLED: 'false',
                     XPACK_APM_SERVICEMAPENABLED: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_SECURITY_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',


### PR DESCRIPTION
## What does this PR do?

It adds an env var to disable telemetry on 7.6.

## Why is it important?

We send telemetry data from our tests and local development environments, this data is nois.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/829
