### PR TITLE
Introduce APM log level flag

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "8.0.0", description: "Elastic Stack Git branch/tag to use")
-    string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
+    string(name: 'BUILD_OPTS', defaultValue: "", description: "Additional build options to pass to compose.py")
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }
   stages{

--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -14,6 +14,6 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-apm-server-self-instrument \
   --apm-server-agent-config-poll=1s \
   --force-build --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-${AGENT}" "docker-test-agent-${AGENT}"

--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -13,6 +13,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --apm-server-agent-config-poll=1s \
-  --force-build --no-xpack-secure"
+  --force-build --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-${AGENT}" "docker-test-agent-${AGENT}"

--- a/.ci/scripts/all.sh
+++ b/.ci/scripts/all.sh
@@ -28,7 +28,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS}\
   --no-verify-server-cert  \
   --apm-server-secret-token=${ELASTIC_APM_SECRET_TOKEN} \
   --apm-server-url=${APM_SERVER_URL} \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-all docker-test-all

--- a/.ci/scripts/all.sh
+++ b/.ci/scripts/all.sh
@@ -27,7 +27,8 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS}\
   --apm-server-enable-tls \
   --no-verify-server-cert  \
   --apm-server-secret-token=${ELASTIC_APM_SECRET_TOKEN} \
-  --apm-server-url=${APM_SERVER_URL}"
+  --apm-server-url=${APM_SERVER_URL} \
+  --apm-log-level debug"
 
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-all docker-test-all

--- a/.ci/scripts/dotnet.sh
+++ b/.ci/scripts/dotnet.sh
@@ -18,6 +18,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-apm-server-self-instrument \
   --no-kibana --with-agent-dotnet \
   --force-build \
-  --no-xpack-secure"
+  --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-dotnet docker-test-agent-dotnet

--- a/.ci/scripts/dotnet.sh
+++ b/.ci/scripts/dotnet.sh
@@ -19,6 +19,6 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-kibana --with-agent-dotnet \
   --force-build \
   --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-dotnet docker-test-agent-dotnet

--- a/.ci/scripts/go.sh
+++ b/.ci/scripts/go.sh
@@ -20,7 +20,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-go-net-http \
   --force-build \
   --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 
 runTests env-agent-go docker-test-agent-go

--- a/.ci/scripts/go.sh
+++ b/.ci/scripts/go.sh
@@ -19,7 +19,8 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-kibana \
   --with-agent-go-net-http \
   --force-build \
-  --no-xpack-secure"
+  --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 
 runTests env-agent-go docker-test-agent-go

--- a/.ci/scripts/java.sh
+++ b/.ci/scripts/java.sh
@@ -19,6 +19,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-kibana \
   --with-agent-java-spring \
   --force-build \
-  --no-xpack-secure"
+  --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-java docker-test-agent-java

--- a/.ci/scripts/java.sh
+++ b/.ci/scripts/java.sh
@@ -20,6 +20,6 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-java-spring \
   --force-build \
   --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-java docker-test-agent-java

--- a/.ci/scripts/nodejs.sh
+++ b/.ci/scripts/nodejs.sh
@@ -19,6 +19,6 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-nodejs-express \
   --force-build \
   --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-nodejs docker-test-agent-nodejs

--- a/.ci/scripts/nodejs.sh
+++ b/.ci/scripts/nodejs.sh
@@ -18,6 +18,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-kibana \
   --with-agent-nodejs-express \
   --force-build \
-  --no-xpack-secure"
+  --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-nodejs docker-test-agent-nodejs

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -23,6 +23,6 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --apm-server-agent-config-poll=1s \
   --force-build \
   --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-python docker-test-agent-python

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -22,6 +22,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-python-flask \
   --apm-server-agent-config-poll=1s \
   --force-build \
-  --no-xpack-secure"
+  --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-python docker-test-agent-python

--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -17,6 +17,6 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-ruby-rails \
   --force-build \
   --no-xpack-secure \
-  --apm-log-level debug"
+  --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-ruby docker-test-agent-ruby

--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -16,6 +16,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --no-kibana \
   --with-agent-ruby-rails \
   --force-build \
-  --no-xpack-secure"
+  --no-xpack-secure \
+  --apm-log-level debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-ruby docker-test-agent-ruby

--- a/docker/python/flask/app.py
+++ b/docker/python/flask/app.py
@@ -10,8 +10,9 @@ import os
 app = Flask(__name__)
 app.debug = False
 
+
 app.config['ELASTIC_APM'] = {
-    'DEBUG': True,
+    'DEBUG': os.environ.get('ELASTIC_APM_LOG_LEVEL').lower() == 'debug',
     'SERVER_URL': os.environ['APM_SERVER_URL'],
     'SERVICE_NAME': os.environ['FLASK_SERVICE_NAME'],
     'TRANSACTION_SEND_FREQ': 1,  # 1.x

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -221,7 +221,6 @@ class AgentPythonDjango(AgentPython):
     ])
     def _content(self):
         default_environment = {
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
             "DJANGO_PORT": self.SERVICE_PORT,
             "DJANGO_SERVICE_NAME": "djangoapp",
         }
