### PR TITLE
Makefile help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,10 @@ test-compose-2:
 test-kibana: venv ## Run the Kibana integration tests
 	pytest tests/kibana/test_integration.py --reruns 3 --reruns-delay 5 -v -s $(JUNIT_OPT)/kibana-junit.xml
 
-test-server: venv
+test-server: venv  ## Run server tests
 	pytest tests/server/ --reruns 3 --reruns-delay 5 -v -s $(JUNIT_OPT)/server-junit.xml
 
-test-upgrade: venv
+test-upgrade: venv ## Run the upgrade tests
 	pytest tests/server/test_upgrade.py -v -s $(JUNIT_OPT)/server-junit.xml
 
 SUBCOMMANDS = list-options load-dashboards start status stop upload-sourcemap versions
@@ -106,16 +106,16 @@ SUBCOMMANDS = list-options load-dashboards start status stop upload-sourcemap ve
 test-helps:
 	$(foreach subcommand,$(SUBCOMMANDS), $(PYTHON) scripts/compose.py $(subcommand) --help >/dev/null || exit 1;)
 
-test-all: venv test-compose lint test-helps
+test-all: venv test-compose lint test-helps ## Run all the tests
 	pytest -v -s $(JUNIT_OPT)/all-junit.xml
 
-docker-compose-wait: venv
+docker-compose-wait: venv ## Wait for docker services to shutdown and exit
 	docker-compose-wait || (docker ps -a && exit 1)
 
-docker-test-%:
+docker-test-%: ## Run a specific dockerized test. Ex: make docker-test-java
 	TARGET=test-$* $(MAKE) dockerized-test
 
-dockerized-test:
+dockerized-test: ## Run all the dockerized tests
 	@echo waiting for services to be healthy
 	$(MAKE) docker-compose-wait || (./scripts/docker-summary.sh; echo "[ERROR] Failed waiting for all containers are healthy"; exit 1)
 


### PR DESCRIPTION
## What does this PR do?

Makes `make help` work for the APM integration test suite project:

```
❯ make help
destroy-env          Destroy the test environment
docker-compose-wait  Wait for docker services to shutdown and exit
docker-test-%        Run a specific dockerized test. Ex: make docker-test-java
dockerized-test      Run all the dockerized tests
help                 Display this help text
lint                 Lint the project
start-env            Start the test environment
stop-env             Stop the test environment
test-agent-%         Test a specific agent. ex: make test-agent-java
test-all             Run all the tests
test-kibana          Run the Kibana integration tests
test-server          Run server tests
test-upgrade         Run the upgrade tests
test                 Run all the tests
venv                 Prepare the virtual environment
```
