### PR TITLE
[7.x] ci(jenkins): enable opbeans validation in apm agents PRs (#763)

### DIFF
--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -39,6 +39,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout'){
+      options { skipDefaultCheckout() }
       steps {
         githubCheckNotify('PENDING')
         deleteDir()
@@ -56,12 +57,14 @@ pipeline {
     /**
       launch integration tests.
     */
-    stage("Integration Tests"){
+    stage('Integration Tests'){
+      options { skipDefaultCheckout() }
       environment {
         TMPDIR = "${WORKSPACE}"
         ENABLE_ES_DUMP = "true"
         PATH = "${WORKSPACE}/${BASE_DIR}/.ci/scripts:${env.PATH}"
         APP = agentMapping.app(params.INTEGRATION_TEST)
+        OPBEANS_APP = agentMapping.opbeansApp(params.INTEGRATION_TEST)
       }
       when {
         expression {
@@ -69,23 +72,65 @@ pipeline {
                   params.INTEGRATION_TEST != 'Opbeans')
         }
       }
-      steps {
-        deleteDir()
-        unstash "source"
-        dir("${BASE_DIR}"){
-          script {
-            def agentName = agentMapping.id(params.AGENT_INTEGRATION_TEST)
-            def agentApp = agentMapping.app(params.AGENT_INTEGRATION_TEST)
-            sh """#!/bin/bash
-            export TMPDIR="${WORKSPACE}"
-            .ci/scripts/agent.sh ${agentName} ${agentApp}
-            """
+      parallel {
+        stage('Agent app') {
+          steps {
+            deleteDir()
+            unstash "source"
+            dir("${BASE_DIR}"){
+              sh(label: "Testing ${NAME} ${APP}", script: ".ci/scripts/agent.sh ${NAME} ${APP}")
+            }
+          }
+          post {
+            always {
+              wrappingup()
+            }
           }
         }
-      }
-      post {
-        always {
-          wrappingup()
+        stage('Opbeans app') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          when {
+            expression { return (params.INTEGRATION_TEST != 'RUM') }
+            beforeAgent true
+          }
+          steps {
+            deleteDir()
+            unstash "source"
+            dir("${BASE_DIR}"){
+              sh(label: "Testing ${NAME} ${OPBEANS_APP}", script: ".ci/scripts/opbeans-app.sh ${NAME} ${APP} ${OPBEANS_APP}")
+            }
+          }
+          post {
+            always {
+              wrappingup(isJunit: false)
+            }
+          }
+        }
+        stage('Opbeans RUM app') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          when {
+            expression { return (params.INTEGRATION_TEST == 'RUM') }
+            beforeAgent true
+          }
+          steps {
+            deleteDir()
+            unstash "source"
+            dir('opbeans-frontend') {
+              git url: 'https://github.com/elastic/opbeans-frontend.git'
+              sh script: ".ci/bump-version.sh ${env.BUILD_OPTS.replaceAll('--rum-agent-branch ', '')} false", label: 'Bump version'
+              sh script: 'make build', label: 'Build docker image with the new rum agent'
+            }
+            dir("${BASE_DIR}"){
+              sh(label: 'Testing RUM', script: '.ci/scripts/opbeans-rum.sh')
+            }
+          }
+          post {
+            always {
+              wrappingup(isJunit: false)
+            }
+          }
         }
       }
     }
@@ -166,7 +211,8 @@ pipeline {
   }
 }
 
-def wrappingup(){
+def wrappingup(Map params = [:]){
+  def isJunit = params.containsKey('isJunit') ? params.get('isJunit') : true
   dir("${BASE_DIR}"){
     def stepName = agentMapping.id(params.AGENT_INTEGRATION_TEST)
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
@@ -175,10 +221,12 @@ def wrappingup(){
         allowEmptyArchive: true,
         artifacts: 'docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
         defaultExcludes: false)
-    junit(
-      allowEmptyResults: true,
-      keepLongStdio: true,
-      testResults: "**/tests/results/*-junit*.xml")
+    if (isJunit) {
+      junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/tests/results/*-junit*.xml")
+    }
+    // Let's generate the debug report ...
+    sh(label: 'Generate debug docs', script: ".ci/scripts/generate-debug-docs.sh | tee ${env.DETAILS_ARTIFACT}")
+    archiveArtifacts(artifacts: "${env.DETAILS_ARTIFACT}")
   }
 }
 

--- a/.ci/scripts/opbeans-app.sh
+++ b/.ci/scripts/opbeans-app.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+# for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
+
+srcdir=$(dirname "$0")
+test -z "$srcdir" && srcdir=.
+# shellcheck disable=SC1090
+. "${srcdir}/common.sh"
+
+AGENT=$1
+APP=$2
+OPBEANS_APP=$3
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+  --with-agent-${APP} \
+  --with-opbeans-${OPBEANS_APP} \
+  --no-apm-server-dashboards \
+  --no-apm-server-self-instrument \
+  --apm-server-agent-config-poll=1s \
+  --force-build --no-xpack-secure"
+export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
+runTests "env-agent-${AGENT}"

--- a/.ci/scripts/opbeans-rum.sh
+++ b/.ci/scripts/opbeans-rum.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+# for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
+
+srcdir=$(dirname "$0")
+test -z "$srcdir" && srcdir=.
+# shellcheck disable=SC1090
+. "${srcdir}/common.sh"
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+  --with-opbeans-go \
+  --no-apm-server-dashboards \
+  --no-apm-server-self-instrument \
+  --apm-server-agent-config-poll=1s \
+  --force-build --no-xpack-secure"
+export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
+runTests "env-agent-go"
+
+## Use the nginx
+docker run -d --rm --name=opbeans-frontend \
+      --network="apm-integration-testing" \
+      -e ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-rum \
+      -e ELASTIC_APM_JS_BASE_SERVER_URL="http://localtesting_${ELASTIC_STACK_VERSION}_apm-server:8200" \
+      -e ELASTIC_OPBEANS_API_SERVER="http://localtesting_${ELASTIC_STACK_VERSION}_opbeans-go:3000"\
+      -p 3000:3000 \
+      docker.elastic.co/observability-ci/it_opbeans-frontend_nginx
+
+## Test the service is up and running
+http_code=$(curl -s -o /dev/null -w "%{http_code}" http://0.0.0.0:3000/dashboard)
+if [ "${http_code}" == "200" ] ; then
+  docker logs opbeans-frontend | grep '/dashboard'
+  docker stop opbeans-frontend || true
+else
+  echo 'ERROR: service is not listening.'
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Those scripts shut down any existing testing containers and start a fresh new en
 
 These are the scripts available to execute:
 
+* `agent.sh:` runs the tests for the given agent. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `all.sh:` runs all test on apm-server and every agent type.
 * `common.sh:` common scripts variables and functions, it does not execute anything.
 * `dotnet.sh:` runs .NET tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
@@ -192,6 +193,8 @@ These are the scripts available to execute:
 * `java.sh:` runs Java tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `kibana.sh:` runs kibana agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `nodejs.sh:` runs Nodejs agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
+* `opbeans.sh:` runs the unit tests for the apm-integration-testing app and validates the linting. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
+* `opbeans-app.sh:` runs the apm-integration-testing app and validates the stack can be started. You can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `python.sh:` runs Python agent tests, you can choose the versions to run see the [environment variables](environment-variables) configuration.
 * `ruby.sh:` runs Ruby agent tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.
 * `server.sh:` runs APM Server tests, you can choose the versions to run see the [environment variables](#environment-variables) configuration.

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -8,8 +8,11 @@ CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
 BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent -b "${DOTNET_AGENT_BRANCH}"
+  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent
   cd /src/dotnet-agent || exit
+  git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+  git checkout "${DOTNET_AGENT_BRANCH}"
+
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
 

--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -2,25 +2,34 @@
 #
 # GO_AGENT_REPO and GO_AGENT_BRANCH parameterise the Go agent
 # repo and branch (or commit) to use.
-FROM golang:1.12
+FROM golang:stretch
 ENV GO111MODULE=on
+ARG OPBEANS_GO_REPO=elastic/opbeans-go
+ARG OPBEANS_GO_BRANCH=master
 WORKDIR /src/opbeans-go
-RUN git clone https://github.com/elastic/opbeans-go.git .
+
+RUN git clone https://github.com/${OPBEANS_GO_REPO}.git . \
+    && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+    && git checkout ${OPBEANS_GO_BRANCH}
 RUN rm -fr vendor/go.elastic.co/apm
+
 ARG GO_AGENT_REPO=elastic/apm-agent-go
 ARG GO_AGENT_BRANCH=master
-# adding this file will invalidate the layer cache when the branch head changes
-# it does not work with TAGs
-#ADD https://api.github.com/repos/${GO_AGENT_REPO}/git/refs/heads/${GO_AGENT_BRANCH} version.json
+
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/go.elastic.co/apm
-RUN (cd /src/go.elastic.co/apm && git checkout ${GO_AGENT_BRANCH})
+RUN (cd /src/go.elastic.co/apm \
+    && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
+    && git checkout ${GO_AGENT_BRANCH})
 # Add "replace" stanzas to go.mod to use the local agent repo
 RUN go list -m all | grep apm | cut -d' ' -f1 | xargs -i go mod edit -replace {}=/src/{}
 RUN go build
 
 # Stage 1: copy static assets from opbeans/opbeans-frontend and
 # opbeans-go from stage 0 into a minimal image.
-FROM gcr.io/distroless/base-debian10@sha256:afb0261acca92ecd6a19ab4e32aa05a55bd096faa26afdb0c24e2a359f91386d
+FROM gcr.io/distroless/base
+ENV ELASTIC_APM_ENABLE_LOG_CORRELATION=true
+ENV ELASTIC_APM_LOG_LEVEL=DEBUG
+
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
 COPY --from=0 /src/opbeans-go/opbeans-go /
 COPY --from=0 /src/opbeans-go/db /

--- a/docker/opbeans/ruby/entrypoint.sh
+++ b/docker/opbeans/ruby/entrypoint.sh
@@ -1,19 +1,29 @@
-#!/bin/bash -e
-if [[ -f /local-install/Gemfile ]]; then
+#!/usr/bin/env sh
+set -ex
+if [ -f /local-install/Gemfile ]; then
     echo "Installing from local folder"
     # copy to folder inside container to ensure were not poluting the local folder
     cp -r /local-install ~
     cd ~/local-install && bundle
     cd -
-elif [[ $RUBY_AGENT_VERSION ]]; then
-    gem install elastic-apm -v $RUBY_AGENT_VERSION
-elif [[ $RUBY_AGENT_BRANCH ]]; then
+elif [ -n "${RUBY_AGENT_VERSION}" ]; then
+    gem install elastic-apm -v "${RUBY_AGENT_VERSION}"
+elif [ -n "${RUBY_AGENT_BRANCH}" ]; then
     gem install specific_install
-    if [[ -z ${RUBY_AGENT_REPO} ]]; then
+    if [ -z "${RUBY_AGENT_REPO}" ]; then
         RUBY_AGENT_REPO="elastic/apm-agent-ruby"
     fi
+    # This is required with the alpine version
+    apk --no-cache add git
     echo "Installing ${RUBY_AGENT_REPO}:${RUBY_AGENT_BRANCH} from Github"
-    gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b $RUBY_AGENT_BRANCH
+
+    # Support branches/tags and refs
+    set +e
+    if gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -b "${RUBY_AGENT_BRANCH}" ; then
+      set -e
+      gem specific_install https://github.com/${RUBY_AGENT_REPO}.git -r "${RUBY_AGENT_BRANCH}"
+    fi
+
 else
     gem install elastic-apm
 fi


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): enable opbeans validation in apm agents PRs (#763)