### PR TITLE
[php] configure apache automatically

### DIFF
--- a/docker/php/apache/run.sh
+++ b/docker/php/apache/run.sh
@@ -27,6 +27,10 @@ else
   wget -q "https://github.com/elastic/apm-agent-php/releases/download/${TAG_NAME}/apm-agent-php_${VERSION}_all.deb" \
        -O "/tmp/apm-agent-php.deb"
   dpkg -i "/tmp/apm-agent-php.deb"
+
+  ## Echo the installation of the agent requires the configuration for the apache2.
+  a2enconf elastic
+  a2enconf elastic-custom
 fi
 
 ## Copy the app to the /var/www/html folder


### PR DESCRIPTION
## What does this PR do?

Verify https://github.com/elastic/apm-agent-php/pull/310


## Test

Modify `docker/php/apache/run.sh` to use https://apm-ci.elastic.co/job/apm-agent-php/job/apm-agent-php-mbp/view/change-requests/job/PR-311/lastSuccessfulBuild/artifact/build/packages/apm-agent-php_1.0.0-beta1_all.deb

```bash
python3 scripts/compose.py start 8.0.0  --php-agent-version latest --build-parallel --java-m2-cache   --with-agent-php-apache   --no-apm-server-dashboards   --no-apm-server-self-instrument   --apm-server-agent-config-poll=1s   --force-build --no-xpack-secure   --apm-log-level=debug

```


```
Creating /opt/elastic/apm-agent-php/etc/elastic.ini
; ***** DO NOT EDIT THIS FILE *****
; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
; To overwrite the INI settings for this extension, edit
; the INI file in this directory "/opt/elastic/apm-agent-php/etc/elastic-custom.ini"
[elastic]
extension=/opt/elastic/apm-agent-php/extensions/elastic_apm-20190902.so
elastic_apm.bootstrap_php_part_file=/opt/elastic/apm-agent-php/src/bootstrap_php_part.php
; END OF AUTO-GENERATED by the Elastic PHP agent post-install.sh script
/opt/elastic/apm-agent-php/etc/elastic.ini created
Created empty /opt/elastic/apm-agent-php/etc/elastic-custom.ini
Configuring elastic.ini for supported SAPI's
Found SAPI config directory: /etc/apache2/conf-available
Linking /opt/elastic/apm-agent-php/etc/elastic.ini to /etc/apache2/conf-available/98-elastic.ini
Linking /opt/elastic/apm-agent-php/etc/elastic-custom.ini to /etc/apache2/conf-available/99-elastic-custom.ini
Failed. Elastic PHP agent extension is not enabled
Set up the Agent manually as explained in:
https://github.com/elastic/apm-agent-php/blob/master/docs/setup.asciidoc
Enable the extension by adding the following to your php.ini file:
extension=/opt/elastic/apm-agent-php/extensions/elastic_apm-20190902.so
elastic_apm.bootstrap_php_part_file=/opt/elastic/apm-agent-php/src/bootstrap_php_part.php
+ a2enconf elastic
ERROR: Conf elastic does not exist!
+ a2enconf elastic-custom
ERROR: Conf elastic-custom does not exist!
+ cp -rf /src/app/foo /src/app/healthcheck /src/app/info.php /var/www/html
```