### PR TITLE
Use .NET 5 docker image

### DIFF
--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -28,7 +28,7 @@ if [ -n "${APM_SERVER_BRANCH}" ]; then
 fi
 
 if [ -z "${DISABLE_BUILD_PARALLEL}" -o "${DISABLE_BUILD_PARALLEL}" = "false" ]; then
- BUILD_OPTS="${BUILD_OPTS} --build-parallel"
+ BUILD_OPTS="${BUILD_OPTS}"
 fi
 
 ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION:-'7.0.0'}

--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -28,7 +28,7 @@ if [ -n "${APM_SERVER_BRANCH}" ]; then
 fi
 
 if [ -z "${DISABLE_BUILD_PARALLEL}" -o "${DISABLE_BUILD_PARALLEL}" = "false" ]; then
- BUILD_OPTS="${BUILD_OPTS}"
+ BUILD_OPTS="${BUILD_OPTS} --build-parallel"
 fi
 
 ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION:-'7.0.0'}

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -9,7 +9,7 @@ ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=
 # Workaround for https://github.com/dotnet/sdk/issues/14497
-ARG DOTNET_HOST_PATH=dotnet
+ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
 RUN ./run.sh

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -3,10 +3,12 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=
+# Workaround for https://github.com/dotnet/sdk/issues/14497
+ARG DOTNET_HOST_PATH=dotnet
 WORKDIR /src
 COPY . /src
 RUN ./run.sh

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -13,7 +13,7 @@ ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
 # install SDK version in global.json of elastic/apm-agent-dotnet
-# TODO: remove once global.json is on 5.0 *and* PRs are updated to 5.0 in global.json
+# Needed when building branches that specify 3.1.100 SDK in global.json
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -4,6 +4,7 @@
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -12,6 +12,8 @@ ARG DOTNET_AGENT_VERSION=
 ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
+RUN curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh \
+    && bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version 3.1.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -12,8 +12,9 @@ ARG DOTNET_AGENT_VERSION=
 ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
-RUN curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh \
-    && bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version 3.1.100
+# install SDK version in global.json of elastic/apm-agent-dotnet
+# TODO: remove once global.json is on 5.0 *and* PRs are updated to 5.0 in global.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -48,7 +48,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
-  dotnet restore
+
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/aspnetcore

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -21,9 +21,11 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     INSTALLED_VERSIONS=()
     while IFS= read -r result
     do
+        # shellcheck disable=SC2001
         INSTALLED_VERSIONS+=( "$(echo "$result" | sed -e 's/^\(.*\)\s.*/\1/')" )
     done < <(dotnet --list-sdks)
 
+    # shellcheck disable=SC2199,SC2076
     if [[ ! " ${INSTALLED_VERSIONS[@]} " =~ " ${GLOBAL_JSON_VERSION} " ]]; then
       ### No compatible version installed so download and install
       curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -15,24 +15,6 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   git checkout "${DOTNET_AGENT_BRANCH}"
   git rev-parse HEAD
 
-  ### Check the SDK version in global.json and ensure that we have a compatible version installed
-  if [[ -f global.json ]]; then
-    GLOBAL_JSON_VERSION=$(sed -n -e 's/\s*"version":\s*"\(.*\)",/\1/p' global.json)
-    INSTALLED_VERSIONS=()
-    while IFS= read -r result
-    do
-        # shellcheck disable=SC2001
-        INSTALLED_VERSIONS+=( "$(echo "$result" | sed -e 's/^\(.*\)\s.*/\1/')" )
-    done < <(dotnet --list-sdks)
-
-    # shellcheck disable=SC2199,SC2076
-    if [[ ! " ${INSTALLED_VERSIONS[@]} " =~ " ${GLOBAL_JSON_VERSION} " ]]; then
-      ### No compatible version installed so download and install
-      curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh
-      bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version "${GLOBAL_JSON_VERSION}"
-    fi
-  fi
-
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
 
@@ -49,7 +31,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
 
-  dotnet restore -bl:restore.binlog 
+  dotnet restore
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/aspnetcore

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -49,6 +49,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
 
+  dotnet restore -bl:restore.binlog 
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/aspnetcore

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -49,7 +49,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
   dotnet restore
-  dotnet pack -c Release -o /src/local-packages
+  dotnet pack ElasticApmAgent.sln -c Release -o /src/local-packages
 
   cd /src/aspnetcore
   mv /src/NuGet.Config .

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -15,6 +15,22 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   git checkout "${DOTNET_AGENT_BRANCH}"
   git rev-parse HEAD
 
+  ### Check the SDK version in global.json and ensure that we have a compatible version installed
+  if [[ -f global.json ]]; then
+    GLOBAL_JSON_VERSION=$(sed -n -e 's/\s*"version":\s*"\(.*\)",/\1/p' global.json)
+    INSTALLED_VERSIONS=()
+    while IFS= read -r result
+    do
+        INSTALLED_VERSIONS+=( "$(echo "$result" | sed -e 's/^\(.*\)\s.*/\1/')" )
+    done < <(dotnet --list-sdks)
+
+    if [[ ! " ${INSTALLED_VERSIONS[@]} " =~ " ${GLOBAL_JSON_VERSION} " ]]; then
+      ### No compatible version installed so download and install
+      curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh
+      bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version "${GLOBAL_JSON_VERSION}"
+    fi
+  fi
+
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
 

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -49,7 +49,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
   dotnet restore
