### PR TITLE
fix: filter 6.x-v1 tag and other branches

### DIFF
--- a/.ci/jobs/apm-integration-tests.yml
+++ b/.ci/jobs/apm-integration-tests.yml
@@ -11,6 +11,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
+        head-filter-regex: '(master|PR-.*|\d+\.x)'
         discover-tags: true
         notification-context: 'apm-ci'
         repo: apm-integration-testing

--- a/.ci/jobs/apm-it-ec.yml
+++ b/.ci/jobs/apm-it-ec.yml
@@ -11,6 +11,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
+        head-filter-regex: '(master|PR-.*|\d+\.x)'
         discover-tags: true
         notification-context: 'apm-it-ec'
         property-strategies:

--- a/.ci/jobs/apm-it-eck.yml
+++ b/.ci/jobs/apm-it-eck.yml
@@ -11,6 +11,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
+        head-filter-regex: '(master|PR-.*|\d+\.x)'
         discover-tags: true
         notification-context: 'apm-it-eck'
         property-strategies:


### PR DESCRIPTION
Co-Authored-By: Vignesh Shanmugam <vignesh.shanmugam22@gmail.com>

## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It limited the branches/tags/PRs that can be build.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The 6.x-v1 tag is no longer supported and we want to build only main branches/PRs/tags
