### PR TITLE
fix: skip chrome and firefox downloads on the RUM agent Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-agent-%: venv ## Test a specific agent. ex: make test-agent-java
 	pytest tests/agent/test_$*.py --reruns 3 --reruns-delay 5 -v -s $(JUNIT_OPT)/agent-$*-junit.xml
 
 test-compose: venv
-	pytest scripts/tests/*_tests.py -v -s $(JUNIT_OPT)/compose-junit.xml
+	pytest scripts/tests/*_tests.py --reruns 3 --reruns-delay 5 -v -s $(JUNIT_OPT)/compose-junit.xml
 
 test-compose-2:
 	virtualenv --python=python2.7 venv2

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -24,17 +24,6 @@ RUN apt update -qq \
       chromium \
       --no-install-recommends
 
-# we need to install chrome unstable to grab all package dependencies need to run the puppeteer chorme version.
-# RUN curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-#     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-#     && apt update -qq \
-#     && apt install -qq -y \
-#       google-chrome-unstable \
-#       chromium \
-#       --no-install-recommends \
-#     && rm -rf /var/lib/apt/lists/* \
-#     && rm -rf /src/*.deb
-
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
@@ -45,13 +34,6 @@ RUN (cd /rumjs-integration-test \
   && git checkout ${RUM_AGENT_BRANCH})
 
 WORKDIR /rumjs-integration-test
-
-#COPY chrome-linux /rumjs-integration-test/chrome-linux
-# LATEST=$(curl -s https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/LAST_CHANGE)
-#
-# ENV URL=https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/826416/chrome-linux.zip
-# RUN curl -sSL $URL -o chrome-linux.zip \
-#   && unzip -q chrome-linux.zip
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=//usr/bin/chromium

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -5,11 +5,28 @@ ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
 RUN apt update -qq \
-    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1 libxtst6 python g++ build-essential --no-install-recommends \
-    && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && apt install -qq -y \
+      curl \
+      git \
+      gnupg \
+      libgconf-2-4 \
+      libxss1 \
+      libxtst6 \
+      python \
+      g++ \
+      build-essential \
+      fonts-ipafont-gothic \
+      fonts-wqy-zenhei \
+      fonts-thai-tlwg \
+      fonts-kacst \
+      ttf-freefont \
+      --no-install-recommends
+
+RUN curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt update -qq \
-    && apt install -qq -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    && apt install -qq -y \
+      google-chrome-unstable \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb
@@ -25,6 +42,9 @@ RUN (cd /rumjs-integration-test \
 
 WORKDIR /rumjs-integration-test
 
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 # the install is retry threee times with a pause of 10 seconds
 RUN for i in 1 2 3; \
     do \

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -20,16 +20,20 @@ RUN apt update -qq \
       fonts-thai-tlwg \
       fonts-kacst \
       ttf-freefont \
+      ca-certificates \
+      chromium \
       --no-install-recommends
 
-RUN curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt update -qq \
-    && apt install -qq -y \
-      google-chrome-unstable \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb
+# we need to install chrome unstable to grab all package dependencies need to run the puppeteer chorme version.
+# RUN curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+#     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+#     && apt update -qq \
+#     && apt install -qq -y \
+#       google-chrome-unstable \
+#       chromium \
+#       --no-install-recommends \
+#     && rm -rf /var/lib/apt/lists/* \
+#     && rm -rf /src/*.deb
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
@@ -42,8 +46,15 @@ RUN (cd /rumjs-integration-test \
 
 WORKDIR /rumjs-integration-test
 
+#COPY chrome-linux /rumjs-integration-test/chrome-linux
+# LATEST=$(curl -s https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/LAST_CHANGE)
+#
+# ENV URL=https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/826416/chrome-linux.zip
+# RUN curl -sSL $URL -o chrome-linux.zip \
+#   && unzip -q chrome-linux.zip
+
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
+ENV PUPPETEER_EXECUTABLE_PATH=//usr/bin/chromium
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 # the install is retry threee times with a pause of 10 seconds
 RUN for i in 1 2 3; \


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it skips chrome download from puppeteer install, and skips browsers download from playwright install.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Those downloads are not needed and impact the build time and the resilience of the build.
