### PR TITLE
support apm-server debug

### DIFF
--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -789,6 +789,10 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIn("foo:/usr/share/apm-server/ingest/pipeline/definition.json", apm_server["volumes"])
         self.assertIn("apm-server.register.ingest.pipeline.overwrite=true", apm_server["command"])
 
+    def test_debug(self):
+        apm_server = ApmServer(version="6.8.0", apm_server_enable_debug=True).render()["apm-server"]
+        self.assertTrue("-d" in apm_server["command"])
+        self.assertTrue("\"*\"" in apm_server["command"])
 
 class ElasticsearchServiceTest(ServiceTest):
     def test_6_2_release(self):


### PR DESCRIPTION
## What does this PR do?

Add `-d "*"` when running the docker-compose for the apm-server with the flag `apm-server-enable-debug`

## Why is it important?

The command is overriden with the scripts/compose.py therefore there is no an easy way to enable the debug with a flag.

## Tests

```bash

$ scripts/compose.py start master --no-kibana --apm-server-enable-debug
$  grep '*' -A 1 -B 1 docker-compose.yml 
        "-d", 
        "\"*\""
      ], 
```

