### PR TITLE
Agent tests avoid unnecessary sleeps

### DIFF
--- a/tests/fixtures/es.py
+++ b/tests/fixtures/es.py
@@ -36,9 +36,10 @@ def es():
         def count(self, q):
             ct = 0
             while ct == 0:
-                time.sleep(3)
                 s = self.es.count(index=self.index, body=q)
                 ct = s['count']
-            return ct
+                if ct:
+                    return ct
+                time.sleep(3)
 
     return Elasticsearch(getElasticsearchURL())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,6 +52,10 @@ def check_elasticsearch_count(elasticsearch,
     while actual != expected and retries < max_retries:
         try:
             actual = elasticsearch.count(query)
+            if actual >= expected:
+                # if there are already more docs, we can stop counting.
+                # The total count may be larger, but that's not important enough to wait
+                break
             retries += 1
             time.sleep(10)
         except TimeoutError:


### PR DESCRIPTION
## What does this PR do?

This saves 20-30 seconds per agent. Not a huge amount, considering
that some of the agents take 15-20 minutes just to build the docker
containers, but I'll take anything we can :)

## Why is it important?

Faster tests 
