### PR TITLE
fix: use Elasticsearch https when is enabled

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -774,9 +774,10 @@ class Kibana(StackService, Service):
         self.environment = self.default_environment.copy()
 
         self.kibana_tls = self.options.get("kibana_enable_tls", False)
-        default_es_hosts = self.default_elasticsearch_hosts(tls=self.kibana_tls)
+        self.es_tls = options.get("elasticsearch_enable_tls", False)
+        default_es_hosts = self.default_elasticsearch_hosts(tls=self.es_tls)
         urls = self.options.get("kibana_elasticsearch_urls") or [default_es_hosts]
-        self.environment["ELASTICSEARCH_URL"] = ",".join(urls)
+        self.environment["ELASTICSEARCH_HOSTS"] = ",".join(urls)
 
         if not self.oss:
             self.environment["XPACK_MONITORING_ENABLED"] = "true"
@@ -807,7 +808,6 @@ class Kibana(StackService, Service):
                 self.environment["SERVER_SSL_CERTIFICATE"] = certs
                 self.environment["SERVER_SSL_KEY"] = certsKey
                 self.environment["ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES"] = caCerts
-                self.environment["ELASTICSEARCH_HOSTS"] = ",".join(urls)
             else:
                 if self.at_least_version("7.9"):
                     self.environment["XPACK_INGESTMANAGER_FLEET_TLSCHECKDISABLED"] = "true"

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -14,7 +14,7 @@ DEFAULT_SERVICE_VERSION = "9c2e41c8-fb2f-4b75-a89d-5089fb55fc64"
 class Service(object):
     """encapsulate docker-compose service definition"""
 
-    DEFAULT_ELASTICSEARCH_HOSTS = "elasticsearch:9200"
+    DEFAULT_ELASTICSEARCH_HOSTS = "http://elasticsearch:9200"
     DEFAULT_ELASTICSEARCH_HOSTS_TLS = "https://elasticsearch:9200"
     DEFAULT_KIBANA_HOST = "kibana:5601"
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -71,7 +71,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_FLUSH_INTERVAL=5
                       - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                       - ELASTIC_APM_TRANSACTION_SAMPLE_RATE=1
-                      - ELASTICSEARCH_URL=elasticsearch:9200
+                      - ELASTICSEARCH_URL=http://elasticsearch:9200
                       - OPBEANS_DT_PROBABILITY=0.50
                       - ELASTIC_APM_ENVIRONMENT=production
                     logging:
@@ -130,7 +130,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_FLUSH_INTERVAL=5
                       - ELASTIC_APM_TRANSACTION_MAX_SPANS=50
                       - ELASTIC_APM_TRANSACTION_SAMPLE_RATE=1
-                      - ELASTICSEARCH_URL=elasticsearch:9200
+                      - ELASTICSEARCH_URL=http://elasticsearch:9200
                       - OPBEANS_CACHE=redis://redis:6379
                       - OPBEANS_PORT=3000
                       - PGHOST=postgres
@@ -196,7 +196,7 @@ class OpbeansServiceTest(ServiceTest):
                       - DATABASE_DIALECT=POSTGRESQL
                       - DATABASE_DRIVER=org.postgresql.Driver
                       - REDIS_URL=redis://redis:6379
-                      - ELASTICSEARCH_URL=elasticsearch:9200
+                      - ELASTICSEARCH_URL=http://elasticsearch:9200
                       - OPBEANS_SERVER_PORT=3000
                       - JAVA_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
@@ -341,7 +341,7 @@ class OpbeansServiceTest(ServiceTest):
                         - ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES
                         - ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES
                         - REDIS_URL=redis://redis:6379
-                        - ELASTICSEARCH_URL=elasticsearch:9200
+                        - ELASTICSEARCH_URL=http://elasticsearch:9200
                         - OPBEANS_SERVER_URL=http://opbeans-python:3000
                         - PYTHON_AGENT_BRANCH=
                         - PYTHON_AGENT_REPO=
