### PR TITLE
Support ubi8 docker images

### DIFF
--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -15,6 +15,8 @@ class Logstash(StackService, Service):
         image = self.docker_name
         if self.oss:
             image += "-oss"
+        if self.ubi8:
+            image += "-ubi8"
         key = "{image}-{version}-docker-image.tar.gz".format(
             image=image,
             version=version,

--- a/scripts/modules/beats.py
+++ b/scripts/modules/beats.py
@@ -95,6 +95,8 @@ class BeatMixin(object):
         image = self.docker_name
         if self.oss:
             image += "-oss"
+        if self.ubi8:
+            image += "-ubi8"
 
         key = "{image}-{version}-docker-image.tar.gz".format(
             image=image,

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -169,6 +169,8 @@ class LocalSetup(object):
 
         self.args = parser.parse_args(argv)
 
+        self.validate_options(self.args, parser)
+
         # py3
         if not hasattr(self.args, "func"):
             parser.error("command required")
@@ -495,6 +497,13 @@ class LocalSetup(object):
         for subparsers_action in subparsers_actions:
             for choice, subparser in subparsers_action.choices.items():
                 self.available_options.add(choice)
+
+    def validate_options(self, args, parser):
+        """
+        Helper method to validate if certain options are compatible or not.
+        """
+        if hasattr(self.args, "oss") and hasattr(self.args, "ubi8") and args.oss and args.ubi8:
+            parser.error("oss and ubi8 options are incompatible. Choose one of them instead.")
 
     #
     # handlers

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -341,6 +341,14 @@ class LocalSetup(object):
         )
 
         parser.add_argument(
+            '--ubi8',
+            action='store_true',
+            help='use ubi8 container images',
+            dest='ubi8',
+            default=False,
+        )
+
+        parser.add_argument(
             "--apm-server-url",
             action="store",
             help="apm server url to use for all clients",

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -425,6 +425,8 @@ class ApmServer(StackService, Service):
         image = self.docker_name
         if self.oss:
             image += "-oss"
+        if self.ubi8:
+            image += "-ubi8"
 
         key = "{image}-{version}-docker-image.tar.gz".format(
             image=image,
@@ -480,7 +482,11 @@ class ApmServer(StackService, Service):
             build_spec_parts = self.build.split("@", 1)
             repo = build_spec_parts[0]
             branch = build_spec_parts[1] if len(build_spec_parts) > 1 else "master"
-            binary = "apm-server-oss" if self.oss else "apm-server"
+            binary = "apm-server"
+            if self.oss:
+                binary = "apm-server-oss"
+            if self.ubi8:
+                binary = "apm-server-ubi8"
             content.update({
                 "build": {
                     "context": "docker/apm-server",

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -482,11 +482,7 @@ class ApmServer(StackService, Service):
             build_spec_parts = self.build.split("@", 1)
             repo = build_spec_parts[0]
             branch = build_spec_parts[1] if len(build_spec_parts) > 1 else "master"
-            binary = "apm-server"
-            if self.oss:
-                binary = "apm-server-oss"
-            if self.ubi8:
-                binary = "apm-server-ubi8"
+            binary = "apm-server-oss" if self.oss else "apm-server"
             content.update({
                 "build": {
                     "context": "docker/apm-server",

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -38,6 +38,7 @@ class Service(object):
         self._oss = options.get(self.option_name() + "_oss") or options.get("oss")
         self._release = options.get(self.option_name() + "_release") or options.get("release")
         self._snapshot = options.get(self.option_name() + "_snapshot") or options.get("snapshot")
+        self._ubi8 = options.get(self.option_name() + "_ubi8") or options.get("ubi8")
 
         # version is service specific or stack or default
         self._version = options.get(self.option_name() + "_version") or options.get("version", DEFAULT_STACK_VERSION)
@@ -69,6 +70,8 @@ class Service(object):
         image = "/".join((self.docker_registry, self.docker_path, self.docker_name))
         if self.oss:
             image += "-oss"
+        if self.ubi8:
+            image += "-ubi8"
         image += ":" + (version_override or self.version)
         # no command line option for setting snapshot, snapshot == no bc and not release
         if self.snapshot or not (any((self.bc, self.release))):
@@ -106,6 +109,10 @@ class Service(object):
     @property
     def oss(self):
         return self._oss
+
+    @property
+    def ubi8(self):
+        return self._ubi8
 
     @staticmethod
     def publish_port(external, internal=None, expose=False):
@@ -175,6 +182,8 @@ class StackService(object):
         image = self.docker_name
         if self.oss:
             image += "-oss"
+        if self.ubi8:
+            image += "-ubi8"
         key = "{image}-{version}-docker-image.tar.gz".format(
             image=image,
             version=version,
@@ -205,7 +214,7 @@ class StackService(object):
                 dest=cls.option_name() + "_" + image_detail_key,
                 help="stack {} override".format(image_detail_key),
             )
-        for image_detail_key in ("oss", "release", "snapshot"):
+        for image_detail_key in ("oss", "release", "snapshot", "ubi8"):
             parser.add_argument(
                 "--" + cls.name() + "-" + image_detail_key,
                 action="store_true",

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -440,6 +440,12 @@ class ApmServerServiceTest(ServiceTest):
             apm_server["image"], "docker.elastic.co/apm/apm-server-oss:6.3.100"
         )
 
+    def test_ubi8_snapshot(self):
+        apm_server = ApmServer(version="8.0.0", ubi8=True, snapshot=True).render()["apm-server"]
+        self.assertEqual(
+            apm_server["image"], "docker.elastic.co/apm/apm-server-ubi8:8.0.0-SNAPSHOT"
+        )
+
     def test_api_key_auth(self):
         apm_server = ApmServer(version="7.6.100", apm_server_api_key_auth=True).render()["apm-server"]
         self.assertIn("apm-server.api_key.enabled=true", apm_server["command"])
@@ -721,6 +727,16 @@ class ApmServerServiceTest(ServiceTest):
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
 
+    def test_apm_server_build_ubi8(self):
+        apm_server = ApmServer(version="7.9.2", apm_server_build="foo.git", release=True, ubi8=True).render()["apm-server"]
+        self.assertIsNone(apm_server.get("image"))
+        self.assertDictEqual(apm_server["build"], {
+            'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server-ubi8:7.9.2',
+                     'apm_server_binary': 'apm-server-ubi8',
+                     'apm_server_branch_or_commit': 'master',
+                     'apm_server_repo': 'foo.git'},
+            'context': 'docker/apm-server'})
+
     def test_apm_server_count(self):
         render = ApmServer(version="6.4.100", apm_server_count=2).render()
         apm_server_lb = render["apm-server"]
@@ -835,6 +851,16 @@ class ElasticsearchServiceTest(ServiceTest):
             elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4"
         )
         self.assertFalse(
+            any(e.startswith("xpack.security.enabled=") for e in elasticsearch["environment"]),
+            "xpack.security.enabled set while oss"
+        )
+
+    def test_7_10_ubi8_release(self):
+        elasticsearch = Elasticsearch(version="7.10.0", ubi8=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch-ubi8:7.10.0"
+        )
+        self.assertTrue(
             any(e.startswith("xpack.security.enabled=") for e in elasticsearch["environment"]),
             "xpack.security.enabled set while oss"
         )
@@ -1090,6 +1116,10 @@ class KibanaServiceTest(ServiceTest):
     def test_kibana_snapshot(self):
         kibana = Kibana(version="7.3.0", kibana_snapshot=True, kibana_version="7.3.0").render()["kibana"]
         self.assertEqual("docker.elastic.co/kibana/kibana:7.3.0-SNAPSHOT", kibana["image"])
+
+    def test_kibana_ubi8(self):
+        kibana = Kibana(version="7.10.0", release=True, kibana_ubi8=True, kibana_version="7.10.0").render()["kibana"]
+        self.assertEqual("docker.elastic.co/kibana/kibana-ubi8:7.10.0", kibana["image"])
 
     def test_kibana_login_assistance_message(self):
         kibana = Kibana(version="7.6.0", xpack_secure=True, kibana_version="7.6.0").render()["kibana"]

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -732,7 +732,7 @@ class ApmServerServiceTest(ServiceTest):
         self.assertIsNone(apm_server.get("image"))
         self.assertDictEqual(apm_server["build"], {
             'args': {'apm_server_base_image': 'docker.elastic.co/apm/apm-server-ubi8:7.9.2',
-                     'apm_server_binary': 'apm-server-ubi8',
+                     'apm_server_binary': 'apm-server',
                      'apm_server_branch_or_commit': 'master',
                      'apm_server_repo': 'foo.git'},
             'context': 'docker/apm-server'})
@@ -1211,6 +1211,9 @@ class LogstashServiceTest(ServiceTest):
         self.assertTrue("elasticsearch" in logstash['depends_on'])
         self.assertEqual("elasticsearch01:9200,elasticsearch02:9200", logstash['environment']["ELASTICSEARCH_URL"])
 
+    def test_logstash_ubi8(self):
+        logstash = Logstash(version="7.10.0", release=True, ubi8=True).render()["logstash"]
+        self.assertEqual("docker.elastic.co/logstash/logstash-ubi8:7.10.0", logstash['image'])
 
 class MetricbeatServiceTest(ServiceTest):
     def test_metricbeat(self):

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,3 +1,4 @@
 APM_SERVER:
   - master
   - master --oss
+  - master --ubi8


### PR DESCRIPTION
## What does this PR do?

Add `--ubi8` option to use ubi8 docker images. Verify `--oss` and `--ubi8` options are not enabled at the same time.

## Why is it important?

Support the ITs with the ubi8 minimal docker images locally and also in the CI as part of the compatibility matrix.

## Related issues

Closes https://github.com/elastic/apm-integration-testing/issues/900

## Tests

- locally
```bash
$ BUILD_OPTS="--ubi8" ELASTIC_STACK_VERSION="8.0.0" .ci/scripts/go.sh
$ grep 'ubi8' docker-compose.yml 
      "image": "docker.elastic.co/apm/apm-server-ubi8:8.0.0-SNAPSHOT",
      "image": "docker.elastic.co/elasticsearch/elasticsearch-ubi8:8.0.0-SNAPSHOT",
$ docker ps
CONTAINER ID        IMAGE                                                               COMMAND                  CREATED             STATUS                            PORTS                                                                                                        NAMES
f4378529d269        docker.elastic.co/apm/apm-server-ubi8:8.0.0-SNAPSHOT                "/usr/local/bin/dock…"   9 seconds ago       Up 8 seconds (health: starting)   127.0.0.1:6060->6060/tcp, 127.0.0.1:8200->8200/tcp, 127.0.0.1:14250->14250/tcp, 127.0.0.1:14268->14268/tcp   localtesting_8.0.0_apm-server
a78a0dbc8094        docker.elastic.co/elasticsearch/elasticsearch-ubi8:8.0.0-SNAPSHOT   "/tini -- /usr/local…"   40 seconds ago      Up 39 seconds (healthy)           127.0.0.1:9200->9200/tcp, 9300/tcp                                                                           localtesting_8.0.0_elasticsearch

```

- in the CI i forced the build [see here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-test-downstream/detail/PR-931/4/pipeline)