### PR TITLE
set kibana SERVER_HOST

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -895,7 +895,10 @@ class EnterpriseSearch(StackService, Service):
 
 
 class Kibana(StackService, Service):
-    default_environment = {"SERVER_NAME": "kibana.example.org"}
+    default_environment = {
+        "SERVER_HOST": "0.0.0.0",
+        "SERVER_NAME": "kibana.example.org",
+    }
 
     SERVICE_PORT = 5601
 

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -723,7 +723,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_6.2.10_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
+                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_HOST: 0.0.0.0, SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true'}
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -818,7 +818,7 @@ class LocalTest(unittest.TestCase):
                 container_name: localtesting_6.3.10_kibana
                 depends_on:
                     elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
+                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_HOST: 0.0.0.0, SERVER_NAME: kibana.example.org, XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
                     interval: 10s
                     retries: 20
@@ -957,6 +957,7 @@ class LocalTest(unittest.TestCase):
                     ELASTICSEARCH_PASSWORD: changeme,
                     ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200',
                     ELASTICSEARCH_USERNAME: kibana_system_user,
+                    SERVER_HOST: 0.0.0.0,
                     SERVER_NAME: kibana.example.org,
                     STATUS_ALLOWANONYMOUS: 'true',
                     TELEMETRY_ENABLED: 'false',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1155,6 +1155,7 @@ class KibanaServiceTest(ServiceTest):
                     image: docker.elastic.co/kibana/kibana-x-pack:6.2.4
                     container_name: localtesting_6.2.4_kibana
                     environment:
+                        SERVER_HOST: 0.0.0.0
                         SERVER_NAME: kibana.example.org
                         ELASTICSEARCH_HOSTS: http://elasticsearch:9200
                         XPACK_MONITORING_ENABLED: 'true'
@@ -1184,6 +1185,7 @@ class KibanaServiceTest(ServiceTest):
                     image: docker.elastic.co/kibana/kibana:6.3.5
                     container_name: localtesting_6.3.5_kibana
                     environment:
+                        SERVER_HOST: 0.0.0.0
                         SERVER_NAME: kibana.example.org
                         ELASTICSEARCH_HOSTS: http://elasticsearch:9200
                         XPACK_MONITORING_ENABLED: 'true'


### PR DESCRIPTION
## What does this PR do?

work around issue `"host" must be a valid hostname` with kibana container default `server.host: 0` setting

## Why is it important?

kibana container can't start

related to: https://github.com/elastic/kibana/issues/86716

