### PR TITLE
Build apm-server-oss when passing --oss

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,7 +1,13 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
 ARG go_version=1.13
+ARG apm_server_binary=apm-server
+
+###############################################################################
+# Build stage: build apm-server binary and update apm-server.yml
+###############################################################################
 
 FROM golang:${go_version} AS build
+ARG apm_server_binary
 
 RUN apt -qq remove -y python2 && apt -qq autoremove -y
 
@@ -22,13 +28,19 @@ RUN git clone ${apm_server_repo} ${SRC} \
 
 RUN cd ${SRC} && git rev-parse HEAD && echo ${apm_server_branch_or_commit}
 
-RUN make -C ${SRC} update apm-server \
+RUN make -C ${SRC} update ${apm_server_binary} \
 	  && sed -zri -e 's/output.elasticsearch:(\n[^\n]*){5}/output.elasticsearch:\n  hosts: ["\${ELASTICSEARCH_HOSTS:elasticsearch:9200}"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' ${SRC}/apm-server.yml \
 	  && chmod go+r ${SRC}/apm-server.yml
 
+###############################################################################
+# Image update stage: layer apm-server binary and apm-server.yml on top of the
+# base image.
+###############################################################################
+
 FROM ${apm_server_base_image}
+ARG apm_server_binary
 ENV SRC=/go/src/github.com/elastic/apm-server
-COPY --from=build ${SRC}/apm-server /usr/share/apm-server/apm-server
+COPY --from=build ${SRC}/${apm_server_binary} /usr/share/apm-server/apm-server
 COPY --from=build ${SRC}/apm-server.yml /usr/share/apm-server/apm-server.yml
 
 CMD ./apm-server -e -d "*"

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -447,6 +447,7 @@ class ApmServer(StackService, Service):
             build_spec_parts = self.build.split("@", 1)
             repo = build_spec_parts[0]
             branch = build_spec_parts[1] if len(build_spec_parts) > 1 else "master"
+            binary = "apm-server-oss" if self.oss else "apm-server"
             content.update({
                 "build": {
                     "context": "docker/apm-server",
@@ -454,6 +455,7 @@ class ApmServer(StackService, Service):
                         "apm_server_base_image": self.default_image(),
                         "apm_server_branch_or_commit": branch,
                         "apm_server_repo": repo,
+                        "apm_server_binary": binary,
                     }
                 },
                 "image": None,

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -676,6 +676,7 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
+                     'apm_server_binary': 'apm-server',
                      'apm_server_branch_or_commit': 'bar',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
@@ -685,6 +686,17 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server:6.3.100',
+                     'apm_server_binary': 'apm-server',
+                     'apm_server_branch_or_commit': 'master',
+                     'apm_server_repo': 'foo.git'},
+            'context': 'docker/apm-server'})
+
+    def test_apm_server_build_oss(self):
+        apm_server = ApmServer(version="6.3.100", apm_server_build="foo.git", release=True, oss=True).render()["apm-server"]
+        self.assertIsNone(apm_server.get("image"))
+        self.assertDictEqual(apm_server["build"], {
+            'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server-oss:6.3.100',
+                     'apm_server_binary': 'apm-server-oss',
                      'apm_server_branch_or_commit': 'master',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})


### PR DESCRIPTION
## What does this PR do?

When passing `--oss` to compose.py, make sure we build the `apm-server-oss` binary for the apm-server Docker image.

## Why is it important?

It's expected to run the OSS-only apm-server, and work when running with a pure-OSS stack.

## Related issues

None.