### PR TITLE
update setting in version 7.10

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -807,7 +807,9 @@ class Kibana(StackService, Service):
                 self.environment["ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES"] = caCerts
                 self.environment["ELASTICSEARCH_HOSTS"] = ",".join(urls)
             else:
-                if self.at_least_version("7.9"):
+                if self.at_least_version("7.10"):
+                    self.environment["XPACK_FLEET_AGENTS_TLSCHECKDISABLED"] = "true"
+                elif self.at_least_version("7.9"):
                     self.environment["XPACK_INGESTMANAGER_FLEET_TLSCHECKDISABLED"] = "true"
 
     @classmethod

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -945,7 +945,7 @@ class LocalTest(unittest.TestCase):
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_SECURITY_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
                     XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
-                    XPACK_INGESTMANAGER_FLEET_TLSCHECKDISABLED: 'true',
+                    XPACK_FLEET_AGENTS_TLSCHECKDISABLED: 'true',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
                     XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'
                 }


### PR DESCRIPTION
## What does this PR do?

Fleet settings have been moved in 7.10, see https://www.elastic.co/guide/en/kibana/7.10/fleet-settings-kb.html

This updates the one we use.
