### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -66,7 +66,9 @@ ruby:latest
 wordpress:php7.3-fpm-alpine
 "
 
-for di in ${DOCKER_IMAGES}
-do
-(retry 2 docker pull "${di}") || echo "Error pulling ${di} Docker image, we continue"
-done
+if [ -x "$(command -v docker)" ]; then
+  for di in ${DOCKER_IMAGES}
+  do
+  (retry 2 docker pull "${di}") || echo "Error pulling ${di} Docker image, we continue"
+  done
+fi


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.