### PR TITLE
More python logging fixes + regression fix from #962

### DIFF
--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -8,12 +8,22 @@ test -z "$srcdir" && srcdir=.
 
 AGENT=$1
 APP=$2
-DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --with-agent-${APP} \
-  --no-apm-server-dashboards \
-  --no-apm-server-self-instrument \
-  --apm-server-agent-config-poll=1s \
-  --force-build --no-xpack-secure \
-  --apm-log-level=debug"
+if [ "${AGENT}" = "python" ]; then
+    DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+      --with-agent-${APP} \
+      --no-apm-server-dashboards \
+      --no-apm-server-self-instrument \
+      --apm-server-agent-config-poll=1s \
+      --force-build --no-xpack-secure"
+else
+    DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+      --with-agent-${APP} \
+      --no-apm-server-dashboards \
+      --no-apm-server-self-instrument \
+      --apm-server-agent-config-poll=1s \
+      --force-build --no-xpack-secure \
+      --apm-log-level=debug"
+fi
+
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-${AGENT}" "docker-test-agent-${AGENT}"

--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -8,22 +8,18 @@ test -z "$srcdir" && srcdir=.
 
 AGENT=$1
 APP=$2
-if [ "${AGENT}" = "python" ]; then
-    DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-      --with-agent-${APP} \
-      --no-apm-server-dashboards \
-      --no-apm-server-self-instrument \
-      --apm-server-agent-config-poll=1s \
-      --force-build --no-xpack-secure"
-else
-    DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-      --with-agent-${APP} \
-      --no-apm-server-dashboards \
-      --no-apm-server-self-instrument \
-      --apm-server-agent-config-poll=1s \
-      --force-build --no-xpack-secure \
-      --apm-log-level=debug"
+APM_DEBUG=""
+if [ "${AGENT}" != "python" ]; then
+  APM_DEBUG="--apm-log-level=debug"
 fi
+
+DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
+  --with-agent-${APP} \
+  --no-apm-server-dashboards \
+  --no-apm-server-self-instrument \
+  --apm-server-agent-config-poll=1s \
+  --force-build --no-xpack-secure \
+  ${APM_DEBUG}"
 
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-${AGENT}" "docker-test-agent-${AGENT}"

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -411,7 +411,9 @@ class AgentRubyRails(Service):
         default_environment = {
             "APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_LOG_LEVEL": self._map_log_level(
-                self.options.get("apm_log_level").lower() if self.options.get("apm_log_level") else DEFAULT_APM_LOG_LEVEL
+                self.options.get("apm_log_level").lower()
+                if self.options.get("apm_log_level")
+                else DEFAULT_APM_LOG_LEVEL
             ),
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
@@ -584,7 +586,9 @@ class AgentDotnet(Service):
             "ELASTIC_APM_SERVICE_NAME": "dotnetapp",
             "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
             "ELASTIC_APM_LOG_LEVEL": self._map_log_level(
-                self.options.get("apm_log_level").lower() if self.options.get("apm_log_level") else DEFAULT_APM_LOG_LEVEL
+                self.options.get("apm_log_level").lower()
+                if self.options.get("apm_log_level")
+                else DEFAULT_APM_LOG_LEVEL
             ),
         }
         environment = default_environment

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -38,7 +38,7 @@ class AgentRUMJS(Service):
             "ELASTIC_APM_SERVICE_NAME": "rum",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL)
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level") or DEFAULT_APM_LOG_LEVEL
         }
         environment = default_environment
         if self.apm_api_key:
@@ -99,7 +99,7 @@ class AgentGoNetHttp(Service):
     ])
     def _content(self):
         default_environment = {
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level") or DEFAULT_APM_LOG_LEVEL,
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_FLUSH_INTERVAL": "500ms",
             "ELASTIC_APM_SERVICE_NAME": "gonethttpapp",
@@ -161,7 +161,7 @@ class AgentNodejsExpress(Service):
             "EXPRESS_PORT": str(self.SERVICE_PORT),
             "EXPRESS_SERVICE_NAME": "expressapp",
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level") or DEFAULT_APM_LOG_LEVEL,
         }
         environment = default_environment
         if self.apm_api_key:
@@ -411,7 +411,7 @@ class AgentRubyRails(Service):
         default_environment = {
             "APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_LOG_LEVEL": self._map_log_level(
-                self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL).lower()
+                self.options.get("apm_log_level").lower() if self.options.get("apm_log_level") else DEFAULT_APM_LOG_LEVEL
             ),
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
@@ -493,7 +493,7 @@ class AgentJavaSpring(Service):
             "ELASTIC_APM_API_REQUEST_TIME": "3s",
             "ELASTIC_APM_SERVICE_NAME": "springapp",
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
-            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL),
+            "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level") or DEFAULT_APM_LOG_LEVEL,
         }
         environment = default_environment
         if self.apm_api_key:
@@ -584,7 +584,7 @@ class AgentDotnet(Service):
             "ELASTIC_APM_SERVICE_NAME": "dotnetapp",
             "ELASTIC_APM_TRANSACTION_IGNORE_NAMES": "healthcheck",
             "ELASTIC_APM_LOG_LEVEL": self._map_log_level(
-                self.options.get("apm_log_level", DEFAULT_APM_LOG_LEVEL).lower()
+                self.options.get("apm_log_level").lower() if self.options.get("apm_log_level") else DEFAULT_APM_LOG_LEVEL
             ),
         }
         environment = default_environment


### PR DESCRIPTION
## What does this PR do?

Fixes log_level default handling change from #962 (this PR replaces #966).

Also fixes one more instance of `--apm-log-level` messing up python agent testing.