@@ -421,7 +421,7 @@ class OpbeansServiceTest(ServiceTest):
                       - ELASTIC_APM_VERIFY_SERVER_CERT=true
                       - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans-ruby
                       - REDIS_URL=redis://redis:6379
-                      - ELASTICSEARCH_URL=elasticsearch:9200
+                      - ELASTICSEARCH_URL=http://elasticsearch:9200
                       - OPBEANS_SERVER_URL=http://opbeans-ruby:3000
                       - RAILS_ENV=production
                       - RAILS_LOG_TO_STDOUT=1
@@ -683,7 +683,7 @@ class LocalTest(unittest.TestCase):
                     -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true, -E, setup.dashboards.enabled=true,
-                    -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true]
+                    -E, 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', -E, output.elasticsearch.enabled=true]
                 container_name: localtesting_6.2.10_apm-server
                 depends_on:
                     elasticsearch: {condition: service_healthy}
@@ -723,7 +723,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_6.2.10_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
+                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -764,7 +764,7 @@ class LocalTest(unittest.TestCase):
                     -E, setup.template.settings.index.number_of_replicas=0,
                     -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true, -E, setup.dashboards.enabled=true,
-                    -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]', -E, output.elasticsearch.enabled=true ]
+                    -E, 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', -E, output.elasticsearch.enabled=true ]
                 container_name: localtesting_6.3.10_apm-server
                 depends_on:
                     elasticsearch: {condition: service_healthy}
@@ -808,7 +808,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_6.3.10_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_URL: 'elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
+                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -864,7 +864,7 @@ class LocalTest(unittest.TestCase):
                     -E, apm-server.kibana.username=apm_server_user, -E, apm-server.kibana.password=changeme,
                     -E, apm-server.jaeger.http.enabled=true, -E, "apm-server.jaeger.http.host=0.0.0.0:14268",
                     -E, apm-server.jaeger.grpc.enabled=true, -E, "apm-server.jaeger.grpc.host=0.0.0.0:14250",
-                    -E, 'output.elasticsearch.hosts=["elasticsearch:9200"]',
+                    -E, 'output.elasticsearch.hosts=["http://elasticsearch:9200"]',
                     -E, output.elasticsearch.username=apm_server_user, -E, output.elasticsearch.password=changeme,
                     -E, output.elasticsearch.enabled=true,
                     -E, "output.elasticsearch.pipelines=[{pipeline: 'apm'}]", -E, 'apm-server.register.ingest.pipeline.enabled=true'
@@ -936,7 +936,7 @@ class LocalTest(unittest.TestCase):
                     elasticsearch: {condition: service_healthy}
                 environment: {
                     ELASTICSEARCH_PASSWORD: changeme,
-                    ELASTICSEARCH_URL: 'elasticsearch:9200',
+                    ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200',
                     ELASTICSEARCH_USERNAME: kibana_system_user,
                     SERVER_NAME: kibana.example.org,
                     STATUS_ALLOWANONYMOUS: 'true',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -462,7 +462,7 @@ class ApmServerServiceTest(ServiceTest):
         )
         self.assertTrue("elasticsearch" in apm_server["depends_on"])
         self.assertTrue("kibana" in apm_server["depends_on"])
-        self.assertTrue("output.elasticsearch.hosts=[\"elasticsearch:9200\"]" in apm_server["command"])
+        self.assertTrue("output.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in apm_server["command"])
 
     def test_elasticsearch_output_overrides(self):
         apm_server = ApmServer(version="6.3.100", apm_server_output="elasticsearch",
@@ -515,7 +515,7 @@ class ApmServerServiceTest(ServiceTest):
             "output.elasticsearch.enabled=false",
             "output.file.enabled=true",
             "output.file.path=" + os.devnull,
-            "monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+            "monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]",
         ]
         for o in options:
             self.assertTrue(o in apm_server["command"], "{} not set while output=file".format(o))
@@ -523,17 +523,17 @@ class ApmServerServiceTest(ServiceTest):
     def test_monitoring_options_6(self):
         apm_server = ApmServer(version="6.8.0", apm_server_output="file").render()["apm-server"]
         self.assertTrue("xpack.monitoring.enabled=true" in apm_server["command"])
