### PR TITLE
fix: missing dependencies for rum test

### DIFF
--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -4,7 +4,7 @@ FROM node:12-slim
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
 RUN apt update -qq \
-    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1  python g++ build-essential --no-install-recommends \
+    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1 libxtst6 python g++ build-essential --no-install-recommends \
     && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt update -qq \

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -5,7 +5,7 @@ ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
 RUN apt update -qq \
-    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1  python g++ build-essential --no-install-recommends \
+    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1 libxtst6 python g++ build-essential --no-install-recommends \
     && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt update -qq \


### PR DESCRIPTION
+ fixing https://apm-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/apm-integration-test-downstream/branches/master/runs/6290/nodes/77/steps/98/log/