### PR TITLE
add --kibana-yml option

### DIFF
--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -1,0 +1,7 @@
+#server.name: kibana
+server.host: "0"
+#elasticsearch.hosts: [ "http://elasticsearch:9200" ]
+monitoring.ui.container.elasticsearch.enabled: true
+
+elastic.apm.active: true
+elastic.apm.serverUrl: "http://apm-server:8200"

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -775,6 +775,7 @@ class Kibana(StackService, Service):
 
         self.kibana_tls = self.options.get("kibana_enable_tls", False)
         self.es_tls = options.get("elasticsearch_enable_tls", False)
+        self.kibana_yml = options.get("kibana_yml")
         default_es_hosts = self.default_elasticsearch_hosts(tls=self.es_tls)
         urls = self.options.get("kibana_elasticsearch_urls") or [default_es_hosts]
         self.environment["ELASTICSEARCH_HOSTS"] = ",".join(urls)
@@ -831,6 +832,13 @@ class Kibana(StackService, Service):
         )
 
         parser.add_argument(
+            '--kibana-yml',
+            const="./docker/kibana/kibana.yml",
+            nargs="?",
+            help='override kibana.yml'
+        )
+
+        parser.add_argument(
             "--no-kibana-apm-servicemaps",
             action="store_true",
             help="disable the APM service maps UI",
@@ -844,6 +852,9 @@ class Kibana(StackService, Service):
                 "./scripts/tls/kibana/kibana.key:/usr/share/kibana/config/certs/tls.key",
                 "./scripts/tls/ca/ca.crt:/usr/share/kibana/config/certs/ca.crt"
             ])
+
+        if self.kibana_yml:
+            volumes.append("{}:/usr/share/kibana/config/kibana.yml".format(self.kibana_yml))
 
         content = dict(
             healthcheck=curl_healthcheck(

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1148,6 +1148,9 @@ class KibanaServiceTest(ServiceTest):
         self.assertIn("XPACK_SECURITY_ENCRYPTIONKEY", kibana['environment'])
         self.assertIn("XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY", kibana['environment'])
 
+    def test_kibana_yml(self):
+        kibana = Kibana(kibana_yml="/path/to.yml").render()["kibana"]
+        self.assertIn("/path/to.yml:/usr/share/kibana/config/kibana.yml", kibana['volumes'])
 
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):


### PR DESCRIPTION
with a kibana.yml that activates instrumentation

## What does this PR do?

enables use of a local kibana.yml file as the kibana configuration.  This is currently a workaround for enabling apm instrumentation in kibana since environment variable support is not available.

To use as is, run `./scripts/compose.py master --kibana-yml`.

`apm-server` will need to resolve to your apm-server from your browser in order to get frontend transactions - it's not currently possible to specify separate apm-servers for kibana's node and rum agents.  I've done this locally by updating `/etc/hosts` with:

```
# rum agent fun
127.0.0.1  apm-server
```