### PR TITLE
[7.x] fix: use Node.js LTS version for ITs (#921)

### DIFF
--- a/docker/nodejs/express/Dockerfile
+++ b/docker/nodejs/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12.18.1
 
 RUN mkdir -p /app
 RUN npm install express


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: use Node.js LTS version for ITs (#921)