### PR TITLE
[7.x] ci: store docker logs only if it fails (#954)

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -216,7 +216,9 @@ def runScript(Map params = [:]){
 
 def wrappingup(label){
   dir("${BASE_DIR}"){
-    dockerLogs(step: label, failNever: true)
+    if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+      dockerLogs(step: label, failNever: true)
+    }
     sh('make stop-env || echo 0')
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -218,7 +218,9 @@ pipeline {
 def wrappingup(Map params = [:]){
   def isJunit = params.containsKey('isJunit') ? params.get('isJunit') : true
   dir("${BASE_DIR}"){
-    dockerLogs(step: "${env.NAME}", failNever: true)
+    if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+      dockerLogs(step: label, failNever: true)
+    }
     sh('make stop-env || echo 0')
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: store docker logs only if it fails (#954)