### PR TITLE
fix: debug for apm-server

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -442,7 +442,7 @@ class ApmServer(StackService, Service):
 
         command = ["apm-server", "-e", "--httpprof", ":{}".format(self.apm_server_monitor_port)] + command_args
         if self.options.get("apm_server_enable_debug"):
-            command = command + ["-d", "\"*\""]
+            command = command + ["-d", "*"]
 
         content = dict(
             cap_add=["CHOWN", "DAC_OVERRIDE", "SETGID", "SETUID"],

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -792,7 +792,7 @@ class ApmServerServiceTest(ServiceTest):
     def test_debug(self):
         apm_server = ApmServer(version="6.8.0", apm_server_enable_debug=True).render()["apm-server"]
         self.assertTrue("-d" in apm_server["command"])
-        self.assertTrue("\"*\"" in apm_server["command"])
+        self.assertTrue("*" in apm_server["command"])
 
 class ElasticsearchServiceTest(ServiceTest):
     def test_6_2_release(self):


### PR DESCRIPTION
## What does this PR do?

Fix the format to run the apm-server in debug mode


## Why is it important?

Otherwise it won't work

## Tests
```bash
$ scripts/compose.py start master \                                      
    --no-kibana \
    --elasticsearch-port 9201 \
    --apm-server-port=8201 \
    --elasticsearch-heap 4g \
    --apm-server-opt queue.mem.events=8192 \
    --apm-server-opt output.elasticsearch.bulk_max_size=4096 --apm-server-enable-debug
```

```bash
$ grep '*' -A 1 -B 2 docker-compose.yml 
        "output.elasticsearch.bulk_max_size=4096", 
        "-d", 
        "*"
      ], 
$ docker-compose up -d                  
Creating network "apm-integration-testing" with the default driver
Creating volume "apm-integration-testing_esdata" with local driver
Creating volume "apm-integration-testing_pgdata" with local driver
Creating localtesting_8.0.0_elasticsearch ... done
Creating localtesting_8.0.0_apm-server    ... done

$ docker logs localtesting_8.0.0_apm-server 2>&1 | grep debug | wc -l
     146

$ docker logs localtesting_8.0.0_apm-server 2>&1 | grep debug | tail -n 3
{"level":"debug","timestamp":"2020-05-05T15:50:05.523Z","logger":"monitoring","caller":"memqueue/ackloop.go:131","message":"ackloop:  done send ack"}
{"level":"debug","timestamp":"2020-05-05T15:50:06.723Z","logger":"kibana","caller":"kibana/connecting_client.go:73","message":"Trying to obtain connection to Kibana."}
{"level":"debug","timestamp":"2020-05-05T15:50:06.788Z","logger":"kibana","caller":"kibana/connecting_client.go:73","message":"Trying to obtain connection to Kibana."}
```