### PR TITLE
[CI] Aggregate all the tests from all the stages

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -154,7 +154,7 @@ def runJob(testName, buildOpts = ''){
     catchError(buildResult: 'SUCCESS', message: "Aggregate test results from dowsntream job has failed failed. Let's keep moving.") {
       dir(testName) {
         copyArtifacts(projectName: jobName, selector: specific(buildNumber: buildObject.number.toString()))
-        junit(testResults: 'tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
+        junit(testResults: '**/tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Archive all the tests for all the stages rather than just the latest executed test.

## Why is it important?

To populate the test results to the parentstream, since it only populates one stage.

![image](https://user-images.githubusercontent.com/2871786/97427731-e5c30f80-190c-11eb-883f-dd8b2f50029d.png)

![image](https://user-images.githubusercontent.com/2871786/97427769-f2476800-190c-11eb-9845-4872d7155c56.png)

And therefore the parenstream does not have any context of the test failure 

![image](https://user-images.githubusercontent.com/2871786/97427811-012e1a80-190d-11eb-9fc8-0e34d1b8e5b0.png)


## Tests

[build 2](https://apm-ci.elastic.co/job/apm-integration-test-downstream/job/PR-953/2)

![image](https://user-images.githubusercontent.com/2871786/97438950-743f8d00-191d-11eb-92a1-9174fee69ee9.png)

![image](https://user-images.githubusercontent.com/2871786/97438967-7a356e00-191d-11eb-8021-950c9e9b29a6.png)
