### PR TITLE
fix: disable the Elasticsearch dump by default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,5 +16,4 @@ apm-server
 docker-compose.yml
 docker/
 htmlcov/
-scripts/
 venv/

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,11 +5,16 @@
 **/tmp
 *.py[cod]
 *.pyc
-.git
 .cache
+.ci/
 .coverage
+.git
+.github
+.pytest_cache
 /.idea
 apm-server
 docker-compose.yml
+docker/
 htmlcov/
+scripts/
 venv/

--- a/conftest.py
+++ b/conftest.py
@@ -43,8 +43,8 @@ def pytest_runtest_logreport(report):
         name = report.nodeid.split(":", 2)[-1]
         try:
             es_url = getElasticsearchURL()
-            isDumpEnable = os.getenv("ENABLE_ES_DUMP")
-            if isDumpEnable is not None:
+            isDumpEnable = os.getenv("ENABLE_ES_DUMP", False)
+            if isDumpEnable:
                 subprocess.call(['elasticdump',
                                  '--input={}/apm-*'.format(es_url),
                                  '--output=/app/tests/results/data-{}.json'.format(name)])


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Add a default value for the ENABLE_ES_DUMP env var and adapt the condition
* Remove everything not needed from the test Docker container

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The Elasticsearch dump needs some parameters, without them it shows authentication errors in the console, this can confuse people, so it should be disabled by default. 
The Python Docker container build for run the test has more files it needs, in my local, the Docker context is about 4GB (I have a bunch of folders with data) to build this Docker container when it should be about 30MB, by modifying the .dockerignore file this Docker context takes only the files needed
