### PR TITLE
fix: apm-server running issues

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -461,7 +461,7 @@ class ApmServer(StackService, Service):
             command=command,
             depends_on=self.depends_on,
             environment=[
-                "BEATS_STRICT_PERM=false"  # Workaround https://github.com/elastic/beats/issues/18858
+                "BEAT_STRICT_PERMS=false"  # Workaround https://github.com/elastic/beats/issues/18858
             ],
             healthcheck=curl_healthcheck(self.SERVICE_PORT, path=healthcheck_path),
             labels=["co.elastic.apm.stack-version=" + self.version],

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -460,6 +460,9 @@ class ApmServer(StackService, Service):
             cap_drop=["ALL"],
             command=command,
             depends_on=self.depends_on,
+            environment=[
+                "BEATS_STRICT_PERM=false"  # Workaround https://github.com/elastic/beats/issues/18858
+            ],
             healthcheck=curl_healthcheck(self.SERVICE_PORT, path=healthcheck_path),
             labels=["co.elastic.apm.stack-version=" + self.version],
             ports=ports

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -689,7 +689,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
                 environment: [
-                    BEATS_STRICT_PERM=false
+                    BEAT_STRICT_PERMS=false
                 ]
                 healthcheck:
                     interval: 10s
@@ -770,7 +770,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
                 environment: [
-                    BEATS_STRICT_PERM=false
+                    BEAT_STRICT_PERMS=false
                 ]
                 healthcheck:
                     interval: 10s
@@ -874,7 +874,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
                 environment: [
-                    BEATS_STRICT_PERM=false
+                    BEAT_STRICT_PERMS=false
                 ]
                 healthcheck:
                     interval: 10s

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -688,6 +688,9 @@ class LocalTest(unittest.TestCase):
                 depends_on:
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
+                environment: [
+                    BEATS_STRICT_PERM=false
+                ]
                 healthcheck:
                     interval: 10s
                     retries: 12
@@ -766,6 +769,9 @@ class LocalTest(unittest.TestCase):
                 depends_on:
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
+                environment: [
+                    BEATS_STRICT_PERM=false
+                ]
                 healthcheck:
                     interval: 10s
                     retries: 12
@@ -867,6 +873,9 @@ class LocalTest(unittest.TestCase):
                 depends_on:
                     elasticsearch: {condition: service_healthy}
                     kibana: {condition: service_healthy}
+                environment: [
+                    BEATS_STRICT_PERM=false
+                ]
                 healthcheck:
                     interval: 10s
                     retries: 12


### PR DESCRIPTION
See https://github.com/elastic/beats/issues/18858


## What does this PR do?

Workaround the current issue when running the apm-server container

## Why is it important?

Otherwise all the consumers from this library will have issues such as:
- e2e APM UI
- APM UI Team
- MBP for the daily builds
- APM ITs for the agents
- Test Clusters

## Related issues
Caused by https://github.com/elastic/beats/issues/18858