### PR TITLE
add enterprise search

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -129,6 +129,12 @@ class LocalSetup(object):
         ).set_defaults(func=self.start_handler)
 
         subparsers.add_parser(
+            'reset-enterprise-search-password',
+            help="Resets enterprise search password.",
+            description="Resets enterprise search password."
+        ).set_defaults(func=self.reset_enterprise_search_password_handler)
+
+        subparsers.add_parser(
             'status',
             help="Prints status of all services.",
             description="Prints the container status for each running service."
@@ -669,6 +675,14 @@ class LocalSetup(object):
             if not sys.stdin.isatty():
                 up_params.extend(["--quiet-pull"])
             self.run_docker_compose_process(docker_compose_cmd + up_params)
+
+            if args.get("enable_enterprise_search"):
+                print("run 'compose.py reset-enterprise-search-password' to reset the enterprise search password")
+
+    @staticmethod
+    def reset_enterprise_search_password_handler():
+        subprocess.call(["docker-compose", "exec", "enterprise-search", "/usr/local/bin/docker-entrypoint.sh",
+                         "--reset-auth"])
 
     @staticmethod
     def status_handler():

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -22,7 +22,7 @@ from .beats import (  # noqa: F401
     Packetbeat, Metricbeat, Heartbeat, Filebeat
 )
 from .elastic_stack import (  # noqa: F401
-    ApmServer, Elasticsearch, Kibana
+    ApmServer, Elasticsearch, EnterpriseSearch, Kibana
 )
 from .aux_services import (  # noqa: F401
     Kafka, Logstash, Postgres, Redis, Zookeeper, WaitService

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -676,9 +676,6 @@ class LocalSetup(object):
                 up_params.extend(["--quiet-pull"])
             self.run_docker_compose_process(docker_compose_cmd + up_params)
 
-            if args.get("enable_enterprise_search"):
-                print("run 'compose.py reset-enterprise-search-password' to reset the enterprise search password")
-
     @staticmethod
     def reset_enterprise_search_password_handler():
         subprocess.call(["docker-compose", "exec", "enterprise-search", "/usr/local/bin/docker-entrypoint.sh",

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -801,7 +801,7 @@ class EnterpriseSearch(StackService, Service):
             "allow_es_settings_modification": "true",
             "ent_search.external_url": "http://localhost:{}".format(self.port),
             "secret_management.encryption_keys": '[4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09]',
-            "ELASTIC_APM_ENABLE": "active",
+            "ELASTIC_APM_ACTIVE": "true",
             "ELASTIC_APM_SERVER_URL": options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ENT_SEARCH_DEFAULT_PASSWORD": options.get("enterprise_search_password", "changeme")
         }

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -763,6 +763,7 @@ class Elasticsearch(StackService, Service):
 
 class EnterpriseSearch(StackService, Service):
     SERVICE_PORT = 3002
+    EXTERNAL_PORT = 3005
 
     @classmethod
     def add_arguments(cls, parser):
@@ -780,6 +781,11 @@ class EnterpriseSearch(StackService, Service):
             "--{}-elasticsearch-password".format(cls.name()),
             help="{} elasticsearch output password.".format(cls.name()),
         )
+        parser.add_argument(
+            "--{}-port".format(cls.name()),
+            default=cls.EXTERNAL_PORT,
+            help="Enterprise search exposed port.",
+        )
 
     def __init__(self, **options):
         super(EnterpriseSearch, self).__init__(**options)
@@ -788,6 +794,7 @@ class EnterpriseSearch(StackService, Service):
 
         self.environment = {
             "allow_es_settings_modification": "true",
+            "ent_search.external_url": "http://localhost:{}".format(self.port),
             "secret_management.encryption_keys": '[4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09]',
             "ELASTIC_APM_ENABLE": "active",
             "ELASTIC_APM_SERVER_URL": options.get("apm_server_url", DEFAULT_APM_SERVER_URL)

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -7,7 +7,7 @@ import json
 import os
 
 from .helpers import curl_healthcheck, try_to_set_slowlog
-from .service import StackService, Service
+from .service import StackService, Service, DEFAULT_APM_SERVER_URL
 
 
 class ApmServer(StackService, Service):
@@ -759,6 +759,63 @@ class Elasticsearch(StackService, Service):
     @staticmethod
     def enabled():
         return True
+
+
+class EnterpriseSearch(StackService, Service):
+    SERVICE_PORT = 3002
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument(
+            "--{}-elasticsearch-url".format(cls.name()),
+            action="append",
+            dest="{}_elasticsearch_urls".format(cls.name()),
+            help="{} elasticsearch output url(s).".format(cls.name())
+        )
+        parser.add_argument(
+            "--{}-elasticsearch-username".format(cls.name()),
+            help="{} elasticsearch output username.".format(cls.name()),
+        )
+        parser.add_argument(
+            "--{}-elasticsearch-password".format(cls.name()),
+            help="{} elasticsearch output password.".format(cls.name()),
+        )
+
+    def __init__(self, **options):
+        super(EnterpriseSearch, self).__init__(**options)
+        self.depends_on = {"elasticsearch": {"condition": "service_healthy"}} if options.get(
+            "enable_elasticsearch", True) else {}
+
+        self.environment = {
+            "allow_es_settings_modification": "true",
+            "secret_management.encryption_keys": '[4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09]',
+            "ELASTIC_APM_ENABLE": "active",
+            "ELASTIC_APM_SERVER_URL": options.get("apm_server_url", DEFAULT_APM_SERVER_URL)
+        }
+
+        self.es_tls = options.get("elasticsearch_enable_tls", False)
+        self.kibana_tls = options.get("kibana_enable_tls", False)
+        es_urls = self.options.get("enterprise_search_elasticsearch_urls") or \
+            [self.default_elasticsearch_hosts(self.es_tls)]
+        self.environment["elasticsearch.host"] = es_urls[0]
+
+        default_creds = {"username": "admin", "password": "changeme"}
+        for cfg in ("username", "password"):
+            es_opt = "{}_elasticsearch_{}".format(self.name(), cfg)
+            if options.get(es_opt):
+                self.environment.update({"elasticsearch.{}".format(cfg): options[es_opt]})
+            elif options.get("xpack_secure"):
+                self.environment.update({"elasticsearch.{}".format(cfg): default_creds.get(cfg)})
+
+    def _content(self):
+        return dict(
+            depends_on=self.depends_on,
+            environment=self.environment,
+            healthcheck=curl_healthcheck(
+                self.SERVICE_PORT, "enterprise-search", path="/", retries=20),
+            labels=None,
+            ports=[self.publish_port(self.port, self.SERVICE_PORT)],
+        )
 
 
 class Kibana(StackService, Service):

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -782,6 +782,11 @@ class EnterpriseSearch(StackService, Service):
             help="{} elasticsearch output password.".format(cls.name()),
         )
         parser.add_argument(
+            "--{}-password".format(cls.name()),
+            default="changeme",
+            help="{} user password.".format(cls.name()),
+        )
+        parser.add_argument(
             "--{}-port".format(cls.name()),
             default=cls.EXTERNAL_PORT,
             help="Enterprise search exposed port.",
@@ -797,7 +802,8 @@ class EnterpriseSearch(StackService, Service):
             "ent_search.external_url": "http://localhost:{}".format(self.port),
             "secret_management.encryption_keys": '[4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09]',
             "ELASTIC_APM_ENABLE": "active",
-            "ELASTIC_APM_SERVER_URL": options.get("apm_server_url", DEFAULT_APM_SERVER_URL)
+            "ELASTIC_APM_SERVER_URL": options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
+            "ENT_SEARCH_DEFAULT_PASSWORD": options.get("enterprise_search_password", "changeme")
         }
 
         self.es_tls = options.get("elasticsearch_enable_tls", False)

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -12,7 +12,7 @@ from ..modules.apm_agents import (
 )
 from ..modules.aux_services import Logstash, Kafka, Zookeeper
 from ..modules.beats import Filebeat, Heartbeat, Metricbeat, Packetbeat
-from ..modules.elastic_stack import ApmServer, Elasticsearch, Kibana
+from ..modules.elastic_stack import ApmServer, Elasticsearch, EnterpriseSearch, Kibana
 
 
 class ServiceTest(unittest.TestCase):
@@ -464,6 +464,7 @@ class AgentServiceTest(ServiceTest):
 
         agent = AgentPhpApache(enable_apm_server=False).render()["agent-php-apache"]
         self.assertFalse("apm-server" in agent["depends_on"])
+
 
 class ApmServerServiceTest(ServiceTest):
     def test_default_snapshot(self):
@@ -963,6 +964,14 @@ class ElasticsearchServiceTest(ServiceTest):
                               ], elasticsearch["labels"])
 
 
