### PR TITLE
fix: change yaml.load to yaml.safe_load

### DIFF
--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -48,7 +48,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_dotnet(self):
         opbeans_go = OpbeansDotnet(version="6.3.10").render()
         self.assertEqual(
-            opbeans_go, yaml.load("""
+            opbeans_go, yaml.safe_load("""
                 opbeans-dotnet:
                     build:
                       dockerfile: Dockerfile
@@ -108,7 +108,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_go(self):
         opbeans_go = OpbeansGo(version="6.3.10").render()
         self.assertEqual(
-            opbeans_go, yaml.load("""
+            opbeans_go, yaml.safe_load("""
                 opbeans-go:
                     build:
                       dockerfile: Dockerfile
@@ -169,7 +169,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_java(self):
         opbeans_java = OpbeansJava(version="6.3.10").render()
         self.assertEqual(
-            opbeans_java, yaml.load("""
+            opbeans_java, yaml.safe_load("""
                 opbeans-java:
                     build:
                       dockerfile: Dockerfile
@@ -237,7 +237,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_node(self):
         opbeans_node = OpbeansNode(version="6.2.4").render()
         self.assertEqual(
-            opbeans_node, yaml.load("""
+            opbeans_node, yaml.safe_load("""
                 opbeans-node:
                     build:
                       dockerfile: Dockerfile
@@ -310,7 +310,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_python(self):
         opbeans_python = OpbeansPython(version="6.2.4").render()
         self.assertEqual(
-            opbeans_python, yaml.load("""
+            opbeans_python, yaml.safe_load("""
                 opbeans-python:
                     build:
                       dockerfile: Dockerfile
@@ -403,7 +403,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_ruby(self):
         opbeans_ruby = OpbeansRuby(version="6.3.10").render()
         self.assertEqual(
-            opbeans_ruby, yaml.load("""
+            opbeans_ruby, yaml.safe_load("""
                 opbeans-ruby:
                     build:
                       dockerfile: Dockerfile
@@ -464,7 +464,7 @@ class OpbeansServiceTest(ServiceTest):
     def test_opbeans_rum(self):
         opbeans_rum = OpbeansRum(version="6.3.10").render()
         self.assertEqual(
-            opbeans_rum, yaml.load("""
+            opbeans_rum, yaml.safe_load("""
                 opbeans-rum:
                      build:
                          dockerfile: Dockerfile
@@ -586,7 +586,7 @@ class OpbeansServiceTest(ServiceTest):
             opbeans_python_loadgen_rpm=50,
             opbeans_ruby_loadgen_rpm=10,
         ).render()
-        assert opbeans_load_gen == yaml.load("""
+        assert opbeans_load_gen == yaml.safe_load("""
             opbeans-load-generator:
                 image: opbeans/opbeans-loadgen:latest
                 container_name: localtesting_6.3.1_opbeans-load-generator
@@ -605,7 +605,7 @@ class PostgresServiceTest(ServiceTest):
     def test_postgres(self):
         postgres = Postgres(version="6.2.4").render()
         self.assertEqual(
-            postgres, yaml.load("""
+            postgres, yaml.safe_load("""
                 postgres:
                     image: postgres:10
                     container_name: localtesting_6.2.4_postgres
@@ -632,7 +632,7 @@ class RedisServiceTest(ServiceTest):
     def test_redis(self):
         redis = Redis(version="6.2.4").render()
         self.assertEqual(
-            redis, yaml.load("""
+            redis, yaml.safe_load("""
                 redis:
                     image: redis:4
                     container_name: localtesting_6.2.4_redis
@@ -670,8 +670,8 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
-        want = yaml.load("""
+        got = yaml.safe_load(docker_compose_yml)
+        want = yaml.safe_load("""
         version: '2.1'
         services:
             apm-server:
@@ -751,8 +751,8 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
-        want = yaml.load("""
+        got = yaml.safe_load(docker_compose_yml)
+        want = yaml.safe_load("""
         version: '2.1'
         services:
             apm-server:
@@ -836,7 +836,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         self.assertIn('ELASTIC_APM_SERVICE_VERSION=1.2.3', got['services']['opbeans-java']['environment'])
 
     def test_start_master_default(self):
@@ -847,8 +847,8 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
-        want = yaml.load("""
+        got = yaml.safe_load(docker_compose_yml)
+        want = yaml.safe_load("""
         version: '2.1'
         services:
             apm-server:
@@ -975,7 +975,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         # apm-server should use user/pass -> es
         apm_server_cmd = got["services"]["apm-server"]["command"]
         self.assertTrue(any(cmd.startswith("output.elasticsearch.password=") for cmd in apm_server_cmd), apm_server_cmd)
@@ -1006,7 +1006,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         # apm-server should use user/pass -> es
         apm_server_cmd = got["services"]["apm-server"]["command"]
         self.assertTrue(any(cmd.startswith("output.elasticsearch.password=") for cmd in apm_server_cmd), apm_server_cmd)
@@ -1036,7 +1036,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertNotIn("elasticsearch", services)
         self.assertNotIn("elasticsearch", services["apm-server"]["depends_on"])
@@ -1049,7 +1049,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = set(got["services"])
         self.assertSetEqual(services, {
             "apm-server", "elasticsearch", "kibana",
@@ -1073,7 +1073,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertIn("redis", services)
         self.assertIn("postgres", services)
@@ -1088,7 +1088,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertIn("redis", services)
         self.assertIn("postgres", services)
@@ -1103,7 +1103,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertIn("redis", services)
         self.assertIn("postgres", services)
@@ -1119,7 +1119,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertIn("opbeans-dotnet01", services)
         self.assertIn("opbeans-node01", services)
@@ -1136,7 +1136,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         depends_on = set(got["services"]["opbeans-node"]["depends_on"].keys())
         self.assertSetEqual({"postgres", "redis"}, depends_on)
         depends_on = set(got["services"]["opbeans-python"]["depends_on"].keys())
@@ -1155,7 +1155,7 @@ class LocalTest(unittest.TestCase):
         setup.set_docker_compose_path(docker_compose_yml)
         setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertEqual(
             "docker.elastic.co/elasticsearch/elasticsearch-platinum:{}".format(version),
@@ -1172,7 +1172,7 @@ class LocalTest(unittest.TestCase):
         setup.set_docker_compose_path(docker_compose_yml)
         setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertEqual(
             "docker.elastic.co/elasticsearch/elasticsearch:{}-SNAPSHOT".format(version),
@@ -1237,7 +1237,7 @@ class LocalTest(unittest.TestCase):
         setup.set_docker_compose_path(docker_compose_yml)
         setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertEqual(
             "docker.elastic.co/elasticsearch/elasticsearch:{}".format(version),
@@ -1295,7 +1295,7 @@ class LocalTest(unittest.TestCase):
         setup.set_docker_compose_path(docker_compose_yml)
         setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertEqual(
             "docker.elastic.co/elasticsearch/elasticsearch-oss:{}".format(version),
@@ -1353,7 +1353,7 @@ class LocalTest(unittest.TestCase):
         setup.set_docker_compose_path(docker_compose_yml)
         setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertEqual(
             "docker.elastic.co/apm/apm-server:{}".format(apm_server_version),
@@ -1407,7 +1407,7 @@ class LocalTest(unittest.TestCase):
         setup.set_docker_compose_path(docker_compose_yml)
         setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = got["services"]
         self.assertEqual(
             "docker.elastic.co/elasticsearch/elasticsearch-ubi8:{}".format(version),
@@ -1470,7 +1470,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = set(got["services"])
         self.assertIn("apm-server", services)
         self.assertIn("opbeans-python", services)
@@ -1513,7 +1513,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = set(got["services"])
         self.assertIn("elasticsearch", services)
 
@@ -1541,7 +1541,7 @@ class LocalTest(unittest.TestCase):
             setup.set_docker_compose_path(docker_compose_yml)
             setup()
         docker_compose_yml.seek(0)
-        got = yaml.load(docker_compose_yml)
+        got = yaml.safe_load(docker_compose_yml)
         services = set(got["services"])
         self.assertIn("kibana", services)
 

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -23,7 +23,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_go_net_http(self):
         agent = AgentGoNetHttp().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-go-net-http:
                     build:
                         args:
@@ -81,7 +81,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_nodejs_express(self):
         agent = AgentNodejsExpress().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-nodejs-express:
                     build:
                         dockerfile: Dockerfile
@@ -131,7 +131,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_python_django(self):
         agent = AgentPythonDjango().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-python-django:
                     build:
                         dockerfile: Dockerfile
@@ -176,7 +176,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_python_flask(self):
         agent = AgentPythonFlask(version="6.2.4").render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-python-flask:
                     build:
                         dockerfile: Dockerfile
@@ -221,7 +221,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_ruby_rails(self):
         agent = AgentRubyRails().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-ruby-rails:
                     build:
                         args:
@@ -289,7 +289,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_java_spring(self):
         agent = AgentJavaSpring().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-java-spring:
                     build:
                         args:
@@ -351,7 +351,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_dotnet(self):
         agent = AgentDotnet().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-dotnet:
                     build:
                         args:
@@ -416,7 +416,7 @@ class AgentServiceTest(ServiceTest):
     def test_agent_php(self):
         agent = AgentPhpApache().render()
         self.assertDictEqual(
-            agent, yaml.load("""
+            agent, yaml.safe_load("""
                 agent-php-apache:
                     build:
                         args:
@@ -668,7 +668,7 @@ class ApmServerServiceTest(ServiceTest):
             self.assertEqual(1, len(got))
             directive, setting = got[0]
             self.assertEqual("output.elasticsearch.pipelines", directive)
-            return yaml.load(setting)
+            return yaml.safe_load(setting)
 
         apm_server = ApmServer(version="6.5.10").render()["apm-server"]
         self.assertEqual(get_pipelines(apm_server["command"]), [{'pipeline': 'apm_user_agent'}],
@@ -967,7 +967,7 @@ class FilebeatServiceTest(ServiceTest):
     def test_filebeat_pre_6_1(self):
         filebeat = Filebeat(version="6.0.4", release=True).render()
         self.assertEqual(
-            filebeat, yaml.load("""
+            filebeat, yaml.safe_load("""
                 filebeat:
                     image: docker.elastic.co/beats/filebeat:6.0.4
                     container_name: localtesting_6.0.4_filebeat
@@ -994,7 +994,7 @@ class FilebeatServiceTest(ServiceTest):
     def test_filebeat_post_6_1(self):
         filebeat = Filebeat(version="6.1.1", release=True).render()
         self.assertEqual(
-            filebeat, yaml.load("""
+            filebeat, yaml.safe_load("""
                 filebeat:
                     image: docker.elastic.co/beats/filebeat:6.1.1
                     container_name: localtesting_6.1.1_filebeat
@@ -1063,7 +1063,7 @@ class KafkaServiceTest(ServiceTest):
     def test_kafka(self):
         kafka = Kafka(version="6.2.4").render()
         self.assertEqual(
-            kafka, yaml.load("""
+            kafka, yaml.safe_load("""
                 kafka:
                     image: confluentinc/cp-kafka:4.1.3
                     container_name: localtesting_6.2.4_kafka
@@ -1084,7 +1084,7 @@ class KibanaServiceTest(ServiceTest):
     def test_6_2_release(self):
         kibana = Kibana(version="6.2.4", release=True).render()
         self.assertEqual(
-            kibana, yaml.load("""
+            kibana, yaml.safe_load("""
                 kibana:
                     image: docker.elastic.co/kibana/kibana-x-pack:6.2.4
                     container_name: localtesting_6.2.4_kibana
@@ -1113,7 +1113,7 @@ class KibanaServiceTest(ServiceTest):
     def test_6_3_release(self):
         kibana = Kibana(version="6.3.5", release=True).render()
         self.assertDictEqual(
-            kibana, yaml.load("""
+            kibana, yaml.safe_load("""
                 kibana:
                     image: docker.elastic.co/kibana/kibana:6.3.5
                     container_name: localtesting_6.3.5_kibana
@@ -1215,7 +1215,7 @@ class LogstashServiceTest(ServiceTest):
     def test_logstash(self):
         logstash = Logstash(version="6.3.0", release=True).render()
         self.assertEqual(
-            logstash, yaml.load("""
+            logstash, yaml.safe_load("""
         logstash:
             container_name: localtesting_6.3.0_logstash
             depends_on:
@@ -1272,7 +1272,7 @@ class MetricbeatServiceTest(ServiceTest):
     def test_metricbeat(self):
         metricbeat = Metricbeat(version="7.2.0", release=True, apm_server_pprof_url='apm-server:6060').render()
         self.assertEqual(
-            metricbeat, yaml.load("""
+            metricbeat, yaml.safe_load("""
                 metricbeat:
                     image: docker.elastic.co/beats/metricbeat:7.2.0
                     container_name: localtesting_7.2.0_metricbeat
@@ -1351,7 +1351,7 @@ class PacketbeatServiceTest(ServiceTest):
     def test_packetbeat(self):
         packetbeat = Packetbeat(version="7.3.0", release=True).render()
         self.assertEqual(
-            packetbeat, yaml.load("""
+            packetbeat, yaml.safe_load("""
                 packetbeat:
                     image: docker.elastic.co/beats/packetbeat:7.3.0
                     container_name: localtesting_7.3.0_packetbeat
@@ -1439,7 +1439,7 @@ class ZookeeperServiceTest(ServiceTest):
     def test_zookeeper(self):
         zookeeper = Zookeeper(version="6.2.4").render()
         self.assertEqual(
-            zookeeper, yaml.load("""
+            zookeeper, yaml.safe_load("""
                 zookeeper:
                     image: confluentinc/cp-zookeeper:latest
                     container_name: localtesting_6.2.4_zookeeper


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it changes `yaml.load` to `yaml.safe_load`

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
`yaml.load` is not safe and show a warning in the logs that this call is deprecated, this change removes all those warnings

see https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

