### PR TITLE
Bump APM Server to 7.10 release

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
     quietPeriod(10)
   }
   parameters {
-    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.7", description: "Elastic Stack Git branch/tag to use")
+    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.10", description: "Elastic Stack Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -31,7 +31,7 @@ pipeline {
   }
   parameters {
     choice(name: 'INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All'], description: 'Name of the Tests or APM Agent you want to run the integration tests.')
-    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.7", description: "Elastic Stack Git branch/tag to use")
+    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.10", description: "Elastic Stack Git branch/tag to use")
     string(name: 'INTEGRATION_TESTING_VERSION', defaultValue: "7.x", description: "Integration testing Git branch/tag to use")
     string(name: 'MERGE_TARGET', defaultValue: "7.x", description: "Integration testing Git branch/tag where to merge this code")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -28,7 +28,7 @@ pipeline {
   }
   parameters {
     choice(name: 'INTEGRATION_TEST', choices: ['.NET', 'Go', 'Java', 'Node.js', 'Python', 'Ruby', 'RUM', 'UI', 'All', 'Opbeans'], description: 'Name of the APM Agent you want to run the integration tests.')
-    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "8.0.0", description: "Elastic Stack Git branch/tag to use")
+    string(name: 'ELASTIC_STACK_VERSION', defaultValue: "7.10", description: "Elastic Stack Git branch/tag to use")
     string(name: 'BUILD_OPTS', defaultValue: "", description: "Addicional build options to passing compose.py")
     string(name: 'GITHUB_CHECK_NAME', defaultValue: '', description: 'Name of the GitHub check to be updated. Only if this build is triggered from another parent stream.')
     string(name: 'GITHUB_CHECK_REPO', defaultValue: '', description: 'Name of the GitHub repo to be updated. Only if this build is triggered from another parent stream.')

--- a/.ci/scripts/7.0-upgrade.sh
+++ b/.ci/scripts/7.0-upgrade.sh
@@ -24,7 +24,7 @@ make start-env docker-compose-wait
 sleep 60
 
 # upgrade elasticsearch, remove all other services
-export COMPOSE_ARGS="7.7 --no-apm-server --elasticsearch-data-dir '' --remove-orphans"
+export COMPOSE_ARGS="7.10 --no-apm-server --elasticsearch-data-dir '' --remove-orphans"
 
 # install 6.x* index pattern for v1 tests
 docker run --rm --network apm-integration-testing docker.elastic.co/apm/apm-server:6.7.1 apm-server setup --template -e -E setup.template.pattern='apm-6.x*' -E setup.template.name=apm-6.x

--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -32,7 +32,7 @@ if [ -z "${DISABLE_BUILD_PARALLEL}" ] || [ "${DISABLE_BUILD_PARALLEL}" = "false"
  BUILD_OPTS="${BUILD_OPTS} --build-parallel"
 fi
 
-ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION:-'7.4'}
+ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION:-'7.10'}
 
 # assume we're under CI if BUILD_NUMBER is set
 if [ -n "${BUILD_NUMBER}" ]; then


### PR DESCRIPTION
## What does this PR do?
It adds the 7.10-release of APM Server to the ITs

After the release, we bumped the stack too in this PR

## Why is it important?
We want to start testing the new version of the APM Server

## Issues

Blocked by https://github.com/elastic/apm-integration-testing/pull/1001