### PR TITLE
fix: remove relative import from compose.py

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -5,13 +5,7 @@ from __future__ import print_function
 import logging
 import sys
 
-
-if __package__ is None:
-    # for use as Python script
-    from modules.cli import LocalSetup
-else:
-    # for use as module from tests
-    from .modules.cli import LocalSetup
+from modules.cli import LocalSetup
 
 
 def main():


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
This removes a workaround to make an import in case there is not package loaded.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
For an unknown reason this import alternative stop working and throws tons of errors when you use the `--bc` setting, I have tested the compose test and I think is no longer need, so we can remove it safely.

```
./scripts/compose.py start 7.10 --bc 
found latest build candidate for 7.10 - https://staging.elastic.co/7.10.0-0624cd63/summary-7.10.0.html at https://staging.elastic.co/latest/7.10.json
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/spawn.py", line 116, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/spawn.py", line 125, in _main
    prepare(preparation_data)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/spawn.py", line 236, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/spawn.py", line 287, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 268, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/inifc/src/apm-integration-testing/scripts/compose.py", line 14, in <module>
    from .modules.cli import LocalSetup
ImportError: attempted relative import with no known parent package

```