### PR TITLE
fix docker images for the opbeans

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1823,7 +1823,7 @@ class OpbeansJava(OpbeansService):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-java"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = 'opbeans-java'
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-java'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-java'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod
@@ -1901,7 +1901,7 @@ class OpbeansJava(OpbeansService):
 class OpbeansNode(OpbeansService):
     SERVICE_PORT = 3000
     DEFAULT_LOCAL_REPO = "."
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-node'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-node'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod
@@ -1990,7 +1990,7 @@ class OpbeansPython(OpbeansService):
     DEFAULT_AGENT_BRANCH = "2.x"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = 'opbeans-python'
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-python'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-python'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod
@@ -2078,7 +2078,7 @@ class OpbeansRuby(OpbeansService):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-ruby"
     DEFAULT_LOCAL_REPO = "."
     DEFAULT_SERVICE_NAME = "opbeans-ruby"
-    DEFAULT_OPBEANS_IMAGE = 'elastic/opbeans-ruby'
+    DEFAULT_OPBEANS_IMAGE = 'opbeans/opbeans-ruby'
     DEFAULT_OPBEANS_VERSION = 'latest'
 
     @classmethod

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -169,7 +169,7 @@ class OpbeansServiceTest(ServiceTest):
                       args:
                         - JAVA_AGENT_BRANCH=
                         - JAVA_AGENT_REPO=elastic/apm-agent-java
-                        - OPBEANS_JAVA_IMAGE=elastic/opbeans-java
+                        - OPBEANS_JAVA_IMAGE=opbeans/opbeans-java
                         - OPBEANS_JAVA_VERSION=latest
                     container_name: localtesting_6.3.10_opbeans-java
                     ports:
@@ -226,7 +226,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/node
                       args:
-                      - OPBEANS_NODE_IMAGE=elastic/opbeans-node
+                      - OPBEANS_NODE_IMAGE=opbeans/opbeans-node
                       - OPBEANS_NODE_VERSION=latest
                     container_name: localtesting_6.2.4_opbeans-node
                     ports:
@@ -297,7 +297,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/python
                       args:
-                      - OPBEANS_PYTHON_IMAGE=elastic/opbeans-python
+                      - OPBEANS_PYTHON_IMAGE=opbeans/opbeans-python
                       - OPBEANS_PYTHON_VERSION=latest
                     container_name: localtesting_6.2.4_opbeans-python
                     ports:
@@ -386,7 +386,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/ruby
                       args:
-                        - OPBEANS_RUBY_IMAGE=elastic/opbeans-ruby
+                        - OPBEANS_RUBY_IMAGE=opbeans/opbeans-ruby
                         - OPBEANS_RUBY_VERSION=latest
                     container_name: localtesting_6.3.10_opbeans-ruby
                     ports:


### PR DESCRIPTION
## What does this PR do?

Change the default namespace to be opbeans, see https://hub.docker.com/u/opbeans

## Why is it important?

Fix the [upgrade pipeline](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-tests-upgrade-mbp/)

This was already fixed in the master when the big-refactor was done, see https://github.com/elastic/apm-integration-testing/pull/597

## Tests

```bash
hub pr checkout 860
./scripts/compose.py start master --all-opbeans 
```

```
Successfully built ab44e87155f8
Successfully tagged apm-integration-testing_opbeans-go:latest
Pulling elasticsearch          ... done
Pulling kibana                 ... done
Pulling apm-server             ... done
Pulling postgres               ... done
Pulling redis                  ... done
Pulling opbeans-load-generator ... done
Recreating localtesting_8.0.0_elasticsearch ... done
Creating localtesting_8.0.0_postgres        ... done
Creating localtesting_8.0.0_redis           ... done
Creating localtesting_8.0.0_kibana          ... done
Recreating localtesting_8.0.0_apm-server    ... done
Creating localtesting_latest_opbeans-ruby   ... done
Creating localtesting_latest_opbeans-node   ... done
Creating localtesting_latest_opbeans-java   ... done
Creating localtesting_8.0.0_opbeans-dotnet  ... done
Creating localtesting_latest_opbeans-python ... done
Creating localtesting_8.0.0_opbeans-go      ... done
Creating localtesting_8.0.0_opbeans-rum     ... done
Creating localtesting_8.0.0_opbeans-load-generator ... done
➜  apm-integration-testing git:(fix/opbeans-docker-java-image) docker ps                                                                                                                     
CONTAINER ID        IMAGE                                                          COMMAND                  CREATED             STATUS                   PORTS                                                NAMES
c0e50e23dea5        opbeans/opbeans-loadgen:latest                                 "/app/entrypoint.sh …"   2 minutes ago       Up 2 minutes                                                                  localtesting_8.0.0_opbeans-load-generator
9d772a910386        apm-integration-testing_opbeans-rum                            "docker-entrypoint.s…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:9222->9222/tcp                             localtesting_8.0.0_opbeans-rum
ea12e7d13f3f        apm-integration-testing_opbeans-go                             "/opbeans-go -log-js…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:3003->3000/tcp                             localtesting_8.0.0_opbeans-go
d29a172ba032        apm-integration-testing_opbeans-python                         "/bin/bash /app/entr…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:8000->3000/tcp                             localtesting_latest_opbeans-python
41c382e5ee74        apm-integration-testing_opbeans-dotnet                         "dotnet opbeans-dotn…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:3004->80/tcp                               localtesting_8.0.0_opbeans-dotnet
ac2319fcef22        apm-integration-testing_opbeans-java                           "/bin/bash /app/entr…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:3002->3000/tcp                             localtesting_latest_opbeans-java
6cb8cbf21918        apm-integration-testing_opbeans-node                           "/bin/bash /app/entr…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:3000->3000/tcp                             localtesting_latest_opbeans-node
7acb8d0415fb        apm-integration-testing_opbeans-ruby                           "/bin/bash /app/entr…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:3001->3000/tcp                             localtesting_latest_opbeans-ruby
da5b94f7730e        docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT                "/usr/local/bin/dock…"   3 minutes ago       Up 3 minutes (healthy)   127.0.0.1:6060->6060/tcp, 127.0.0.1:8200->8200/tcp   localtesting_8.0.0_apm-server
88cb00e9dc66        docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT                 "/usr/local/bin/dumb…"   4 minutes ago       Up 4 minutes (healthy)   127.0.0.1:5601->5601/tcp                             localtesting_8.0.0_kibana
1e0836d90a65        docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT   "/tini -- /usr/local…"   4 minutes ago       Up 4 minutes (healthy)   127.0.0.1:9200->9200/tcp, 9300/tcp                   localtesting_8.0.0_elasticsearch
aa9bf854eb70        postgres:10                                                    "docker-entrypoint.s…"   4 minutes ago       Up 4 minutes (healthy)   0.0.0.0:5432->5432/tcp                               localtesting_8.0.0_postgres
e232a9e32a9e        redis:4                                                        "docker-entrypoint.s…"   4 minutes ago       Up 4 minutes (healthy)   0.0.0.0:6379->6379/tcp                               localtesting_8.0.0_redis

```