### PR TITLE
feta: add a wait container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,16 +110,10 @@ test-helps:
 test-all: venv test-compose lint test-helps ## Run all the tests
 	pytest -v -s $(JUNIT_OPT)/all-junit.xml
 
-docker-compose-wait: venv ## Wait for docker services to shutdown and exit
-	docker-compose-wait || (docker ps -a && exit 1)
-
 docker-test-%: ## Run a specific dockerized test. Ex: make docker-test-java
 	TARGET=test-$* $(MAKE) dockerized-test
 
 dockerized-test: ## Run all the dockerized tests
-	@echo waiting for services to be healthy
-	$(MAKE) docker-compose-wait || (./scripts/docker-summary.sh; echo "[ERROR] Failed waiting for all containers are healthy"; exit 1)
-
 	./scripts/docker-summary.sh
 
 	@echo running make $(TARGET) inside a container

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cached-property==1.5.1
 certifi==2017.11.5
 chardet==3.0.4
 coverage==4.5.1
-docker-compose-wait==1.0.0
 docker-compose==1.27.4
 docker==4.3.1
 dockerpty==0.4.1

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -120,7 +120,6 @@ class Zookeeper(Service):
         )
 
 
-
 class WaitService(Service):
     """Create a service that depends on all services ."""
 

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -136,9 +136,6 @@ class WaitService(Service):
             container_name="wait",
             image="busybox",
             depends_on=self.depends_on,
-            healthcheck={
-                "interval": "10s",
-                "retries": "100",
-                "test": ["CMD", "exit 0"],
-            }
+            labels=None,
+            logging=None,
         )

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -118,3 +118,27 @@ class Zookeeper(Service):
             logging=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
         )
+
+
+
+class WaitService(Service):
+    """Creeate a service that depends on all services ."""
+
+    def __init__(self, services, **options):
+        super(WaitService, self).__init__(**options)
+        self.services = services
+
+    def _content(self):
+        for s in self.services:
+            if s.name() != self.name():
+                self.depends_on[s.name()] = {"condition": "service_healthy"}
+        return dict(
+            container_name="wait",
+            image="busybox",
+            depends_on=self.depends_on,
+            healthcheck={
+                "interval": "10s",
+                "retries": "100",
+                "test": ["CMD", "exit 0"],
+            }
+        )

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -122,7 +122,7 @@ class Zookeeper(Service):
 
 
 class WaitService(Service):
-    """Creeate a service that depends on all services ."""
+    """Create a service that depends on all services ."""
 
     def __init__(self, services, **options):
         super(WaitService, self).__init__(**options)

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -25,7 +25,7 @@ from .elastic_stack import (  # noqa: F401
     ApmServer, Elasticsearch, Kibana
 )
 from .aux_services import (  # noqa: F401
-    Kafka, Logstash, Postgres, Redis, Zookeeper
+    Kafka, Logstash, Postgres, Redis, Zookeeper, WaitService
 )
 from .opbeans import (  # noqa: F401
     OpbeansNode, OpbeansRuby, OpbeansPython, OpbeansDotnet,
@@ -570,6 +570,7 @@ class LocalSetup(object):
                     (run_all and is_obs and not is_opbeans_2nd)):
                 selections.add(service(**args))
 
+        selections.add(WaitService(selections, **args))
         # `docker load` images if necessary, usually only for build candidates
         services_to_load = {}
         for service in selections:
@@ -606,7 +607,7 @@ class LocalSetup(object):
                 del services["opbeans-load-generator"]
 
         compose = dict(
-            version="2.1",
+            version="2.4",
             services=services,
             networks=dict(
                 default={"name": "apm-integration-testing"},

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -672,7 +672,7 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml.seek(0)
         got = yaml.load(docker_compose_yml)
         want = yaml.load("""
-        version: '2.1'
+        version: '2.4'
         services:
             apm-server:
                 cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
@@ -734,6 +734,16 @@ class LocalTest(unittest.TestCase):
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}
                 ports: ['127.0.0.1:5601:5601']
+            wait-service:
+                container_name: wait
+                depends_on:
+                    apm-server:
+                        condition: service_healthy
+                    elasticsearch:
+                        condition: service_healthy
+                    kibana:
+                        condition: service_healthy
+                image: busybox
         networks:
             default: {name: apm-integration-testing}
         volumes:
@@ -753,7 +763,7 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml.seek(0)
         got = yaml.load(docker_compose_yml)
         want = yaml.load("""
-        version: '2.1'
+        version: '2.4'
         services:
             apm-server:
                 cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
@@ -819,7 +829,16 @@ class LocalTest(unittest.TestCase):
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}
                 ports: ['127.0.0.1:5601:5601']
-
+            wait-service:
+                container_name: wait
+                depends_on:
+                    apm-server:
+                        condition: service_healthy
+                    elasticsearch:
+                        condition: service_healthy
+                    kibana:
+                        condition: service_healthy
+                image: busybox
         networks:
             default: {name: apm-integration-testing}
         volumes:
@@ -849,7 +868,7 @@ class LocalTest(unittest.TestCase):
         docker_compose_yml.seek(0)
         got = yaml.load(docker_compose_yml)
         want = yaml.load("""
-        version: '2.1'
+        version: '2.4'
         services:
             apm-server:
                 cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
@@ -959,6 +978,16 @@ class LocalTest(unittest.TestCase):
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}
                 ports: ['127.0.0.1:5601:5601']
+            wait-service:
+                container_name: wait
+                depends_on:
+                    apm-server:
+                        condition: service_healthy
+                    elasticsearch:
+                        condition: service_healthy
+                    kibana:
+                        condition: service_healthy
+                image: busybox
         networks:
             default: {name: apm-integration-testing}
         volumes:
@@ -1062,7 +1091,9 @@ class LocalTest(unittest.TestCase):
             "opbeans-python",
             "opbeans-ruby",
             "opbeans-rum",
-            "postgres", "redis",
+            "postgres",
+            "redis",
+            "wait-service",
         })
 
     @mock.patch(cli.__name__ + ".load_images")


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Add a new wait container
* Remove docker-compose-wait dependency

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
This new wait container depends on all enabled services, this makes that until all services are not healthy this container is not started. In this way, docker-compose only exits when all containers are healthy or one fails to start.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/964
