### PR TITLE
configure apm-server elasticsearch and kibana conns when TLS is enabled

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -20,7 +20,7 @@ class ApmServer(StackService, Service):
     DEFAULT_OUTPUT = "elasticsearch"
     OUTPUTS = {"elasticsearch", "file", "kafka", "logstash"}
     DEFAULT_KIBANA_HOST = "kibana:5601"
-    STACK_CA_PATH = "/usr/share/apm-serer/config/certs/stack-ca.crt"
+    STACK_CA_PATH = "/usr/share/apm-server/config/certs/stack-ca.crt"
 
     def __init__(self, **options):
         super(ApmServer, self).__init__(**options)
@@ -487,7 +487,7 @@ class ApmServer(StackService, Service):
         # don't unconditionally add this ca so quick start can be depenedency free
         if self.es_tls or self.kibana_tls:
             volumes.extend([
-                "./scripts/tls/ca/ca.crt:/usr/share/apm-serer/config/certs/stack-ca.crt"
+                "./scripts/tls/ca/ca.crt:/usr/share/apm-server/config/certs/stack-ca.crt"
             ])
         if self.options.get("apm_server_enable_tls"):
             volumes.extend([

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -163,8 +163,7 @@ class ApmServer(StackService, Service):
                 elif self.options.get("xpack_secure"):
                     args.append((prefix + ".elasticsearch.{}".format(cfg), default_apm_server_creds.get(cfg)))
             if tls:
-                args.append((prefix +
-                    ".elasticsearch.ssl.certificate_authorities", "['" + self.STACK_CA_PATH + "']"))
+                args.append((prefix + ".elasticsearch.ssl.certificate_authorities", "['" + self.STACK_CA_PATH + "']"))
 
         es_urls = self.options.get("apm_server_elasticsearch_urls") or [self.default_elasticsearch_hosts(self.es_tls)]
 
@@ -814,7 +813,8 @@ class Kibana(StackService, Service):
             ])
 
         content = dict(
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, "kibana", path="/api/status", retries=20, https=self.kibana_tls),
+            healthcheck=curl_healthcheck(
+                self.SERVICE_PORT, "kibana", path="/api/status", retries=20, https=self.kibana_tls),
             depends_on={"elasticsearch": {"condition": "service_healthy"}} if self.options.get(
                 "enable_elasticsearch", True) else {},
             environment=self.environment,

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -155,8 +155,8 @@ class Service(object):
     def image_download_url(self):
         pass
 
-    def default_elasticsearch_hosts(self, isTls=False):
-        if isTls:
+    def default_elasticsearch_hosts(self, tls=False):
+        if tls:
             return self.DEFAULT_ELASTICSEARCH_HOSTS_TLS
         else:
             return self.DEFAULT_ELASTICSEARCH_HOSTS

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -472,6 +472,13 @@ class ApmServerServiceTest(ServiceTest):
                             "{} not set while output=elasticsearch and overrides set: ".format(o) + " ".join(
                                 apm_server["command"]))
 
+    def test_elasticsearch_output_tls(self):
+        apm_server = ApmServer(version="7.8.100", apm_server_output="elasticsearch",
+                               elasticsearch_enable_tls=True,
+                               ).render()["apm-server"]
+        self.assertTrue("output.elasticsearch.ssl.certificate_authorities=['/usr/share/apm-serer/config/certs/stack-ca.crt']" in apm_server["command"],
+                        "CA not set when elasticsearch TLS is enabled")
+
     def test_ilm_default(self):
         """enable ILM by default in 7.2+"""
         apm_server = ApmServer(version="6.3.100").render()["apm-server"]
@@ -572,6 +579,13 @@ class ApmServerServiceTest(ServiceTest):
         ]
         for o in kafka_options:
             self.assertTrue(o in apm_server["command"], "{} not set while output=kafka".format(o))
+
+    def test_kibana_tls(self):
+        apm_server = ApmServer(version="7.8.100", kibana_enable_tls=True).render()["apm-server"]
+        self.assertTrue(
+            "apm-server.kibana.ssl.certificate_authorities=[\"/usr/share/apm-serer/config/certs/stack-ca.crt\"]" in apm_server["command"],
+            "CA not set when kibana TLS is enabled"
+        )
 
     def test_opt(self):
         apm_server = ApmServer(version="7.1.10", apm_server_opt=("an.opt=foo", "opt2=bar")).render()["apm-server"]

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -476,7 +476,7 @@ class ApmServerServiceTest(ServiceTest):
         apm_server = ApmServer(version="7.8.100", apm_server_output="elasticsearch",
                                elasticsearch_enable_tls=True,
                                ).render()["apm-server"]
-        self.assertTrue("output.elasticsearch.ssl.certificate_authorities=['/usr/share/apm-serer/config/certs/stack-ca.crt']" in apm_server["command"],
+        self.assertTrue("output.elasticsearch.ssl.certificate_authorities=['/usr/share/apm-server/config/certs/stack-ca.crt']" in apm_server["command"],
                         "CA not set when elasticsearch TLS is enabled")
 
     def test_ilm_default(self):
@@ -583,7 +583,7 @@ class ApmServerServiceTest(ServiceTest):
     def test_kibana_tls(self):
         apm_server = ApmServer(version="7.8.100", kibana_enable_tls=True).render()["apm-server"]
         self.assertTrue(
-            "apm-server.kibana.ssl.certificate_authorities=[\"/usr/share/apm-serer/config/certs/stack-ca.crt\"]" in apm_server["command"],
+            "apm-server.kibana.ssl.certificate_authorities=[\"/usr/share/apm-server/config/certs/stack-ca.crt\"]" in apm_server["command"],
             "CA not set when kibana TLS is enabled"
         )
 


### PR DESCRIPTION
## What does this PR do?

Configures apm-server connections when TLS is enabled for elasticsearch and/or kibana.

## Why is it important?
APM Server is unable to communicate with Elaticsearch and Kibana when `--elasticsearch-enable-tls --kibana-enable-tls` are set, reporting:

```
Failed to connect to backoff(elasticsearch(http://elasticsearch:9200)): Get http://elasticsearch:9200: EOF

failed to obtain connection to Kibana: fail to get the Kibana version: HTTP GET request to http://kibana:5601/api/status fails: fail to execute the HTTP GET request: Get http://kibana:5601/api/status: EOF. Response: ."
```

The options are more commonly enabled now that alerting requires TLS configuration.

## Related issues
Follow up on #820 