### PR TITLE
[CI] fixes No artifacts found

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
             always {
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
-                testResults: "${BASE_DIR}/**/*junit.xml")
+                testResults: "${BASE_DIR}/tests/results/*junit.xml")
             }
           }
         }
@@ -152,7 +152,7 @@ def runJob(testName, buildOpts = ''){
     catchError(buildResult: 'SUCCESS', message: "Aggregate test results from dowsntream job has failed failed. Let's keep moving.") {
       dir(testName) {
         copyArtifacts(projectName: jobName, selector: specific(buildNumber: buildObject.number.toString()))
-        junit(testResults: '**/tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
+        junit(testResults: 'tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
       }
     }
   }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -219,10 +219,10 @@ def wrappingup(label){
   dir("${BASE_DIR}"){
     dockerLogs(step: label, failNever: true)
     sh('make stop-env || echo 0')
-    def testResultsPattern = '**/tests/results/*-junit*.xml'
+    def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: "**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json,${testResultsPattern}",
+        artifacts: "tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
     junit(testResults: testResultsPattern, allowEmptyResults: true, keepLongStdio: true)
     // Let's generate the debug report ...

--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -257,12 +257,12 @@ def grabResultsAndLogs(label){
       sh('.ci/scripts/remove_env.sh docker-info')
       archiveArtifacts(
           allowEmptyArchive: true,
-          artifacts: '**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
+          artifacts: 'tests/results/data-*.json,tests/results/packetbeat-*.json',
           defaultExcludes: false)
       junit(
         allowEmptyResults: true,
         keepLongStdio: true,
-        testResults: "**/tests/results/*-junit*.xml")
+        testResults: "tests/results/*-junit*.xml")
     }
   }
 }

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -273,12 +273,12 @@ def grabResultsAndLogs(label){
       sh('.ci/scripts/remove_env.sh docker-info')
       archiveArtifacts(
           allowEmptyArchive: true,
-          artifacts: '**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json',
+          artifacts: 'tests/results/data-*.json,tests/results/packetbeat-*.json',
           defaultExcludes: false)
       junit(
         allowEmptyResults: true,
         keepLongStdio: true,
-        testResults: "**/tests/results/*-junit*.xml")
+        testResults: "tests/results/*-junit*.xml")
     }
   }
 }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -219,10 +219,10 @@ def wrappingup(Map params = [:]){
   dir("${BASE_DIR}"){
     dockerLogs(step: "${env.NAME}", failNever: true)
     sh('make stop-env || echo 0')
-    def testResultsPattern = '**/tests/results/*-junit*.xml'
+    def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: "**/tests/results/data-*.json,,**/tests/results/packetbeat-*.json,${testResultsPattern}",
+        artifacts: "tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
     if (isJunit) {
       junit(allowEmptyResults: true, keepLongStdio: true, testResults: testResultsPattern)


### PR DESCRIPTION
## What does this PR do?

Avoid wildcards since the location of those artifacts/test-results is always  stored in the top-level `tests` folder. See the variable `JUNIT_RESULTS_DIR` in the Makefile:

https://github.com/elastic/apm-integration-testing/blob/8459767ed201d76b1955ce8edb2d2aaa6de8af8d/Makefile#L8-L9
 
## Why is it important?

Avoid any misleading stacktraces when archiving files with wildcards in workspaces that are too big.

## Related issues
Closes #905