### PR TITLE
fix: ignore load generator on th wait container

### DIFF
--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -129,7 +129,7 @@ class WaitService(Service):
 
     def _content(self):
         for s in self.services:
-            if s.name() != self.name():
+            if s.name() != self.name() and s.name() != "opbeans-load-generator":
                 self.depends_on[s.name()] = {"condition": "service_healthy"}
         return dict(
             container_name="wait",


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Adds a condition to ignore the opbeans-load-generator Docker container.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
this container is special and not always is running.
