### PR TITLE
[6.x] fix: change to use adoptOpenJDK to fix the build (#944)

### DIFF
--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -19,16 +19,14 @@ RUN cd /agent/apm-agent-java \
 COPY maven-package.sh /agent
 RUN ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"
 
-FROM openjdk:10-jre-slim
+FROM adoptopenjdk:11-jre-hotspot
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar /app
 RUN apt-get -qq update \
-  && apt-get -qq install -y curl \
+  && apt-get -qq install -y --no-install-recommends curl \
   && apt-get -qq clean \
   && rm -fr /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 8090
 ENV ELASTIC_APM_API_REQUEST_TIME 50ms
 CMD ["java", "-javaagent:/app/apm-agent.jar", "-Delastic.apm.service_name=springapp", "-Delastic.apm.application_packages=hello", "-Delastic.apm.ignore_urls=/healthcheck", "-jar","/app/target/hello-spring-0.1.jar"]
-
-


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix: change to use adoptOpenJDK to fix the build (#944)