@@ -257,7 +256,6 @@ class AgentPythonFlask(AgentPython):
     ])
     def _content(self):
         default_environment = {
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
             "FLASK_SERVICE_NAME": "flaskapp",
             "GUNICORN_CMD_ARGS": "-w 4 -b 0.0.0.0:{}".format(self.SERVICE_PORT),
         }

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -258,6 +258,7 @@ class AgentPythonFlask(AgentPython):
         default_environment = {
             "FLASK_SERVICE_NAME": "flaskapp",
             "GUNICORN_CMD_ARGS": "-w 4 -b 0.0.0.0:{}".format(self.SERVICE_PORT),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
         }
         environment = default_environment
         if self.apm_api_key:

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -496,7 +496,7 @@ class AgentDotnet(Service):
             "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
             "ELASTIC_APM_LOG_LEVEL": self._map_log_level(
                 self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL).lower()
-                ),
+            ),
         }
         environment = default_environment
         if self.apm_api_key:

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -467,6 +467,22 @@ class AgentDotnet(Service):
                 "apm-server": {"condition": "service_healthy"},
             }
 
+    def _map_log_level(self, lvl):
+        """
+        Resolves a standard log level such as 'info' to
+        a specific log level string as required by the .NET agent.
+
+        See https://www.elastic.co/guide/en/apm/agent/dotnet/current/config-supportability.html#config-log-level
+        """
+        log_level_map = {
+            "info": "Info",
+            "error": "Error",
+            "warning": "Warning",
+            "debug": "Debug",
+            "trace": "Trace"
+        }
+        return log_level_map[lvl]
+
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN"),
         ("apm_server_url", "ELASTIC_APM_SERVER_URLS"),
@@ -479,7 +495,9 @@ class AgentDotnet(Service):
             "ELASTIC_APM_TRANSACTION_SAMPLE_RATE": "1",
             "ELASTIC_APM_SERVICE_NAME": "dotnetapp",
             "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
+            "ELASTIC_APM_LOG_LEVEL": self._map_log_level(
+                self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL).lower()
+                ),
         }
         environment = default_environment
         if self.apm_api_key:

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -3,7 +3,7 @@
 #
 
 from .helpers import curl_healthcheck, add_agent_environment
-from .service import Service, DEFAULT_APM_SERVER_URL
+from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_LOG_LEVEL
 
 
 class AgentRUMJS(Service):
@@ -38,6 +38,7 @@ class AgentRUMJS(Service):
             "ELASTIC_APM_SERVICE_NAME": "rum",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL)
         }
         environment = default_environment
         if self.apm_api_key:
@@ -98,6 +99,7 @@ class AgentGoNetHttp(Service):
     ])
     def _content(self):
         default_environment = {
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_FLUSH_INTERVAL": "500ms",
             "ELASTIC_APM_SERVICE_NAME": "gonethttpapp",
@@ -159,6 +161,7 @@ class AgentNodejsExpress(Service):
             "EXPRESS_PORT": str(self.SERVICE_PORT),
             "EXPRESS_SERVICE_NAME": "expressapp",
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
         }
         environment = default_environment
         if self.apm_api_key:
@@ -218,6 +221,7 @@ class AgentPythonDjango(AgentPython):
     ])
     def _content(self):
         default_environment = {
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
             "DJANGO_PORT": self.SERVICE_PORT,
             "DJANGO_SERVICE_NAME": "djangoapp",
         }
@@ -253,6 +257,7 @@ class AgentPythonFlask(AgentPython):
     ])
     def _content(self):
         default_environment = {
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
             "FLASK_SERVICE_NAME": "flaskapp",
             "GUNICORN_CMD_ARGS": "-w 4 -b 0.0.0.0:{}".format(self.SERVICE_PORT),
         }
@@ -319,6 +324,7 @@ class AgentRubyRails(Service):
     def _content(self):
         default_environment = {
             "APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
@@ -399,6 +405,7 @@ class AgentJavaSpring(Service):
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVICE_NAME": "springapp",
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
         }
         environment = default_environment
         if self.apm_api_key:
@@ -472,6 +479,7 @@ class AgentDotnet(Service):
             "ELASTIC_APM_TRANSACTION_SAMPLE_RATE": "1",
             "ELASTIC_APM_SERVICE_NAME": "dotnetapp",
             "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
         }
         environment = default_environment
         if self.apm_api_key:

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -13,7 +13,7 @@ import re
 from .beats import BeatMixin
 from .helpers import load_images
 from .opbeans import OpbeansService, OpbeansRum
-from .service import Service, DEFAULT_APM_SERVER_URL
+from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_LOG_LEVEL
 
 # these imports are used by discover_services function to discover services from modules loaded
 
@@ -345,6 +345,14 @@ class LocalSetup(object):
             action="store",
             help="apm server url to use for all clients",
             default=DEFAULT_APM_SERVER_URL,
