### PR TITLE
 Fix regression with dependency:go-offline

### DIFF
--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -15,8 +15,8 @@ if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
   mvn dependency:go-offline --fail-never -q -B
   mvn -q --batch-mode clean install \
     -DskipTests=true \
-    -Dhttps.protocols=TLSv1.2 \
     -Dmaven.javadoc.skip=true \
+    -Dhttps.protocols=TLSv1.2 \
     -Dmaven.wagon.http.retryHandler.count=10 \
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
@@ -39,10 +39,10 @@ cd /app
 mvn -q --batch-mode -DAGENT_API_VERSION="${JAVA_AGENT_BUILT_VERSION}" \
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
   -DskipTests=true \
-  -Dhttps.protocols=TLSv1.2 \
   -Dmaven.javadoc.skip=true \
+  -Dhttps.protocols=TLSv1.2 \
   -Dmaven.wagon.http.retryHandler.count=10 \
-  -Dhttp.keepAlive=false \
+  -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
   -Dmaven.repo.local=${M2_REPOSITORY_FOLDER} \
   package
 

--- a/docker/java/spring/maven-package.sh
+++ b/docker/java/spring/maven-package.sh
@@ -25,7 +25,6 @@ if [ -z "${JAVA_AGENT_BUILT_VERSION}" ] ; then
   JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   export JAVA_AGENT_BUILT_VERSION="${JAVA_AGENT_BUILT_VERSION}"
 else
-  mvn dependency:go-offline --fail-never -q -B
   mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
       -Dhttps.protocols=TLSv1.2 \


### PR DESCRIPTION
## What does this PR do?

* `dependency:go-offline` should not run using `JAVA_AGENT_BUILT_VERSION`
* Normalise some other maven commands
