### PR TITLE
fix: add the parameter repoUrl it is needed by maven-dependency-plugin

### DIFF
--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -21,6 +21,7 @@ else
   mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       -Dhttps.protocols=TLSv1.2 \
+      -DrepoUrl=https://repo1.maven.apache.org/maven2 \
       -Dmaven.wagon.http.retryHandler.count=3 \
       -Dhttp.keepAlive=false \
       -Dartifact="co.elastic.apm:${ARTIFACT_ID}:${JAVA_AGENT_BUILT_VERSION}"


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it adds the repoUrl parameter to the maven-dependency-plugin command

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
fix regression on the ITs, this parameter is needed

## Related issues
related to https://github.com/elastic/apm-integration-testing/pull/927/files
