### PR TITLE
fix: update Elastic Stack versions

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -56,7 +56,7 @@ pipeline {
         axes {
           axis {
               name 'ELASTIC_STACK_VERSION'
-              values '8.0.0-SNAPSHOT', '7.8.0', '7.7.2-SNAPSHOT'
+              values '8.0.0-SNAPSHOT', '7.8.1', '7.9.0-SNAPSHOT'
           }
         }
         stages {

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -58,7 +58,7 @@ pipeline {
         axes {
           axis {
               name 'ELASTIC_STACK_VERSION'
-              values '7.9.0-SNAPSHOT', '7.8.0', '7.7.2-SNAPSHOT'
+              values '7.9.0-SNAPSHOT', '7.8.1', '7.8.1-SNAPSHOT'
           }
         }
         stages {


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Update the Elastic stack versions.


## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
7.7.x snapshots are not available anymore.