+class EnterpriseSearchServiceTest(ServiceTest):
+    def test_release(self):
+        entsearch = EnterpriseSearch(version="7.12.20", release=True).render()["enterprise-search"]
+        self.assertEqual(
+            entsearch["image"], "docker.elastic.co/enterprise-search/enterprise-search:7.12.20"
+        )
+
+
 class FilebeatServiceTest(ServiceTest):
     def test_filebeat_pre_6_1(self):
         filebeat = Filebeat(version="6.0.4", release=True).render()
@@ -1202,6 +1211,7 @@ class KibanaServiceTest(ServiceTest):
         kibana = Kibana(kibana_yml="/path/to.yml").render()["kibana"]
         self.assertIn("/path/to.yml:/usr/share/kibana/config/kibana.yml", kibana['volumes'])
 
+
 class LogstashServiceTest(ServiceTest):
     def test_snapshot(self):
         logstash = Logstash(version="6.2.4", snapshot=True).render()["logstash"]
@@ -1267,6 +1277,7 @@ class LogstashServiceTest(ServiceTest):
     def test_logstash_ubi8(self):
         logstash = Logstash(version="7.10.0", release=True, ubi8=True).render()["logstash"]
         self.assertEqual("docker.elastic.co/logstash/logstash-ubi8:7.10.0", logstash['image'])
+
 
 class MetricbeatServiceTest(ServiceTest):
     def test_metricbeat(self):


### PR DESCRIPTION
## What does this PR do?

Adds enterprise search into apm-integration-testing using `--with-enterprise-search` option.  Also adds a convenience command for resetting the enterprise search user password using `compose.py reset-enterprise-search-password`.

## Why is it important?

Enterprise search has the Ruby agent integrated.  By default APM is enabled:

![image](https://user-images.githubusercontent.com/83483/99590126-ef471100-29ba-11eb-8f7a-43ca9651d082.png)

