### PR TITLE
[6.x-v1] fix: add libxss dependency to the opbean-rum (#880)

### DIFF
--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
 	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
 	&& echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
 	&& apt-get -qq update && apt-get -qq install -y \
-	google-chrome-stable \
+	google-chrome-stable libxss1 fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf\
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Backports the following commits to 6.x-v1:
 - fix: add libxss dependency to the opbean-rum (#880)