### PR TITLE
[7.x] fix: bump go version (#933)

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.13
+ARG go_version=1.14
 
 FROM golang:${go_version} AS build
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: bump go version (#933)