### PR TITLE
[7.x] ci(jjbb): less consume of GH api quota (#812)

### DIFF
--- a/.ci/jobs/apm-integration-test-downstream.yml
+++ b/.ci/jobs/apm-integration-test-downstream.yml
@@ -37,5 +37,3 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
-    prune-dead-branches: true

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -37,5 +37,3 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
-    prune-dead-branches: true

--- a/.ci/jobs/apm-integration-tests.yml
+++ b/.ci/jobs/apm-integration-tests.yml
@@ -39,5 +39,3 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
-    prune-dead-branches: true

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -14,6 +14,8 @@
       numToKeep: 300
     node: linux
     concurrent: true
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true
     publishers:
     - email:
         recipients: infra-root+build@elastic.co


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jjbb): less consume of GH api quota (#812)