### PR TITLE
[6.x] fix: update dependencies to run integration tests (#872)

### DIFF
--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -4,10 +4,9 @@ ARG RUM_AGENT_BRANCH
 ARG RUM_AGENT_REPO
 ARG APM_SERVER_URL
 
-RUN apt-get -qq update \
-    && apt-get -qq install -yq libgconf-2-4 \
-    && apt-get -qq install -y curl git --no-install-recommends \
-    && curl -L https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN apt update -qq \
+    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1 --no-install-recommends \
+    && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get -qq update \
     && apt-get -qq install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix: update dependencies to run integration tests (#872)