### PR TITLE
Fix PHP test to not include query string in transaction name

### DIFF
--- a/tests/agent/test_php.py
+++ b/tests/agent/test_php.py
@@ -17,5 +17,5 @@ def test_concurrent_req_php_apache(php_apache):
     foo = Concurrent.Endpoint(php_apache.foo.url,
                               php_apache.app_name,
                               ["foo"],
-                              "GET /foo/?q=1")
+                              "GET /foo/")
     Concurrent(php_apache.apm_server.elasticsearch, [foo], iters=2).run()


### PR DESCRIPTION
## What does this PR do?

This PR fixes PHP test to not include query string in transaction name.

## Why is it important?

To make tests pass after changes to PHP Agent (https://github.com/elastic/apm-agent-php/pull/285).

## Related issues

Address PHP test failure encountered at #971
