### PR TITLE
fix: update dependencies to run integration tests

### DIFF
--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -5,7 +5,7 @@ ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
 RUN apt update -qq \
-    && apt install -qq -y curl git gnupg libgconf-2-4 --no-install-recommends \
+    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1 --no-install-recommends \
     && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt update -qq \


### PR DESCRIPTION
+ This shouldn't be necessary as `google-chrome-unstable` should install these dep's. But this is a workaround that runs the tests without any issues.

## Related issues
Closes #870 
