### PR TITLE
fix: execute remove_env.sh only if docker-info is generated

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -264,9 +264,9 @@ def grabResultsAndLogs(label){
     dir("${BASE_DIR}"){
       if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
         dockerLogs(step: label, failNever: true)
+        sh('.ci/scripts/remove_env.sh docker-info')
       }
       sh('make stop-env || echo 0')
-      sh('.ci/scripts/remove_env.sh docker-info')
       archiveArtifacts(
           allowEmptyArchive: true,
           artifacts: 'tests/results/data-*.json,tests/results/packetbeat-*.json',

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -280,9 +280,9 @@ def grabResultsAndLogs(label){
     dir("${BASE_DIR}"){
       if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
         dockerLogs(step: label, failNever: true)
+        sh('.ci/scripts/remove_env.sh docker-info')
       }
       sh('make stop-env || echo 0')
-      sh('.ci/scripts/remove_env.sh docker-info')
       archiveArtifacts(
           allowEmptyArchive: true,
           artifacts: 'tests/results/data-*.json,tests/results/packetbeat-*.json',


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
 execute remove_env.sh only if docker-info is generated
