### PR TITLE
[7.x] ci: aggregate downstream test results (#835)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -94,9 +94,8 @@ pipeline {
       launch integration tests.
     */
     stage("Integration Tests") {
-      agent none
       steps {
-        log(level: "INFO", text: "Launching Agent tests in parallel")
+        log(level: 'INFO', text: "Launching Agent tests in parallel")
         /*
           Declarative pipeline's parallel stages lose the reference to the downstream job,
           because of that, I use the parallel step. It is probably a bug.
@@ -133,9 +132,10 @@ pipeline {
 
 def runJob(testName, buildOpts = ''){
   def branch = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
-  def job
+  def jobName = "apm-integration-test-downstream/${branch}"
+  def buildObject
   try {
-    job = build(job: "apm-integration-test-downstream/${branch}",
+    buildObject = build(job: jobName,
       parameters: [
       string(name: 'INTEGRATION_TEST', value: testName),
       string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
@@ -148,9 +148,16 @@ def runJob(testName, buildOpts = ''){
       quietPeriod: 10,
       wait: true)
   } catch(e) {
-    job = e
+    buildObject = e
     error("Downstream job for '${testName}' failed")
   } finally {
-    itsDownstreamJobs["${testName}"] = job
+    itsDownstreamJobs["${testName}"] = buildObject
+
+    catchError(buildResult: 'SUCCESS', message: "Aggregate test results from dowsntream job has failed failed. Let's keep moving.") {
+      dir(testName) {
+        copyArtifacts(projectName: jobName, selector: specific(buildNumber: buildObject.number.toString()))
+        junit(testResults: '**/tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
+      }
+    }
   }
 }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -151,7 +151,7 @@ pipeline {
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
         }
-        notifyBuildResult()
+        notifyBuildResult(prComment: false)
       }
     }
   }
@@ -221,13 +221,14 @@ def wrappingup(label){
       .replace(".","_")
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
     sh('make stop-env || echo 0')
+    def testResultsPattern = '**/tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
+        artifacts: "docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
-    junit(
-      allowEmptyResults: true,
-      keepLongStdio: true,
-      testResults: "**/tests/results/*-junit*.xml")
+    junit(testResults: testResultsPattern, allowEmptyResults: true, keepLongStdio: true)
+    // Let's generate the debug report ...
+    sh(label: 'Generate debug docs', script: '.ci/scripts/generate-debug-docs.sh | tee docs.txt')
+    archiveArtifacts(artifacts: 'docs.txt')
   }
 }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -210,7 +210,7 @@ pipeline {
   post {
     cleanup {
       githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
-      notifyBuildResult()
+      notifyBuildResult(prComment: false)
     }
   }
 }
@@ -221,12 +221,13 @@ def wrappingup(Map params = [:]){
     def stepName = agentMapping.id(params.INTEGRATION_TEST)
     sh("./scripts/docker-get-logs.sh '${stepName}'|| echo 0")
     sh('make stop-env || echo 0')
+    def testResultsPattern = '**/tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: 'docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
+        artifacts: "docker-info/**,**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
     if (isJunit) {
-      junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/tests/results/*-junit*.xml")
+      junit(allowEmptyResults: true, keepLongStdio: true, testResults: testResultsPattern)
     }
     // Let's generate the debug report ...
     sh(label: 'Generate debug docs', script: ".ci/scripts/generate-debug-docs.sh | tee ${env.DETAILS_ARTIFACT}")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: aggregate downstream test results (#835)