### PR TITLE
fix: change to use adoptOpenJDK to fix the build

### DIFF
--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -19,16 +19,14 @@ RUN cd /agent/apm-agent-java \
 COPY maven-package.sh /agent
 RUN ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"
 
-FROM openjdk:10-jre-slim
+FROM adoptopenjdk:11-jre-hotspot
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar /app
 RUN apt-get -qq update \
-  && apt-get -qq install -y curl \
+  && apt-get -qq install -y curl --no-install-recommends curl\
   && apt-get -qq clean \
   && rm -fr /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 8090
 ENV ELASTIC_APM_API_REQUEST_TIME 50ms
 CMD ["java", "-javaagent:/app/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.max_queue_size=2048", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","/app/target/hello-spring-0.1.jar"]
-
-

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -23,7 +23,7 @@ FROM adoptopenjdk:11-jre-hotspot
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar /app
 RUN apt-get -qq update \
-  && apt-get -qq install -y curl --no-install-recommends curl\
+  && apt-get -qq install -y --no-install-recommends curl \ 
   && apt-get -qq clean \
   && rm -fr /var/lib/apt/lists/*
 WORKDIR /app


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes to use AdoptOpenJDK Docker image to build the Agent Java test container.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
For some reason the OpenJDK:10-jre-slim stop to configure libc6:amd64 and this breaks the build. The. AdoptOpenJDK Docker image does not have this issue.