-        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in apm_server["command"])
+        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in apm_server["command"])
 
     def test_monitoring_options_71(self):
         apm_server = ApmServer(version="7.1.0", apm_server_output="file").render()["apm-server"]
         self.assertTrue("xpack.monitoring.enabled=true" in apm_server["command"])
-        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in apm_server["command"])
+        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in apm_server["command"])
 
     def test_monitoring_options_post_72(self):
         apm_server = ApmServer(version="7.2.0", apm_server_output="file").render()["apm-server"]
         self.assertTrue("monitoring.enabled=true" in apm_server["command"])
-        self.assertTrue("monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in apm_server["command"])
+        self.assertTrue("monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in apm_server["command"])
 
     def test_file_output_path(self):
         apm_server = ApmServer(version="7.3.100", apm_server_output="file",
@@ -542,7 +542,7 @@ class ApmServerServiceTest(ServiceTest):
             "output.elasticsearch.enabled=false",
             "output.file.enabled=true",
             "output.file.path=foo",
-            "monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+            "monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]",
         ]
         for o in options:
             self.assertTrue(o in apm_server["command"], "{} not set while output=file".format(o))
@@ -553,7 +553,7 @@ class ApmServerServiceTest(ServiceTest):
             "output.elasticsearch.enabled=false",
             "output.logstash.enabled=true",
             "output.logstash.hosts=[\"logstash:5044\"]",
-            "monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+            "monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]",
         ]
         for o in options:
             self.assertTrue(o in apm_server["command"], "{} not set while output=logstash".format(o))
@@ -577,7 +577,7 @@ class ApmServerServiceTest(ServiceTest):
     def test_kafka_output(self):
         apm_server = ApmServer(version="6.3.100", apm_server_output="kafka").render()["apm-server"]
         self.assertTrue(
-            "xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in apm_server["command"],
+            "xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in apm_server["command"],
             "xpack.monitoring.elasticsearch.hosts not set while output=kafka"
         )
         self.assertTrue(
@@ -922,7 +922,7 @@ class FilebeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/filebeat:6.0.4
                     container_name: localtesting_6.0.4_filebeat
                     user: root
-                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
+                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -949,7 +949,7 @@ class FilebeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/filebeat:6.1.1
                     container_name: localtesting_6.1.1_filebeat
                     user: root
-                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
+                    command: ["filebeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'
@@ -1003,7 +1003,7 @@ class FilebeatServiceTest(ServiceTest):
             "output.elasticsearch.enabled=false",
             "output.logstash.enabled=true",
             "output.logstash.hosts=[\"logstash:5044\"]",
-            "xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+            "xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]",
         ]
         for o in options:
             self.assertTrue(o in beat["command"], "{} not set in {} while output=logstash".format(o, beat["command"]))
@@ -1040,7 +1040,7 @@ class KibanaServiceTest(ServiceTest):
                     container_name: localtesting_6.2.4_kibana
                     environment:
                         SERVER_NAME: kibana.example.org
-                        ELASTICSEARCH_URL: elasticsearch:9200
+                        ELASTICSEARCH_HOSTS: http://elasticsearch:9200
                         XPACK_MONITORING_ENABLED: 'true'
                     ports:
                         - "127.0.0.1:5601:5601"
@@ -1069,7 +1069,7 @@ class KibanaServiceTest(ServiceTest):
                     container_name: localtesting_6.3.5_kibana
                     environment:
                         SERVER_NAME: kibana.example.org
-                        ELASTICSEARCH_URL: elasticsearch:9200
+                        ELASTICSEARCH_HOSTS: http://elasticsearch:9200
                         XPACK_MONITORING_ENABLED: 'true'
                         XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'
                     ports:
@@ -1094,12 +1094,12 @@ class KibanaServiceTest(ServiceTest):
         kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=[
                         "elasticsearch01:9200"]).render()["kibana"]
         self.assertTrue("elasticsearch" in kibana['depends_on'])
