### PR TITLE
fix: add libxss dependency to the opbean-rum

### DIFF
--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update -qq  \
     && curl -sSkfL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt update -qq \
-    && apt install -qq -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt install -qq -y google-chrome-unstable libxss1 fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it adds the library libxss to the opbeans-rum docker container.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

Chrome fails without it 

```
Error: Failed to launch chrome!
/home/pptruser/node_modules/puppeteer/.local-chromium/linux-706915/chrome-linux/chrome: error while loading
 shared libraries: libXss.so.1: cannot open shared object file: No such file or directory
```

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/879
related https://github.com/elastic/apm-integration-testing/pull/872

## Note
needs backport to 7.x, 6.x, 6.x-v1
