### PR TITLE
don't use our own logging handler for logging in the flask app

### DIFF
--- a/docker/python/flask/app.py
+++ b/docker/python/flask/app.py
@@ -3,7 +3,6 @@
 import elasticapm
 from flask import Flask
 from elasticapm.contrib.flask import ElasticAPM
-from elasticapm.handlers.logging import LoggingHandler
 import logging
 import os
 
@@ -72,6 +71,6 @@ if __name__ == '__main__':
     app.run(host='0.0.0.0', port=int(os.environ['FLASK_PORT']))
 
     # Create a logging handler and attach it.
-    handler = LoggingHandler(client=apm.client)
+    handler = logging.StreamHandler()
     handler.setLevel(logging.INFO)
     app.logger.addHandler(handler)

--- a/docker/python/flask/app.py
+++ b/docker/python/flask/app.py
@@ -23,7 +23,7 @@ app.config['ELASTIC_APM'] = {
     'TRANSACTIONS_IGNORE_PATTERNS': ['.*healthcheck'],
     'LOG_LEVEL': 'warning',
 }
-apm = ElasticAPM(app, logging=True)
+apm = ElasticAPM(app, logging=False)
 
 
 @app.route('/')

--- a/tests/agent/test_python.py
+++ b/tests/agent/test_python.py
@@ -13,8 +13,7 @@ def test_req_flask(flask):
 @pytest.mark.version
 @pytest.mark.flask
 def test_flask_error(flask):
-    # one from exception handler, one from logging handler
-    utils.check_agent_error(flask.oof, flask.apm_server.elasticsearch, ct=2)
+    utils.check_agent_error(flask.oof, flask.apm_server.elasticsearch, ct=1)
 
 
 @pytest.mark.version


### PR DESCRIPTION
this leads to spurious events, making tests fail

## What does this PR do?

For some reason, the flask test app was set up to use our own logging handlers for log messages from the agent itself. This led to problems once the log level of some internal log messages of the agent changed.
## Why is it important?

Logging to STDERR instead of using our own log handlers sends the logs from the agent to the console instead of APM Server

## Related issues
Closes #987
