### PR TITLE
fix: bump go version

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.13
+ARG go_version=1.14
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It bumps the Go version used to compile the APM Server.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The master branch does not compile with Go 1.13 anymore.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/932
