### PR TITLE
fix: use a Opbeans-go fixed version

### DIFF
--- a/.ci/scripts/7.0-upgrade.sh
+++ b/.ci/scripts/7.0-upgrade.sh
@@ -5,7 +5,7 @@ test -z "$srcdir" && srcdir=.
 # shellcheck source=/dev/null
 . "${srcdir}/common.sh"
 
-docker build --build-arg GO_AGENT_BRANCH=v1.5.0 -t localtesting_6.6.2_opbeans-go docker/opbeans/go
+docker build --build-arg GO_AGENT_BRANCH=v1.6.0 --build-arg OPBEANS_GO_BRANCH=v1.6.0 -t localtesting_6.6.2_opbeans-go docker/opbeans/go
 docker build --build-arg JAVA_AGENT_VERSION=v1.10.0 -t localtesting_6.6.2_opbeans-java docker/opbeans/java
 docker build --build-arg PYTHON_AGENT_VERSION=v5.2.1 -t localtesting_6.6.2_opbeans-python docker/opbeans/python
 docker build --build-arg NODE_AGENT_VERSION=v3.0.0 -t localtesting_6.6.2_opbeans-node docker/opbeans/node


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It fixes the Opbeans-go version and update the APM Agent Go version to 1.6.0

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

A change on the Opbeans master breaks the compilation of the Opbeans with version v1.5.0 of the APM Agent.
