### PR TITLE
Fix packetbeat kibana user/pass

### DIFF
--- a/docker/packetbeat/packetbeat.6.x-compat.yml
+++ b/docker/packetbeat/packetbeat.6.x-compat.yml
@@ -35,5 +35,5 @@ xpack.monitoring.enabled: true
 queue.mem:
   events: 20000
 setup.kibana.host: '${KIBANA_HOST:kibana}:${KIBANA_PORT:5601}'
-setup.kibana.username: '${KIBANA_USERNAME:}'
-setup.kibana.password: '${KIBANA_PASSWORD:}'
+setup.kibana.username: '${KIBANA_USERNAME:admin}'
+setup.kibana.password: '${KIBANA_PASSWORD:changeme}'

--- a/docker/packetbeat/packetbeat.yml
+++ b/docker/packetbeat/packetbeat.yml
@@ -36,5 +36,5 @@ monitoring.enabled: true
 queue.mem:
   events: 20000
 setup.kibana.host: '${KIBANA_HOST:kibana}:${KIBANA_PORT:5601}'
-setup.kibana.username: '${KIBANA_USERNAME:}'
-setup.kibana.password: '${KIBANA_PASSWORD:}'
+setup.kibana.username: '${KIBANA_USERNAME:admin}'
+setup.kibana.password: '${KIBANA_PASSWORD:changeme}'

--- a/scripts/modules/beats.py
+++ b/scripts/modules/beats.py
@@ -220,7 +220,25 @@ class Packetbeat(BeatMixin, StackService, Service):
     DEFAULT_COMMAND = ["packetbeat", "-e", "--strict.perms=false", "-E", "packetbeat.interfaces.device=eth0"]
     docker_path = "beats"
 
+    @classmethod
+    def add_arguments(cls, parser):
+        super(Packetbeat, cls).add_arguments(parser)
+        parser.add_argument(
+            "--packetbeat-kibana-username",
+            help="packetbeat kibana username (default admin).",
+            dest="packetbeat_kibana_username"
+        )
+        parser.add_argument(
+            "--packetbeat-kibana-password",
+            help="packetbeat kibana password (default changeme).",
+            dest="packetbeat_kibana_password"
+        )
+
     def _content(self):
+        if self.options.get("packetbeat_kibana_username"):
+            self.environment['KIBANA_USERNAME'] = self.options.get("packetbeat_kibana_username")
+        if self.options.get("packetbeat_kibana_password"):
+            self.environment['KIBANA_PASSWORD'] = self.options.get("packetbeat_kibana_password")
         return dict(
             command=self.command,
             depends_on=self.depends_on,

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1423,6 +1423,11 @@ class PacketbeatServiceTest(ServiceTest):
         self.assertTrue(
             "output.elasticsearch.hosts=[\"elasticsearch01:9200\", \"elasticsearch02:9200\"]" in beat['command'])
 
+    def test_packetbeat_with_kibana_username_password(self):
+        packetbeat = Packetbeat(packetbeat_kibana_username='foo', packetbeat_kibana_password='bar').render()["packetbeat"]
+        self.assertEqual("foo", packetbeat["environment"]["KIBANA_USERNAME"])
+        self.assertEqual("bar", packetbeat["environment"]["KIBANA_PASSWORD"])
+
 
 class HeartbeatServiceTest(ServiceTest):
     def test_heartbeat_elasticsearch_output_tls(self):


### PR DESCRIPTION
## What does this PR do?

Use default user/pass for the packetbeat and enable the customisation with two new flags:
- `--packetbeat-kibana-username`
- `--packetbeat-kibana-password`

## Why is it important?

Fixes the existing issue with no values by default

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/992


## Tests

```bash
$ ./scripts/compose.py start master --help  | grep packetbeat-kibana -A 1
                        [--packetbeat-kibana-username PACKETBEAT_KIBANA_USERNAME]
                        [--packetbeat-kibana-password PACKETBEAT_KIBANA_PASSWORD]
                        [--postgres-port POSTGRES_PORT]
--
  --packetbeat-kibana-username PACKETBEAT_KIBANA_USERNAME
                        packetbeat kibana username (default admin).
--
  --packetbeat-kibana-password PACKETBEAT_KIBANA_PASSWORD
                        packetbeat kibana password (default changeme).
```
