### PR TITLE
fix: use fixed version of setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pytest-variables==1.9.0
 pytest==5.4.3
 requests==2.22.0
 selenium==3.8.0
+setuptools==49.6.0
 singledispatch==3.4.0.3
 six==1.11.0
 texttable==0.9.1


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It fixed the version of setuptools

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
There is an issue on the new 50.x.x versions that break virtualenv

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/906
