### PR TITLE
fix: retry maven download

### DIFF
--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -11,7 +11,7 @@ if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
     -DskipTests=true \
     -Dhttps.protocols=TLSv1.2 \
     -Dmaven.javadoc.skip=true \
-    -Dmaven.wagon.http.retryHandler.count=3 \
+    -Dmaven.wagon.http.retryHandler.count=5 \
     -Dhttp.keepAlive=false \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   # shellcheck disable=SC2016
@@ -22,7 +22,7 @@ else
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       -Dhttps.protocols=TLSv1.2 \
       -DrepoUrl=https://repo1.maven.apache.org/maven2 \
-      -Dmaven.wagon.http.retryHandler.count=3 \
+      -Dmaven.wagon.http.retryHandler.count=5 \
       -Dhttp.keepAlive=false \
       -Dartifact="co.elastic.apm:${ARTIFACT_ID}:${JAVA_AGENT_BUILT_VERSION}"
 fi
@@ -33,7 +33,7 @@ mvn -q --batch-mode -DAGENT_API_VERSION="${JAVA_AGENT_BUILT_VERSION}" \
   -DskipTests=true \
   -Dhttps.protocols=TLSv1.2 \
   -Dmaven.javadoc.skip=true \
-  -Dmaven.wagon.http.retryHandler.count=3 \
+  -Dmaven.wagon.http.retryHandler.count=5 \
   -Dhttp.keepAlive=false \
   package
 

--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -11,7 +11,7 @@ if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
     -DskipTests=true \
     -Dhttps.protocols=TLSv1.2 \
     -Dmaven.javadoc.skip=true \
-    -Dmaven.wagon.http.retryHandler.count=5 \
+    -Dmaven.wagon.http.retryHandler.count=10 \
     -Dhttp.keepAlive=false \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   # shellcheck disable=SC2016
@@ -22,7 +22,7 @@ else
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       -Dhttps.protocols=TLSv1.2 \
       -DrepoUrl=https://repo1.maven.apache.org/maven2 \
-      -Dmaven.wagon.http.retryHandler.count=5 \
+      -Dmaven.wagon.http.retryHandler.count=10 \
       -Dhttp.keepAlive=false \
       -Dartifact="co.elastic.apm:${ARTIFACT_ID}:${JAVA_AGENT_BUILT_VERSION}"
 fi
@@ -33,7 +33,7 @@ mvn -q --batch-mode -DAGENT_API_VERSION="${JAVA_AGENT_BUILT_VERSION}" \
   -DskipTests=true \
   -Dhttps.protocols=TLSv1.2 \
   -Dmaven.javadoc.skip=true \
-  -Dmaven.wagon.http.retryHandler.count=5 \
+  -Dmaven.wagon.http.retryHandler.count=10 \
   -Dhttp.keepAlive=false \
   package
 


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it increases the retries to 10

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Sometimes seems like 3 are not enough 

```
[2020-11-12T14:11:57.360Z] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java) on project apm-agent-parent: Execution enforce-java of goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce failed: Plugin org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1 or one of its dependencies could not be resolved: Failed to collect dependencies at org.apache.maven.plugins:maven-enforcer-plugin:jar:3.0.0-M1 -> org.apache.maven.enforcer:enforcer-rules:jar:3.0.0-M1 -> org.apache.maven.shared:maven-common-artifact-filters:jar:3.0.1: Failed to read artifact descriptor for org.apache.maven.shared:maven-common-artifact-filters:jar:3.0.1: Could not transfer artifact org.apache.maven.shared:maven-common-artifact-filters:pom:3.0.1 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.pom: readHandshakeRecord: Connection reset by peer (Write failed) -> [Help 1]
[2020-11-12T14:11:57.361Z] [ERROR] 
[2020-11-12T14:11:57.361Z] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[2020-11-12T14:11:57.361Z] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[2020-11-12T14:11:57.361Z] [ERROR] 
[2020-11-12T14:11:57.361Z] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[2020-11-12T14:11:57.361Z] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
```

```
[2020-11-12T14:19:30.026Z] ERROR: for agent-java-spring  (<Service: agent-java-spring>, 'The command \'/bin/sh -c ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"\' returned a non-zero code: 1')
[2020-11-12T14:19:30.026Z] Service 'agent-java-spring' failed to build : The command '/bin/sh -c ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"' returned a non-zero code: 1
[2020-11-12T14:19:30.026Z] Starting stack services..
[2020-11-12T14:19:30.026Z] 
[2020-11-12T14:19:30.026Z] Traceback (most recent call last):
[2020-11-12T14:19:30.026Z]   File "scripts/compose.py", line 19, in <module>
[2020-11-12T14:19:30.026Z]     main()
[2020-11-12T14:19:30.026Z]   File "scripts/compose.py", line 15, in main
[2020-11-12T14:19:30.026Z]     setup()
[2020-11-12T14:19:30.026Z]   File "/var/lib/jenkins/workspace/tegration-test-downstream_PR-975/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 184, in __call__
[2020-11-12T14:19:30.026Z]     self.args.func()
[2020-11-12T14:19:30.026Z]   File "/var/lib/jenkins/workspace/tegration-test-downstream_PR-975/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 654, in start_handler
[2020-11-12T14:19:30.026Z]     self.run_docker_compose_process(docker_compose_build + build_services)
[2020-11-12T14:19:30.026Z]   File "/var/lib/jenkins/workspace/tegration-test-downstream_PR-975/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 433, in run_docker_compose_process
[2020-11-12T14:19:30.026Z]     subprocess.check_call(docker_compose_cmd)
[2020-11-12T14:19:30.026Z]   File "/usr/lib/python3.6/subprocess.py", line 311, in check_call
[2020-11-12T14:19:30.026Z]     raise CalledProcessError(retcode, cmd)
[2020-11-12T14:19:30.026Z] subprocess.CalledProcessError: Command '['docker-compose', '-f', '/var/lib/jenkins/workspace/tegration-test-downstream_PR-975/src/github.com/elastic/apm-integration-testing/docker-compose.yml', '--no-ansi', '--log-level', 'ERROR', 'build', '--pull', '--no-cache', '--parallel', 'agent-python-flask', 'agent-nodejs-express', 'agent-rumjs', 'agent-ruby-rails', 'agent-go-net-http', 'agent-php-apache', 'agent-python-django', 'agent-dotnet', 'agent-java-spring']' returned non-zero exit status 1.
[2020-11-12T14:19:30.026Z] Makefile:67: recipe for target 'start-env' failed
```