+        )
+
+        parser.add_argument(
+            "--apm-log-level",
+            action="store",
+            help="APM log level to use",
+            choices=["off", "error", "warn", "info", "debug", "trace"],
+            default=DEFAULT_APM_LOG_LEVEL
         )
 
         parser.add_argument(

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -7,6 +7,7 @@ from .helpers import resolve_bc, parse_version, _camel_hyphen
 DEFAULT_STACK_VERSION = "8.0"
 DEFAULT_APM_SERVER_URL = "http://apm-server:8200"
 DEFAULT_APM_JS_SERVER_URL = "http://localhost:8200"
+DEFAULT_APM_LOG_LEVEL = "info"
 DEFAULT_SERVICE_VERSION = "9c2e41c8-fb2f-4b75-a89d-5089fb55fc64"
 
 

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -38,6 +38,7 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_FLUSH_INTERVAL: 500ms
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         ELASTIC_APM_SERVICE_NAME: gonethttpapp
                         ELASTIC_APM_TRANSACTION_IGNORE_NAMES: healthcheck
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
@@ -92,6 +93,7 @@ class AgentServiceTest(ServiceTest):
                     command: bash -c "npm install elastic-apm-node && node app.js"
                     environment:
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         EXPRESS_SERVICE_NAME: expressapp
                         EXPRESS_PORT: "8010"
                     healthcheck:
@@ -142,6 +144,7 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         DJANGO_SERVICE_NAME: djangoapp
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         DJANGO_PORT: 8003
                     healthcheck:
                         interval: 10s
@@ -186,6 +189,7 @@ class AgentServiceTest(ServiceTest):
                             condition: 'service_healthy'
                     environment:
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         FLASK_SERVICE_NAME: flaskapp
                         GUNICORN_CMD_ARGS: "-w 4 -b 0.0.0.0:8001"
                     healthcheck:
@@ -235,6 +239,7 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         APM_SERVER_URL: http://apm-server:8200
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         ELASTIC_APM_SERVER_URL: http://apm-server:8200
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         ELASTIC_APM_SERVICE_NAME: railsapp
@@ -301,6 +306,7 @@ class AgentServiceTest(ServiceTest):
                             condition: 'service_healthy'
                     environment:
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         ELASTIC_APM_SERVICE_NAME: springapp
                     healthcheck:
@@ -363,6 +369,7 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_FLUSH_INTERVAL: '5'
+                        ELASTIC_APM_LOG_LEVEL: info
                         ELASTIC_APM_TRANSACTION_SAMPLE_RATE: '1'
                         ELASTIC_APM_SERVICE_NAME: dotnetapp
                         ELASTIC_APM_TRANSACTION_IGNORE_NAMES: 'healthcheck'

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -369,7 +369,7 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
                         ELASTIC_APM_FLUSH_INTERVAL: '5'
-                        ELASTIC_APM_LOG_LEVEL: info
+                        ELASTIC_APM_LOG_LEVEL: Info
                         ELASTIC_APM_TRANSACTION_SAMPLE_RATE: '1'
                         ELASTIC_APM_SERVICE_NAME: dotnetapp
                         ELASTIC_APM_TRANSACTION_IGNORE_NAMES: 'healthcheck'

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -144,7 +144,6 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         DJANGO_SERVICE_NAME: djangoapp
-                        ELASTIC_APM_LOG_LEVEL: 'info'
                         DJANGO_PORT: 8003
                     healthcheck:
                         interval: 10s
@@ -189,7 +188,6 @@ class AgentServiceTest(ServiceTest):
                             condition: 'service_healthy'
                     environment:
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
-                        ELASTIC_APM_LOG_LEVEL: 'info'
                         FLASK_SERVICE_NAME: flaskapp
                         GUNICORN_CMD_ARGS: "-w 4 -b 0.0.0.0:8001"
                     healthcheck:

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -187,6 +187,7 @@ class AgentServiceTest(ServiceTest):
                         apm-server:
                             condition: 'service_healthy'
                     environment:
+                        ELASTIC_APM_LOG_LEVEL: 'info'
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         FLASK_SERVICE_NAME: flaskapp
                         GUNICORN_CMD_ARGS: "-w 4 -b 0.0.0.0:8001"

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -238,7 +238,7 @@ class AgentServiceTest(ServiceTest):
                     environment:
                         APM_SERVER_URL: http://apm-server:8200
                         ELASTIC_APM_API_REQUEST_TIME: '3s'
-                        ELASTIC_APM_LOG_LEVEL: 'info'
+                        ELASTIC_APM_LOG_LEVEL: 1
                         ELASTIC_APM_SERVER_URL: http://apm-server:8200
                         ELASTIC_APM_VERIFY_SERVER_CERT: 'true'
                         ELASTIC_APM_SERVICE_NAME: railsapp


### PR DESCRIPTION
## What does this PR do?

Introduces a new flag called `--apm-log-level` which is set to `info` out-of-the-box when running `compose.py` directly, but when invoked via the `.ci/scripts/*.sh` jobs for the APM agents, it is set to `debug` by default.

## Why is it important?

This was requested by the APM agent teams as a means to debug persistent failures in Elastic Cloud.

cc: @felixbarny 
