### PR TITLE
configure beats elasticsearch and kibana conns when TLS is enabled

### DIFF
--- a/docker/metricbeat/metricbeat.yml
+++ b/docker/metricbeat/metricbeat.yml
@@ -40,6 +40,7 @@ metricbeat.modules:
 metricbeat.autodiscover:
   providers:
     - type: docker
+      hints.enabled: true
       templates:
         - condition:
             contains:
@@ -57,14 +58,6 @@ metricbeat.autodiscover:
               hosts: ["postgres://${data.host}:5432?sslmode=disable"]
               password: verysecure
               username: postgres
-        - condition:
-            contains:
-              docker.container.image: "elasticsearch"
-          config:
-            - module: elasticsearch
-              metricsets: ["node", "node_stats"]
-              period: 10s
-              hosts: "${data.host}:9200"
         - condition:
             contains:
               docker.container.image: "kafka"

--- a/scripts/modules/beats.py
+++ b/scripts/modules/beats.py
@@ -7,6 +7,7 @@ from .service import StackService, Service
 class BeatMixin(object):
     DEFAULT_OUTPUT = "elasticsearch"
     OUTPUTS = {"elasticsearch", "logstash"}
+    STACK_CA_PATH = "/usr/share/beats/config/certs/stack-ca.crt"
 
     @classmethod
     def add_arguments(cls, parser):
@@ -41,9 +42,13 @@ class BeatMixin(object):
             self.depends_on["kibana"] = {"condition": "service_healthy"}
         self.environment = {}
 
-        def add_es_config(args, prefix="output"):
+        self.es_tls = options.get("elasticsearch_enable_tls", False)
+        self.kibana_tls = options.get("kibana_enable_tls", False)
+
+        def add_es_config(args, prefix="output", tls=self.es_tls):
             """add elasticsearch configuration options."""
-            es_urls = options.get("{}_elasticsearch_urls".format(self.name())) or [self.DEFAULT_ELASTICSEARCH_HOSTS]
+            es_urls = options.get("{}_elasticsearch_urls".format(self.name())) or \
+                      [self.default_elasticsearch_hosts(tls=self.kibana_tls)]
             default_beat_creds = {"username": "{}_user".format(self.name()), "password": "changeme"}
             args.append((prefix + ".elasticsearch.hosts", json.dumps(es_urls)))
             for cfg in ("username", "password"):
@@ -52,6 +57,8 @@ class BeatMixin(object):
                     args.append((prefix + ".elasticsearch.{}".format(cfg), options[es_opt]))
                 elif options.get("xpack_secure"):
                     args.append((prefix + ".elasticsearch.{}".format(cfg), default_beat_creds.get(cfg)))
+            if tls:
+                args.append((prefix + ".elasticsearch.ssl.certificate_authorities", "['" + self.STACK_CA_PATH + "']"))
 
         command_args = []
         add_es_config(command_args)
@@ -73,6 +80,12 @@ class BeatMixin(object):
                     ("output.kafka.hosts", "[\"kafka:9092\"]"),
                     ("output.kafka.topics", "[{default: '{}', topic: '{}'}]".format(self.name(), self.name())),
                 ])
+
+        if self.kibana_tls:
+            command_args.extend([
+                ("setup.kibana.protocol", "https"),
+                ("setup.kibana.ssl.certificate_authorities", '["' + self.STACK_CA_PATH + '"]'),
+            ])
 
         for param, value in command_args:
             self.command.extend(["-E", param + "=" + value])
@@ -136,6 +149,7 @@ class Filebeat(BeatMixin, StackService, Service):
                 self.filebeat_config_path + ":/usr/share/filebeat/filebeat.yml",
                 "/var/lib/docker/containers:/var/lib/docker/containers",
                 "/var/run/docker.sock:/var/run/docker.sock",
+                "./scripts/tls/ca/ca.crt:" + self.STACK_CA_PATH,
             ]
         )
 
@@ -161,6 +175,7 @@ class Heartbeat(BeatMixin, StackService, Service):
                 self.heartbeat_config_path + ":/usr/share/heartbeat/heartbeat.yml",
                 "/var/lib/docker/containers:/var/lib/docker/containers",
                 "/var/run/docker.sock:/var/run/docker.sock",
+                "./scripts/tls/ca/ca.crt:" + self.STACK_CA_PATH,
             ]
         )
 
@@ -192,6 +207,7 @@ class Metricbeat(BeatMixin, StackService, Service):
                  if self.at_least_version("7.2")
                  else "./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml"),
                 "/var/run/docker.sock:/var/run/docker.sock",
+                "./scripts/tls/ca/ca.crt:" + self.STACK_CA_PATH,
             ]
         )
 
