### PR TITLE
fix: update PyYAML to work with Python 3.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==3.13
+PyYAML==5.3.1
 attrs==17.4.0
 backports-abc==0.5
 cached-property==1.5.1


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It bumps the version of PyYAML

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Version 3.13 does not work with Python 3.9.0
