### PR TITLE
Fetch .NET Agent version from VersionPrefix

### DIFF
--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -37,7 +37,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   mv /src/NuGet.Config .
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+  DOTNET_AGENT_VERSION=$(grep 'VersionPrefix' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -40,7 +40,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   mv /src/NuGet.Config .
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+  DOTNET_AGENT_VERSION=$(grep 'VersionPrefix' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
 
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'


### PR DESCRIPTION
Addressing https://github.com/elastic/apm-agent-dotnet/pull/869#issuecomment-638778829.

https://github.com/elastic/apm-agent-dotnet/pull/869 changes where the agent version is stored and this PR adapts the script that fetches the version.

I think this is a 🐔 🥚 problem - either we merge the PR in the .NET repo first and the IT that is triggered from the .NET repo will fail (as seen on the referenced comment) or we merge this and in case this runs before we merge .NET PR (not sure on merging this PR we run the whole .NET pipeline) then it'd fail again. To me merging this first sounds better.