### PR TITLE
Update Jaeger instructions for sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ To test HTTP/Thrift with a Jaeger microservice demo, run separately:
 
 To test gRPC, run the Jaeger Agent separately:
 
-    docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/jaeger-agent:latest
+    docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp -p5778:5778 -e REPORTER_GRPC_HOST_PORT=apm-server:14250 jaegertracing/jaeger-agent:latest
 
 And the Jaeger hotrod demo:
 


### PR DESCRIPTION
## What does this PR do?

Update the README's jaeger-agent command to publish port 5778, which is used for serving remote sampling strategies to Jaeger clients.

## Why is it important?

This is needed when running a Jaeger-instrumented app outside of Docker, if you want central sampling to work.

## Related issues

None