### PR TITLE
ci: store docker logs only if it fails

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -223,7 +223,9 @@ def wrappingup(label){
     def testResultsFolder = 'tests/results'
     def testResultsPattern = "${testResultsFolder}/*-junit*.xml"
     def labelFolder = normalise(label)
-    dockerLogs(step: label, failNever: true)
+    if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+      dockerLogs(step: label, failNever: true)
+    }
     sh('make stop-env || echo 0')
     sh(label: 'Folder to aggregate test results from stages',
        script: "mkdir -p ${labelFolder}/${testResultsFolder} && cp -rf ${testResultsPattern} ${labelFolder}/${testResultsFolder}")

--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -262,7 +262,9 @@ def withConfigEnv(Closure body) {
 def grabResultsAndLogs(label){
   withConfigEnv(){
     dir("${BASE_DIR}"){
-      dockerLogs(step: label, failNever: true)
+      if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+        dockerLogs(step: label, failNever: true)
+      }
       sh('make stop-env || echo 0')
       sh('.ci/scripts/remove_env.sh docker-info')
       archiveArtifacts(

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -278,7 +278,9 @@ def withConfigEnv(Closure body) {
 def grabResultsAndLogs(label){
   withConfigEnv(){
     dir("${BASE_DIR}"){
-      dockerLogs(step: label, failNever: true)
+      if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+        dockerLogs(step: label, failNever: true)
+      }
       sh('make stop-env || echo 0')
       sh('.ci/scripts/remove_env.sh docker-info')
       archiveArtifacts(

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -218,7 +218,9 @@ pipeline {
 def wrappingup(Map params = [:]){
   def isJunit = params.containsKey('isJunit') ? params.get('isJunit') : true
   dir("${BASE_DIR}"){
-    dockerLogs(step: "${env.NAME}", failNever: true)
+    if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+      dockerLogs(step: label, failNever: true)
+    }
     sh('make stop-env || echo 0')
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes to cave the Docker logs and info only in case of error.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
This saves space on the Jenkins instance, and makes easy to check the log errors because you will have only the logs from the failed stages.

