### PR TITLE
[7.x] Fetch .NET Agent version from VersionPrefix (#849)

### DIFF
--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -37,7 +37,14 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   mv /src/NuGet.Config .
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+
+  ### Search the version of the agent using VersionPrefix otherwise PackageVersion (to keep backward compatibility)
+  SEARCH="VersionPrefix"
+  if ! grep ${SEARCH} ${BUILD_PROPS} ; then
+    SEARCH="PackageVersion"
+  fi
+
+  DOTNET_AGENT_VERSION=$(grep "${SEARCH}" ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -32,8 +32,14 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   mv /src/NuGet.Config .
   # shellcheck disable=SC2016
   sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
-  DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
 
+  ### Search the version of the agent using VersionPrefix otherwise PackageVersion (to keep backward compatibility)
+  SEARCH="VersionPrefix"
+  if ! grep ${SEARCH} ${BUILD_PROPS} ; then
+    SEARCH="PackageVersion"
+  fi
+
+  DOTNET_AGENT_VERSION=$(grep "${SEARCH}" ${BUILD_PROPS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -x
-git clone https://github.com/${OPBEANS_DOTNET_REPO}.git /src/opbeans-dotnet -b ${OPBEANS_DOTNET_BRANCH}
+
+git clone https://github.com/"${OPBEANS_DOTNET_REPO}".git /src/opbeans-dotnet
+cd /src/opbeans-dotnet || exit
+git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+git checkout "${OPBEANS_DOTNET_BRANCH}"
+
 CSPROJ="opbeans-dotnet.csproj"
 
 PACKAGE=Elastic.Apm.NetCoreAll
@@ -8,8 +13,11 @@ CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
 BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent -b "${DOTNET_AGENT_BRANCH}"
+  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent
   cd /src/dotnet-agent || exit
+  git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
+  git checkout "${DOTNET_AGENT_BRANCH}"
+
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fetch .NET Agent version from VersionPrefix (#849)

### Issues
Depends on https://github.com/elastic/apm-integration-testing/pull/857