### PR TITLE
Fix services without healthcheck

### DIFF
--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -140,4 +140,10 @@ class WaitService(Service):
         )
 
     def isHealthCheckServiceDisabled(self, name):
-        return name == "opbeans-load-generator" or name == "filebeat" or name == "heartbeat" or name == "metricbeat" or name == "packetbeat"
+        return (
+            name == "opbeans-load-generator" or
+            name == "filebeat" or
+            name == "heartbeat" or
+            name == "metricbeat" or
+            name == "packetbeat"
+        )

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -129,7 +129,7 @@ class WaitService(Service):
 
     def _content(self):
         for s in self.services:
-            if s.name() != self.name() and s.name() != "opbeans-load-generator":
+            if s.name() != self.name() and not self.isHealthCheckServiceDisabled(s.name()):
                 self.depends_on[s.name()] = {"condition": "service_healthy"}
         return dict(
             container_name="wait",
@@ -138,3 +138,6 @@ class WaitService(Service):
             labels=None,
             logging=None,
         )
+
+    def isHealthCheckServiceDisabled(self, name):
+        return name == "opbeans-load-generator" or name == "filebeat" or name == "heartbeat" or name == "metricbeat" or name == "packetbeat"

--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -140,10 +140,10 @@ class WaitService(Service):
         )
 
     def isHealthCheckServiceDisabled(self, name):
-        return (
-            name == "opbeans-load-generator" or
-            name == "filebeat" or
-            name == "heartbeat" or
-            name == "metricbeat" or
-            name == "packetbeat"
-        )
+        return name in [
+            "filebeat",
+            "heartbeat",
+            "metricbeat",
+            "opbeans-load-generator",
+            "packetbeat"
+        ]

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1095,6 +1095,8 @@ class LocalTest(unittest.TestCase):
             "redis",
             "wait-service",
         })
+        self.assertIn("apm-server", got["services"]["wait-service"]["depends_on"])
+        self.assertNotIn("filebeat", got["services"]["wait-service"]["depends_on"])
 
     @mock.patch(cli.__name__ + ".load_images")
     def test_start_one_opbeans(self, _ignore_load_images):


### PR DESCRIPTION
## What does this PR do?

Avoid adding healtcheck for services that don't have any healthcheck.

## Why is it important?

Fix a regression

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/986
