### PR TITLE
make log level of elasticapm loggers configurable in flask and django apps

### DIFF
--- a/docker/python/django/testapp/testapp/settings.py
+++ b/docker/python/django/testapp/testapp/settings.py
@@ -114,6 +114,11 @@ LOGGING = {
             'handlers': ['elasticapm'],
             'propagate': False,
         },
+        'elasticapm': {
+            'level': os.environ.get("ELASTIC_APM_LOG_LEVEL", 'ERROR').upper(),
+            'handlers': ['console'],
+            'propagate': True,
+        },
         # Log errors from the Elastic APM module to the console (recommended)
         'elasticapm.errors': {
             'level': 'ERROR',

--- a/docker/python/flask/app.py
+++ b/docker/python/flask/app.py
@@ -23,7 +23,7 @@ app.config['ELASTIC_APM'] = {
     'SECRET_TOKEN': os.getenv('APM_SERVER_SECRET_TOKEN', '1234'),
     'TRANSACTIONS_IGNORE_PATTERNS': ['.*healthcheck']
 }
-apm = ElasticAPM(app, logging=True)
+apm = ElasticAPM(app, logging=logging.ERROR)
 
 
 @app.route('/')
@@ -68,9 +68,7 @@ def oof_route():
 
 
 if __name__ == '__main__':
+    logging.basicConfig(format='%(levelname)s %(asctime)s %(process)d %(message)s', level=logging.WARNING)
+    logging.getLogger('elasticapm').setLevel(os.environ.get("ELASTIC_APM_LOG_LEVEL", "ERROR").upper())
     app.run(host='0.0.0.0', port=int(os.environ['FLASK_PORT']))
 
-    # Create a logging handler and attach it.
-    handler = LoggingHandler(client=apm.client)
-    handler.setLevel(logging.INFO)
-    app.logger.addHandler(handler)

--- a/docker/python/flask/app.py
+++ b/docker/python/flask/app.py
@@ -71,4 +71,3 @@ if __name__ == '__main__':
     logging.basicConfig(format='%(levelname)s %(asctime)s %(process)d %(message)s', level=logging.WARNING)
     logging.getLogger('elasticapm').setLevel(os.environ.get("ELASTIC_APM_LOG_LEVEL", "ERROR").upper())
     app.run(host='0.0.0.0', port=int(os.environ['FLASK_PORT']))
-


### PR DESCRIPTION
## What does this PR do?

As logging is configured on an application basis in Python, the agent doesn't have
the capability to configure its own logger (this might change in the future). As
such, we're checking for the ELASTIC_APM_LOG_LEVEL envionment variable in both the
Django and Flask integration test apps.

## Why is it important?

Some other agents support this environment variable. This way we align behavior of
the integration test apps.

## Related issues
See #894