-        self.assertEqual("elasticsearch01:9200", kibana['environment']["ELASTICSEARCH_URL"])
+        self.assertEqual("elasticsearch01:9200", kibana['environment']["ELASTICSEARCH_HOSTS"])
 
         kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=[
                         "elasticsearch01:9200", "elasticsearch02:9200"]).render()["kibana"]
         self.assertTrue("elasticsearch" in kibana['depends_on'])
-        self.assertEqual("elasticsearch01:9200,elasticsearch02:9200", kibana['environment']["ELASTICSEARCH_URL"])
+        self.assertEqual("elasticsearch01:9200,elasticsearch02:9200", kibana['environment']["ELASTICSEARCH_HOSTS"])
 
     def test_kibana_port(self):
         kibana = Kibana(version="7.3.0", release=True, kibana_port="1234").render()["kibana"]
@@ -1167,7 +1167,7 @@ class LogstashServiceTest(ServiceTest):
             container_name: localtesting_6.3.0_logstash
             depends_on:
                 elasticsearch: {condition: service_healthy}
-            environment: {ELASTICSEARCH_URL: 'elasticsearch:9200'}
+            environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200'}
             healthcheck:
                 test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://logstash:9600/"]
                 interval: 10s
@@ -1224,7 +1224,7 @@ class MetricbeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/metricbeat:7.2.0
                     container_name: localtesting_7.2.0_metricbeat
                     user: root
-                    command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
+                    command: ["metricbeat", "-e", "--strict.perms=false", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {APM_SERVER_PPROF_HOST: 'apm-server:6060'}
                     logging:
                         driver: 'json-file'
@@ -1248,7 +1248,7 @@ class MetricbeatServiceTest(ServiceTest):
             "output.elasticsearch.enabled=false",
             "output.logstash.enabled=true",
             "output.logstash.hosts=[\"logstash:5044\"]",
-            "xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]",
+            "xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]",
         ]
         for o in options:
             self.assertTrue(o in beat["command"], "{} not set in {} while output=logstash".format(o, beat["command"]))
@@ -1278,19 +1278,19 @@ class MetricbeatServiceTest(ServiceTest):
 
     def test_config_6(self):
         beat = Metricbeat(version="6.8.0", release=True, metricbeat_output="logstash").render()["metricbeat"]
-        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in beat["command"])
+        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in beat["command"])
         self.assertTrue(
             "./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
 
     def test_config_71(self):
         beat = Metricbeat(version="7.1.0", release=True, metricbeat_output="logstash").render()["metricbeat"]
-        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in beat["command"])
+        self.assertTrue("xpack.monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in beat["command"])
         self.assertTrue(
             "./docker/metricbeat/metricbeat.6.x-compat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
 
     def test_config_post_72(self):
         beat = Metricbeat(version="7.2.0", release=True, metricbeat_output="logstash").render()["metricbeat"]
-        self.assertTrue("monitoring.elasticsearch.hosts=[\"elasticsearch:9200\"]" in beat["command"])
+        self.assertTrue("monitoring.elasticsearch.hosts=[\"http://elasticsearch:9200\"]" in beat["command"])
         self.assertTrue("./docker/metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml" in beat["volumes"])
 
 
@@ -1303,7 +1303,7 @@ class PacketbeatServiceTest(ServiceTest):
                     image: docker.elastic.co/beats/packetbeat:7.3.0
                     container_name: localtesting_7.3.0_packetbeat
                     user: root
-                    command: ["packetbeat", "-e", "--strict.perms=false", "-E", "packetbeat.interfaces.device=eth0", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
+                    command: ["packetbeat", "-e", "--strict.perms=false", "-E", "packetbeat.interfaces.device=eth0", "-E", "setup.dashboards.enabled=true", "-E", 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', "-E", "output.elasticsearch.enabled=true"]
                     environment: {}
                     logging:
                         driver: 'json-file'


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Enable https connections to Elasticsearch only if `--elasticsearch-enable-tls` is enabled.
* Use only `ELASTICSEARCH_HOSTS` on Kibana
* Fix tests

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/920
