### PR TITLE
[CI] selector and downstream use different commands

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -21,6 +21,10 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
     DISABLE_BUILD_PARALLEL = "${params.DISABLE_BUILD_PARALLEL}"
     ENABLE_ES_DUMP = "true"
+    NAME = agentMapping.id(params.INTEGRATION_TEST)
+    INTEGRATION_TEST = "${params.INTEGRATION_TEST}"
+    ELASTIC_STACK_VERSION = "${params.ELASTIC_STACK_VERSION}"
+    BUILD_OPTS = "${params.BUILD_OPTS}"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -82,14 +86,13 @@ pipeline {
         unstash "source"
         dir("${BASE_DIR}"){
           script {
-            def agentTests = agentMapping.id(params.INTEGRATION_TEST)
             integrationTestsGen = new IntegrationTestingParallelTaskGenerator(
-              xKey: agentMapping.agentVar(agentTests),
+              xKey: agentMapping.agentVar(env.NAME),
               yKey: agentMapping.agentVar('server'),
-              xFile: agentMapping.yamlVersionFile(agentTests),
+              xFile: agentMapping.yamlVersionFile(env.NAME),
               yFile: agentMapping.yamlVersionFile('server'),
-              exclusionFile: agentMapping.yamlVersionFile(agentTests),
-              tag: agentTests,
+              exclusionFile: agentMapping.yamlVersionFile(env.NAME),
+              tag: env.NAME,
               name: params.INTEGRATION_TEST,
               steps: this
               )

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -226,7 +226,7 @@ def wrappingup(label){
         defaultExcludes: false)
     junit(testResults: testResultsPattern, allowEmptyResults: true, keepLongStdio: true)
     // Let's generate the debug report ...
-    sh(label: 'Generate debug docs', script: '.ci/scripts/generate-debug-docs.sh | tee docs.txt')
+    sh(label: 'Generate debug docs', script: '.ci/scripts/generate-debug-docs.sh "downstream" | tee docs.txt')
     archiveArtifacts(artifacts: 'docs.txt')
   }
 }

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -229,7 +229,7 @@ def wrappingup(Map params = [:]){
       junit(allowEmptyResults: true, keepLongStdio: true, testResults: testResultsPattern)
     }
     // Let's generate the debug report ...
-    sh(label: 'Generate debug docs', script: ".ci/scripts/generate-debug-docs.sh | tee ${env.DETAILS_ARTIFACT}")
+    sh(label: 'Generate debug docs', script: ".ci/scripts/generate-debug-docs.sh 'selector' | tee ${env.DETAILS_ARTIFACT}")
     archiveArtifacts(artifacts: "${env.DETAILS_ARTIFACT}")
   }
 }

--- a/.ci/scripts/generate-debug-docs.sh
+++ b/.ci/scripts/generate-debug-docs.sh
@@ -18,16 +18,13 @@ echo ""
 echo "# Let's run the apm-integration testing for ${NAME}"
 echo "export ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION}"
 echo "export BUILD_OPTS=\"${BUILD_OPTS}\""
+SCRIPT_NAME=$(echo "${INTEGRATION_TEST}" | tr '[:upper:]' '[:lower:]')
 if [ "${TYPE}" == "selector" ] ; then
-    if [ "${INTEGRATION_TEST}" == "All" ] ; then
-        echo '.ci/scripts/ui.sh'
-    elif [ "${INTEGRATION_TEST}" == "Opbeans" ] ; then
-        echo ".ci/scripts/opbeans.sh"
-    elif [ "${INTEGRATION_TEST}" == "UI" ] ; then
-        echo ".ci/scripts/all.sh"
+    if [ "${SCRIPT_NAME}" == "all" ] || [ "${SCRIPT_NAME}" == "opbeans" ] || [ "${SCRIPT_NAME}" == "ui" ] ; then
+        echo ".ci/scripts/${SCRIPT_NAME}.sh"
     else
         echo ".ci/scripts/agent.sh ${NAME} ${APP}"
-        if [ "${INTEGRATION_TEST}" == "RUM" ] ; then
+        if [ "${SCRIPT_NAME}" == "rum" ] ; then
             echo "# Build docker image with the new rum agent"
             echo "git clone https://github.com/elastic/opbeans-frontend.git .opbeans-frontend"
             echo "cd .opbeans-frontend"

--- a/.ci/scripts/generate-debug-docs.sh
+++ b/.ci/scripts/generate-debug-docs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+TYPE=${1:-"selector"}
 gitUrl=$(git remote get-url origin)
 commit=$(git rev-parse HEAD)
 
@@ -13,10 +14,36 @@ echo "git clone ${gitUrl} .apm-its"
 echo "cd .apm-its"
 echo "git checkout ${commit}"
 echo ""
+
 echo "# Let's run the apm-integration testing for ${NAME}"
 echo "export ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION}"
-echo "export BUILD_OPTS=${BUILD_OPTS}"
-echo ".ci/scripts/${NAME}.sh"
+echo "export BUILD_OPTS=\"${BUILD_OPTS}\""
+if [ "${TYPE}" == "selector" ] ; then
+    if [ "${INTEGRATION_TEST}" == "All" ] ; then
+        echo '.ci/scripts/ui.sh'
+    elif [ "${INTEGRATION_TEST}" == "Opbeans" ] ; then
+        echo ".ci/scripts/opbeans.sh"
+    elif [ "${INTEGRATION_TEST}" == "UI" ] ; then
+        echo ".ci/scripts/all.sh"
+    else
+        echo ".ci/scripts/agent.sh ${NAME} ${APP}"
+        if [ "${INTEGRATION_TEST}" == "RUM" ] ; then
+            echo "# Build docker image with the new rum agent"
+            echo "git clone https://github.com/elastic/opbeans-frontend.git .opbeans-frontend"
+            echo "cd .opbeans-frontend"
+            echo "VERSION=\${BUILD_OPTS/--rum-agent-branch /}"
+            echo ".ci/bump-version.sh \${VERSION} false"
+            echo 'make build'
+            echo 'cd ..'
+            echo "# Run opbeans rum"
+            echo ".ci/scripts/opbeans-rum.sh"
+        else
+            echo ".ci/scripts/opbeans-app.sh ${NAME} ${APP} ${OPBEANS_APP}"
+        fi
+    fi
+else
+    echo ".ci/scripts/${NAME}.sh"
+fi
 echo ""
 echo "make stop-env || echo 'Failed to stop the environment'"
 echo ""


### PR DESCRIPTION
## What does this PR do?

Add test-selector commands to the generated docs.txt file.

## Why is it important?

Test-Selector and Test-Downstream pipelines use different commands, and there is a `docs.txt` file that reflects how to reproduce those CI steps locally

## Tests

- Downstream

[build](https://apm-ci.elastic.co/job/apm-integration-test-downstream/view/change-requests/job/PR-949/2/)

![image](https://user-images.githubusercontent.com/2871786/96739036-44413880-13b7-11eb-82ee-a19cbb44a4ee.png)

![image](https://user-images.githubusercontent.com/2871786/96739109-57ec9f00-13b7-11eb-96dc-848f09c29f19.png)

- Selector

[build](https://apm-ci.elastic.co/job/apm-integration-tests-selector-mbp/view/change-requests/job/PR-949/2/)

![image](https://user-images.githubusercontent.com/2871786/96739135-620e9d80-13b7-11eb-877d-63a57247fbdc.png)

![image](https://user-images.githubusercontent.com/2871786/96739186-6e92f600-13b7-11eb-998e-71c620b5e948.png)

