### PR TITLE
Fix broken upload-sourcemap command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules
 **/obj
 **/bin
 docker-info/
+.vscode/
 
 # For the BATS testing
 bats-core/

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -660,7 +660,7 @@ class LocalSetup(object):
                 g = os.path.abspath(os.path.join(os.path.dirname(
                     __file__),
                     '../../docker/opbeans/node/sourcemaps/*.map')
-                    )
+                )
                 sourcemap_file = glob.glob(g)[0]
             except IndexError:
                 print(

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -657,7 +657,7 @@ class LocalSetup(object):
                 sys.exit(1)
         else:
             try:
-                g = os.path.abspath(os.path.join(os.path.dirname(__file__), '../docker/opbeans/node/sourcemaps/*.map'))
+                g = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../docker/opbeans/node/sourcemaps/*.map'))
                 sourcemap_file = glob.glob(g)[0]
             except IndexError:
                 print(

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -689,7 +689,7 @@ class LocalSetup(object):
             '-F service_name="{service_name}" '
             '-F service_version="{service_version}" '
             '-F bundle_filepath="{bundle_path}" '
-            '-F sourcemap=@/tmp/sourcemap '
+            '-F sourcemap=@{sourcemap_file} '
             '{auth_header}'
             '{server_url}/v1/client-side/sourcemaps'
         ).format(
@@ -700,6 +700,7 @@ class LocalSetup(object):
             auth_header=auth_header,
             server_url=self.args.apm_server_url,
         )
+        print(cmd)
         cmd = "docker run --rm --network apm-integration-testing " + \
               "-v {}:/tmp/sourcemap centos:7 ".format(sourcemap_file) + cmd
         subprocess.check_output(cmd, shell=True).decode('utf8').strip()

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -657,7 +657,10 @@ class LocalSetup(object):
                 sys.exit(1)
         else:
             try:
-                g = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../docker/opbeans/node/sourcemaps/*.map'))
+                g = os.path.abspath(os.path.join(os.path.dirname(
+                    __file__),
+                    '../../docker/opbeans/node/sourcemaps/*.map')
+                    )
                 sourcemap_file = glob.glob(g)[0]
             except IndexError:
                 print(


### PR DESCRIPTION
## What does this PR do?
Fixes broken `upload-sourcemap` command.

## Why is it important?

Previously, the `upload-sourcemap` command would not work because it both looked in the incorrect path for a sourcemap file and then failed to use the resolved path in the upload. This corrects both issues.

## Related issues
Closes #830 
