### PR TITLE
fix: remove APM Server kibana setting when you set --no-kibana

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -85,9 +85,9 @@ class ApmServer(StackService, Service):
         elif self.at_least_version("7.2") and not self.at_least_version("7.3") and not self.oss:
             self.apm_server_command_args.append(("apm-server.ilm.enabled", "true"))
 
-        if self.options.get("apm_server_acm_disable"):
+        if self.options.get("apm_server_acm_disable") or not self.options.get("enable_kibana", True):
             self.apm_server_command_args.append(("apm-server.kibana.enabled", "false"))
-        elif self.at_least_version("7.3"):
+        elif self.at_least_version("7.3") and self.options.get("enable_kibana", True):
             self.apm_server_command_args.extend([
                 ("apm-server.kibana.enabled", "true"),
                 ("apm-server.kibana.host", self.options.get("apm_server_kibana_url", self.DEFAULT_KIBANA_HOST))])


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Add a missing filter

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
before the change, the Kibana settings are always enabled.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/948
