### PR TITLE
fix: set default log level

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -13,7 +13,7 @@ import re
 from .beats import BeatMixin
 from .helpers import load_images
 from .opbeans import OpbeansService, OpbeansRum
-from .service import Service, DEFAULT_APM_SERVER_URL
+from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_LOG_LEVEL
 
 # these imports are used by discover_services function to discover services from modules loaded
 
@@ -363,6 +363,7 @@ class LocalSetup(object):
             action="store",
             help="APM log level to use",
             choices=["off", "error", "warn", "info", "debug", "trace"],
+            default=DEFAULT_APM_LOG_LEVEL
         )
 
         parser.add_argument(


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It sets the default value for the option `--apm-log-level`

## Why is it important?

<!-- Comment:
Here you can explain how these changes will impact users or in the application
-->
https://github.com/elastic/apm-integration-testing/pull/962 causes a regresion due to `self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL)` returns `None`instead of the default value, then when we make `self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL).lower()` we are making `None.lower()` causing 

```
  File "/Users/inifc/src/apm-integration-testing/scripts/modules/apm_agents.py", line 587, in _content
    self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL).lower()
AttributeError: 'NoneType' object has no attribute 'lower'
make[1]: *** [start-env] Error 1
make: *** [env-agent-dotnet] Error 2
```

