### PR TITLE
feat: build kibana container from sources

### DIFF
--- a/docker/kibana_src/.dockerignore
+++ b/docker/kibana_src/.dockerignore
@@ -1,0 +1,5 @@
+**/.git
+**/.ci
+**/.github
+**/node_modules
+**/kibana/target

--- a/docker/kibana_src/Dockerfile
+++ b/docker/kibana_src/Dockerfile
@@ -22,7 +22,7 @@ ENV BABEL_DISABLE_CACHE=true
 
 EXPOSE 5601
 ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["yarn kbn bootstrap && yarn start"]
+CMD ["yarn kbn bootstrap && yarn start -c /usr/share/kibana/config/kibana_src.yml -c /usr/share/kibana/config/kibana.yml --no-dev-config"]
 
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=300 CMD curl -sSL http://127.0.0.1:5601/login|grep -v 'Kibana server is not ready yet'

--- a/docker/kibana_src/Dockerfile
+++ b/docker/kibana_src/Dockerfile
@@ -1,0 +1,28 @@
+ARG NODE_VERSION=
+FROM node:${NODE_VERSION}
+
+ARG GID=1001
+ARG UID=1001
+RUN mkdir -p /usr/share/kibana/config
+WORKDIR /usr/share/kibana
+RUN groupadd -f --gid ${GID} kibana \
+  && useradd --uid ${UID} --gid ${GID} --groups 0 --home-dir /usr/share/kibana --no-create-home kibana
+RUN chown -R kibana:0 /usr/share/kibana
+# Bazel is installed at global level so we need permissions on /usr/local
+RUN chown -R kibana:0 /usr/local
+USER kibana
+
+RUN git config --global user.email "none@example.com"
+RUN git config --global user.name "None"
+RUN git init && git add . && git commit -a -m "init commit"
+ENV HOME=/usr/share/kibana
+ENV NODE_OPTIONS= --max-old-space-size=4096
+ENV FORCE_COLOR=1
+ENV BABEL_DISABLE_CACHE=true
+
+EXPOSE 5601
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["yarn kbn bootstrap && yarn start"]
+
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=300 CMD curl -sSL http://127.0.0.1:5601/login|grep -v 'Kibana server is not ready yet'

--- a/docker/kibana_src/kibana_src.yml
+++ b/docker/kibana_src/kibana_src.yml
@@ -1,0 +1,5 @@
+elasticsearch.hosts: ["http://elasticsearch:9200"]
+elasticsearch.username: "kibana_system_user"
+elasticsearch.password: "changeme"
+server.host: "0.0.0.0"
+server.port: 5601

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1167,8 +1167,14 @@ class Kibana(StackService, Service):
         parser.add_argument(
             "--kibana-src-start-cmd",
             nargs="?",
-            help="Command used to start Kibana from sources (yarn kbn bootstrap && yarn start).",
-            default="yarn kbn bootstrap && yarn start"
+            help="Command used to start Kibana from sources " +
+                 "(yarn kbn bootstrap && yarn start " +
+                 "-c /usr/share/kibana/config/kibana_src.yml " +
+                 "-c /usr/share/kibana/config/kibana.yml).",
+            default="yarn kbn bootstrap && yarn start " +
+                    "-c /usr/share/kibana/config/kibana_src.yml " +
+                    "-c /usr/share/kibana/config/kibana.yml " +
+                    "--no-dev-config"
         )
 
     def _content(self):
@@ -1185,6 +1191,7 @@ class Kibana(StackService, Service):
             kibana_src = self.options.get("kibana_src")
             volumes.extend([
                 "{}:/usr/share/kibana".format(kibana_src),
+                "./docker/kibana_src/kibana_src.yml:/usr/share/kibana/config/kibana_src.yml"
             ])
 
         if self.kibana_yml:

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1205,14 +1205,13 @@ class Kibana(StackService, Service):
             with open("{}/.node-version".format(kibana_src), 'r') as file:
                 node_version = file.read().replace('\n', '')
             content["build"] = dict(
-                                    context="docker/kibana_src",
-                                    dockerfile="Dockerfile",
-                                    args=[
-                                        "NODE_VERSION={}".format(node_version.replace('\n', '')),
-                                        "UID={}".format(os.getuid()),
-                                        "GID={}".format(os.getgid()),
-                                    ]
-                                )
+                context="docker/kibana_src",
+                dockerfile="Dockerfile",
+                args=[
+                    "NODE_VERSION={}".format(node_version.replace('\n', '')),
+                    "UID={}".format(os.getuid()),
+                    "GID={}".format(os.getgid()),
+                ])
             content["image"] = "kibana_src"
             content["working_dir"] = "/usr/share/kibana"
             content["command"] = "'{}'".format(self.options.get("kibana_src_start_cmd"))

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1216,7 +1216,6 @@ class Kibana(StackService, Service):
             content["working_dir"] = "/usr/share/kibana"
             content["command"] = "'{}'".format(self.options.get("kibana_src_start_cmd"))
             self.environment["NODE_OPTIONS"] = "--max-old-space-size=4096"
-            self.environment["FORCE_COLOR"] = "1"
             self.environment["BABEL_DISABLE_CACHE"] = "true"
             self.environment["HOME"] = "/usr/share/kibana"
             content["healthcheck"] = curl_healthcheck(


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It adds a new flag to build Kibana from sources in a folder.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Now developers can run their Kibana code directly against the Elastic Stack using compose.py.

There are two new flags `--kibana-src` and `kibana-src-start-cmd` 
* `--kibana-src` is the absolute path to a local folder with the kibana sources.
* `kibana-src-start-cmd` it replaces the default command used to start kibana from sources `yarn kbn bootstrap && yarn start -c /usr/share/kibana/config/kibana_src.yml -c /usr/share/kibana/config/kibana.yml --no-dev-config`.

The default starts command loads two configuration files `/usr/share/kibana/config/kibana_src.yml` that configure the docker-compose Elasticsearch and `/usr/share/kibana/config/kibana.yml` that is the file inside `config/kibana.yml` in the Kibana sources folder.

## Limitations 

It only works with the Elasticsearch instance deploy in the Docker compose, to use other Elasticsearch instance you have to use `--kibana-src-start-cmd` to replace the default configurations.
All configuration made on environment variables is ignored, so the only way to configure the settings is by using the `config/kibana.yml` file.

## Local testing

```shell
git clone git@github.com:elastic/kibana.git
cd kibana
git checkout 7.13
export KIBANA_SRC_DIR=$(pwd)
cd -
git clone git@github.com:kuisathaverat/apm-integration-testing.git
cd apm-integration-testing
git checkout -b origin/kibana_src kibana_src
./scripts/compose.py start 7.13.4 --kibana-src=${KIBANA_SRC_DIR} --no-apm-server
```

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/661
