### PR TITLE
[6.x] fix: skip chrome and firefox downloads on the RUM agent Docker image (#965)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-agent-%: venv
 	pytest tests/agent/test_$*.py --reruns 3 --reruns-delay 5 -v -s $(JUNIT_OPT)/agent-$*-junit.xml
 
 test-compose: venv
-	pytest scripts/tests/*_tests.py -v -s $(JUNIT_OPT)/compose-junit.xml
+	pytest scripts/tests/*_tests.py --reruns 3 --reruns-delay 5 -v -s $(JUNIT_OPT)/compose-junit.xml
 
 test-compose-2:
 	virtualenv --python=python2.7 venv2

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -5,15 +5,24 @@ ARG RUM_AGENT_REPO
 ARG APM_SERVER_URL
 
 RUN apt update -qq \
-    && apt install -qq -y curl git gnupg libgconf-2-4 libxss1 libxtst6 python g++ build-essential --no-install-recommends \
-    && curl -sSfkL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update -qq \
-    && apt-get install -qq  -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont python g++ build-essential \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get -qq purge --auto-remove -y \
-    && rm -rf /src/*.deb
+    && apt install -qq -y \
+      curl \
+      git \
+      gnupg \
+      libgconf-2-4 \
+      libxss1 \
+      libxtst6 \
+      python \
+      g++ \
+      build-essential \
+      fonts-ipafont-gothic \
+      fonts-wqy-zenhei \
+      fonts-thai-tlwg \
+      fonts-kacst \
+      ttf-freefont \
+      ca-certificates \
+      chromium \
+      --no-install-recommends
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
@@ -23,6 +32,9 @@ RUN git clone -b $RUM_AGENT_BRANCH --single-branch https://github.com/$RUM_AGENT
 
 WORKDIR /rumjs-integration-test
 
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=//usr/bin/chromium
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 # the install is retry threee times with a pause of 10 seconds
 RUN for i in 1 2 3; \
     do \


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix: skip chrome and firefox downloads on the RUM agent Docker image (#965)