@@ -217,5 +233,6 @@ class Packetbeat(BeatMixin, StackService, Service):
                  if self.at_least_version("7.2")
                  else "./docker/packetbeat/packetbeat.6.x-compat.yml:/usr/share/packetbeat/packetbeat.yml"),
                 "/var/run/docker.sock:/var/run/docker.sock",
+                "./scripts/tls/ca/ca.crt:" + self.STACK_CA_PATH,
             ]
         )

--- a/scripts/modules/beats.py
+++ b/scripts/modules/beats.py
@@ -48,7 +48,7 @@ class BeatMixin(object):
         def add_es_config(args, prefix="output", tls=self.es_tls):
             """add elasticsearch configuration options."""
             es_urls = options.get("{}_elasticsearch_urls".format(self.name())) or \
-                      [self.default_elasticsearch_hosts(tls=self.kibana_tls)]
+                [self.default_elasticsearch_hosts(tls=self.kibana_tls)]
             default_beat_creds = {"username": "{}_user".format(self.name()), "password": "changeme"}
             args.append((prefix + ".elasticsearch.hosts", json.dumps(es_urls)))
             for cfg in ("username", "password"):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -487,7 +487,7 @@ class ApmServer(StackService, Service):
         # don't unconditionally add this ca so quick start can be depenedency free
         if self.es_tls or self.kibana_tls:
             volumes.extend([
-                "./scripts/tls/ca/ca.crt:/usr/share/apm-server/config/certs/stack-ca.crt"
+                "./scripts/tls/ca/ca.crt:" + self.STACK_CA_PATH,
             ])
         if self.options.get("apm_server_enable_tls"):
             volumes.extend([

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -698,6 +698,21 @@ class Elasticsearch(StackService, Service):
         )
 
     def _content(self):
+        protocol = 'https' if self.es_tls else 'http'
+
+        labels = self.default_labels()
+        if self.at_least_version("6.3"):
+            labels.extend([
+                "co.elastic.metrics/module=elasticsearch",
+                "co.elastic.metrics/metricsets=node,node_stats",
+                "co.elastic.metrics/hosts={}://$${{data.host}}:9200".format(protocol),
+            ])
+            if self.es_tls:
+                labels.extend([
+                    "co.elastic.metrics/ssl.enabled=true",
+                    "co.elastic.metrics/ssl.verification_mode=none",
+                ])
+
         volumes = ["esdata:/usr/share/elasticsearch/data"]
         if self.xpack_secure:
             volumes.extend([
@@ -712,7 +727,6 @@ class Elasticsearch(StackService, Service):
                 "./scripts/tls/ca/ca.crt:/usr/share/elasticsearch/config/certs/ca.crt"
             ])
 
-        protocol = 'https' if self.es_tls else 'http'
         entrypoint = "{}://localhost:9200/_cluster/health".format(protocol)
         return dict(
             environment=self.environment,
@@ -721,6 +735,7 @@ class Elasticsearch(StackService, Service):
                 "retries": 10,
                 "test": ["CMD-SHELL", "curl -s -k {} | grep -vq '\"status\":\"red\"'".format(entrypoint)]
             },
+            labels=labels,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
             ulimits={
                 "memlock": {"hard": -1, "soft": -1},

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -785,7 +785,11 @@ class LocalTest(unittest.TestCase):
                     retries: 10
                     test: [CMD-SHELL, 'curl -s -k http://localhost:9200/_cluster/health | grep -vq ''"status":"red"''']
                 image: docker.elastic.co/elasticsearch/elasticsearch:6.3.10-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=6.3.10]
+                labels:
+                    - co.elastic.apm.stack-version=6.3.10
+                    - co.elastic.metrics/module=elasticsearch
+                    - co.elastic.metrics/metricsets=node,node_stats
+                    - co.elastic.metrics/hosts=http://$${data.host}:9200
                 logging:
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}
@@ -899,7 +903,11 @@ class LocalTest(unittest.TestCase):
                     retries: 10
                     test: [CMD-SHELL, 'curl -s -k http://localhost:9200/_cluster/health | grep -vq ''"status":"red"''']
                 image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=8.0.0]
+                labels:
+                    - co.elastic.apm.stack-version=8.0.0
+                    - co.elastic.metrics/module=elasticsearch
+                    - co.elastic.metrics/metricsets=node,node_stats
+                    - co.elastic.metrics/hosts=http://$${data.host}:9200
                 logging:
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}


### PR DESCRIPTION
## What does this PR do?

Configures beats connections when TLS is enabled for elasticsearch and/or kibana.
## Why is it important?

Beats are unable to communicate with Elaticsearch and Kibana when --elasticsearch-enable-tls --kibana-enable-tls are set.

## Related issues
Follow up on #820 and related to https://github.com/elastic/apm-integration-testing/pull/838#discussion_r421260742
