### PR TITLE
Add --index-suffix option to add suffix to all event indices

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -74,6 +74,8 @@ class LocalSetup(object):
         '7.5': '7.5.2',
         '7.6': '7.6.2',
         '7.7': '7.7.0',
+        '7.8': '7.8.0',
+        '7.9': '7.9.0',
         'master': '8.0.0',
     }
 
@@ -342,6 +344,13 @@ class LocalSetup(object):
             action="store",
             help="apm server url to use for all clients",
             default=DEFAULT_APM_SERVER_URL,
+        )
+
+        parser.add_argument(
+            "--index-suffix",
+            action="store",
+            help="index suffix to add to all event indices",
+            default="",
         )
 
         parser.add_argument(

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -76,7 +76,7 @@ class ApmServer(StackService, Service):
         if index_suffix and self.at_least_version("7.9"):
             mapping = []
             for et in ["profile", "error", "transaction", "span", "metric"]:
-                mapping.append({"event_type":et, "index_suffix":index_suffix})
+                mapping.append({"event_type": et, "index_suffix": index_suffix})
             mapping_str = json.dumps(mapping)
             self.apm_server_command_args.append(("apm-server.ilm.setup.mapping", mapping_str))
 

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -75,10 +75,10 @@ class ApmServer(StackService, Service):
         index_suffix = self.options.get("index_suffix")
         if index_suffix and self.at_least_version("7.9"):
             mapping = []
-            for et in ["profile","error","transaction","span","metric"]:
-                mapping.append({"event_type":et,"index_suffix":index_suffix})
+            for et in ["profile", "error", "transaction", "span", "metric"]:
+                mapping.append({"event_type":et, "index_suffix":index_suffix})
             mapping_str = json.dumps(mapping)
-            self.apm_server_command_args.append(("apm-server.ilm.setup.mapping",mapping_str))
+            self.apm_server_command_args.append(("apm-server.ilm.setup.mapping", mapping_str))
 
         if self.options.get("apm_server_ilm_disable"):
             self.apm_server_command_args.append(("apm-server.ilm.enabled", "false"))

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -69,8 +69,16 @@ class ApmServer(StackService, Service):
         self.es_tls = self.options.get("elasticsearch_enable_tls", False)
         self.kibana_tls = self.options.get("kibana_enable_tls", False)
 
-        if self.options.get("apm-server-experimental-mode", True) and self.at_least_version("7.2"):
+        if self.options.get("apm_server_experimental_mode", True) and self.at_least_version("7.2"):
             self.apm_server_command_args.append(("apm-server.mode", "experimental"))
+
+        index_suffix = self.options.get("index_suffix")
+        if index_suffix and self.at_least_version("7.9"):
+            mapping = []
+            for et in ["profile","error","transaction","span","metric"]:
+                mapping.append({"event_type":et,"index_suffix":index_suffix})
+            mapping_str = json.dumps(mapping)
+            self.apm_server_command_args.append(("apm-server.ilm.setup.mapping",mapping_str))
 
         if self.options.get("apm_server_ilm_disable"):
             self.apm_server_command_args.append(("apm-server.ilm.enabled", "false"))


### PR DESCRIPTION
## What does this PR do?
Add an option `--index-suffix`  that can be used to e.g. add an environment to all event indices. 
It will be applied to all event indices, but not to the onboarding and sourcemap index.


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
Should ease testing in different environments and allow for more fine granular deleting of data, e.g. running `DELETE apm*my-env*` will only delete data that have been set up with `--index-suffix="my-env"`.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Came out of offline discussions related to better distinction between testing environments. 


Additionally the PR adds the latest release versions and fixes one flag that was in invalid format.