### PR TITLE
fix: update Go version to the latest LTS version

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.14
 WORKDIR /go/src/testapp
 COPY main.go /go/src/testapp
 ARG GO_AGENT_REPO=elastic/apm-agent-go


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Bump the Go version to the latest LTS version.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The latest version of `elastic/go-sysinfo` has some changes that affect this container updating the Go version used to compile fix the issue.


## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/889
