### PR TITLE
[php] use latest release

### DIFF
--- a/docker/php/apache/run.sh
+++ b/docker/php/apache/run.sh
@@ -15,8 +15,16 @@ if [ -z "${PHP_AGENT_VERSION}" ] ; then
   make clean install
   cp /src/ext-elastic-apm.ini /usr/local/etc/php/conf.d/ext-elastic-apm.ini
 else
-  ## Install the given release
-  wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${PHP_AGENT_VERSION}/apm-agent-php_${PHP_AGENT_VERSION}_all.deb" \
+  if [ "${PHP_AGENT_VERSION}" == "latest" ]  ; then
+    wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+    chmod 755 jq
+    TAG_NAME=$(curl -s https://api.github.com/repos/elastic/apm-agent-php/releases/latest | jq -r .tag_name)
+    VERSION="${TAG_NAME/v/}"
+  else
+    TAG_NAME="v${PHP_AGENT_VERSION}"
+    VERSION=${PHP_AGENT_VERSION}
+  fi
+  wget -q "https://github.com/elastic/apm-agent-php/releases/download/${TAG_NAME}/apm-agent-php_${VERSION}_all.deb" \
        -O "/tmp/apm-agent-php.deb"
   dpkg -i "/tmp/apm-agent-php.deb"
 fi

--- a/docker/php/apache/run.sh
+++ b/docker/php/apache/run.sh
@@ -18,7 +18,7 @@ else
   if [ "${PHP_AGENT_VERSION}" == "latest" ]  ; then
     wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
     chmod 755 jq
-    TAG_NAME=$(curl -s https://api.github.com/repos/elastic/apm-agent-php/releases/latest | jq -r .tag_name)
+    TAG_NAME=$(curl -s https://api.github.com/repos/elastic/apm-agent-php/releases/latest | ./jq -r .tag_name)
     VERSION="${TAG_NAME/v/}"
   else
     TAG_NAME="v${PHP_AGENT_VERSION}"

--- a/tests/versions/php.yml
+++ b/tests/versions/php.yml
@@ -1,3 +1,3 @@
 PHP_AGENT:
   - 'github;master'
-  - 'release;1.0.0-beta1'
+  - 'release;latest'

--- a/tests/versions/php.yml
+++ b/tests/versions/php.yml
@@ -1,3 +1,3 @@
 PHP_AGENT:
   - 'github;master'
-  - 'release;0.2'
+  - 'release;1.0.0-beta1'


### PR DESCRIPTION
## What does this PR do?

Use the latest beta version that contains the fix for https://github.com/elastic/apm-integration-testing/pull/972

## Why is it important?

Fix broken tests

## Tests

![image](https://user-images.githubusercontent.com/2871786/99273400-df93c500-2820-11eb-9e5d-ad8f4aa917fb.png)