-  dotnet pack ElasticApmAgent.sln -c Release -o /src/local-packages
+  dotnet pack -c Release -o /src/local-packages
 
   cd /src/aspnetcore
   mv /src/NuGet.Config .

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -15,8 +15,9 @@ ARG OPBEANS_DOTNET_BRANCH=master
 ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
-RUN curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh \
-    && bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version 3.1.100
+# install SDK version in global.json of elastic/apm-agent-dotnet
+# TODO: remove once global.json is on 5.0 *and* PRs are updated to 5.0 in global.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -15,6 +15,8 @@ ARG OPBEANS_DOTNET_BRANCH=master
 ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
+RUN curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh \
+    && bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version 3.1.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -16,7 +16,7 @@ ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
 # install SDK version in global.json of elastic/apm-agent-dotnet
-# TODO: remove once global.json is on 5.0 *and* PRs are updated to 5.0 in global.json
+# Needed when building branches that specify 3.1.100 SDK in global.json
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -4,12 +4,15 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS opbeans-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS opbeans-dotnet
+ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=
 ARG OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
 ARG OPBEANS_DOTNET_BRANCH=master
+# Workaround for https://github.com/dotnet/sdk/issues/14497
+ARG DOTNET_HOST_PATH=dotnet
 WORKDIR /src
 COPY . /src
 RUN ./run.sh

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -12,7 +12,7 @@ ARG DOTNET_AGENT_VERSION=
 ARG OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
 ARG OPBEANS_DOTNET_BRANCH=master
 # Workaround for https://github.com/dotnet/sdk/issues/14497
-ARG DOTNET_HOST_PATH=dotnet
+ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
 RUN ./run.sh

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -24,9 +24,11 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     INSTALLED_VERSIONS=()
     while IFS= read -r result
     do
+        # shellcheck disable=SC2001
         INSTALLED_VERSIONS+=( "$(echo "$result" | sed -e 's/^\(.*\)\s.*/\1/')" )
     done < <(dotnet --list-sdks)
 
+    # shellcheck disable=SC2199,SC2076
     if [[ ! " ${INSTALLED_VERSIONS[@]} " =~ " ${GLOBAL_JSON_VERSION} " ]]; then
       ### No compatible version installed so download and install
       curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -52,7 +52,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
   dotnet restore
-  dotnet pack -c Release -o /src/local-packages
+  dotnet pack ElasticApmAgent.sln -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet || exit
   mv /src/NuGet.Config .

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -51,7 +51,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
-  dotnet restore
+
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet || exit

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -18,24 +18,6 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
   git checkout "${DOTNET_AGENT_BRANCH}"
 
-  ### Check the SDK version in global.json and ensure that we have a compatible version installed
-  if [[ -f global.json ]]; then
-    GLOBAL_JSON_VERSION=$(sed -n -e 's/\s*"version":\s*"\(.*\)",/\1/p' global.json)
-    INSTALLED_VERSIONS=()
-    while IFS= read -r result
-    do
-        # shellcheck disable=SC2001
-        INSTALLED_VERSIONS+=( "$(echo "$result" | sed -e 's/^\(.*\)\s.*/\1/')" )
-    done < <(dotnet --list-sdks)
-
-    # shellcheck disable=SC2199,SC2076
-    if [[ ! " ${INSTALLED_VERSIONS[@]} " =~ " ${GLOBAL_JSON_VERSION} " ]]; then
-      ### No compatible version installed so download and install
-      curl -s -O -L https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh
-      bash ./dotnet-install.sh --install-dir "${DOTNET_ROOT}" -version "${GLOBAL_JSON_VERSION}"
-    fi
-  fi
-
   ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
   mkdir /src/local-packages
 
@@ -52,7 +34,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
 
-  dotnet restore -bl:restore.binlog 
+  dotnet restore
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet || exit

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -52,6 +52,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
 
+  dotnet restore -bl:restore.binlog 
   dotnet pack -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet || exit

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -52,7 +52,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
   dotnet restore
-  dotnet pack ElasticApmAgent.sln -c Release -o /src/local-packages
+  dotnet pack -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet || exit
   mv /src/NuGet.Config .


### PR DESCRIPTION
## What does this PR do?

This PR updates the dotnet Dockerfile to use .NET 5 docker image for build.

`DOTNET_HOST_PATH` needs to be set to workaround an issue with building ASP.NET Core 2.1 with the .NET 5 SDKs. See https://github.com/dotnet/sdk/issues/14497 for more details.

## Why is it important?

Needed to be able to run integration tests for the .NET agent when the global SDK is updated to .NET 5.

## Related issues
elastic/apm-agent-dotnet#1040
