### PR TITLE
Download maven dependencies firstly

### DIFF
--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -12,24 +12,26 @@ fi
 if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
   cd /agent/apm-agent-java
   git --no-pager log -1
+  mvn dependency:go-offline --fail-never -q -B
   mvn -q --batch-mode clean install \
     -DskipTests=true \
     -Dhttps.protocols=TLSv1.2 \
     -Dmaven.javadoc.skip=true \
     -Dmaven.wagon.http.retryHandler.count=10 \
-    -Dhttp.keepAlive=false \
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     -Dmaven.repo.local=${M2_REPOSITORY_FOLDER}
   # shellcheck disable=SC2016
   JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   export JAVA_AGENT_BUILT_VERSION="${JAVA_AGENT_BUILT_VERSION}"
 else
+  mvn dependency:go-offline --fail-never -q -B
   mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       -Dhttps.protocols=TLSv1.2 \
       -DrepoUrl=https://repo1.maven.apache.org/maven2 \
       -Dmaven.wagon.http.retryHandler.count=10 \
-      -Dhttp.keepAlive=false \
+      -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
       -Dartifact="co.elastic.apm:${ARTIFACT_ID}:${JAVA_AGENT_BUILT_VERSION}" \
       -Dmaven.repo.local=${M2_REPOSITORY_FOLDER}
 fi

--- a/docker/opbeans/java/build-agent.sh
+++ b/docker/opbeans/java/build-agent.sh
@@ -12,12 +12,13 @@ if [ -n "${JAVA_AGENT_BRANCH}" ] ; then
   git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
   git checkout "${JAVA_AGENT_BRANCH}"
 
+  mvn dependency:go-offline --fail-never -q -B
   mvn -q --batch-mode clean install \
     -DskipTests=true \
     -Dhttps.protocols=TLSv1.2 \
     -Dmaven.javadoc.skip=true \
-    -Dmaven.wagon.http.retryHandler.count=3 \
-    -Dhttp.keepAlive=false \
+    -Dmaven.wagon.http.retryHandler.count=10 \
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   # shellcheck disable=SC2016
   VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)


### PR DESCRIPTION
## What does this PR do?

* Use [go-offline](https://maven.apache.org/plugins/maven-dependency-plugin/go-offline-mojo.html) prebuild to fetch all the dependencies.
* Set `maven.wagon.httpconnectionManager.ttlSeconds` to 25 seconds and `maven.wagon.http.retryHandler.count` to 3 retries.

## Why

I still see issues related to the connection reset :/ 

## Further details

The documentation for `maven.wagon.httpconnectionManager.ttlSeconds` is available in the source code:
* https://github.com/apache/maven-wagon/blob/wagon-3.4.1/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java#L297-L305

Documentation for `maven.wagon.http.retryHandler.count` is in https://maven.apache.org/wagon/wagon-providers/wagon-http/


This is similar to the change made in Java Agent: https://github.com/elastic/apm-agent-java/pull/1556