### PR TITLE
fix: remove chrome drive is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
 FROM python:3.7
-# install latest Google Chrome & Chromedriver
-RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-    && apt-get -yqq update \
-    && apt-get -yqq --allow-unauthenticated install google-chrome-unstable
-
-RUN curl -SLO https://chromedriver.storage.googleapis.com/$(curl -o- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip \
-    && apt-get -yqq update \
-    && apt install -yqq --no-install-recommends unzip \
-    && unzip -d /usr/local/bin/ chromedriver_linux64.zip chromedriver
 
 #Install elasticdump
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

removes the installation of Chrome and ChromeDriver on the test container.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

They are not used and causes flakiness to download those resources

## Related issues
related to https://github.com/elastic/apm-integration-testing/issues/871
