### PR TITLE
[ruby] Support 2.x ruby version and latest

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     PIPELINE_LOG_LEVEL='INFO'
+    GIT_REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-integration-testing.git'
   }
   triggers {
     cron 'H H(3-4) * * 1-5'
@@ -43,7 +44,7 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}",
-                    reference: '/var/lib/jenkins/.git-references/apm-integration-testing.git')
+                    reference: "${GIT_REFERENCE_REPO}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
@@ -80,7 +81,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside(){
+                docker.image('python:3.7-stretch').inside("-v ${GIT_REFERENCE_REPO}:${GIT_REFERENCE_REPO}") {
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
                     preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true, registry: '')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,8 +79,13 @@ pipeline {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
               unstash 'source'
-              dir("${BASE_DIR}"){
-                preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true)
+              script {
+                docker.image('python:3.7-stretch').inside(){
+                  dir("${BASE_DIR}"){
+                    // registry: '' will help to disable the docker login
+                    preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true, registry: '')
+                  }
+                }
               }
             }
           }

--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -7,7 +7,16 @@ test -z "$srcdir" && srcdir=.
 . "${srcdir}/common.sh"
 
 if [ -n "${APM_AGENT_RUBY_VERSION}" ]; then
-  BUILD_OPTS="${BUILD_OPTS} --ruby-agent-version='${APM_AGENT_RUBY_VERSION#*;}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}'"
+  RUBY_AGENT_VERSION=${APM_AGENT_RUBY_VERSION#*;}
+  RUBY_MAJOR_VERSION=${RUBY_AGENT_VERSION%.*}
+
+  ## For 2.x and some other apm-agent-ruby branches let's use the major version to configure
+  ## the railsapp docker image with the correct ruby version. By default, it uses latest.
+  RE='^[0-9]+$'
+  if [[ $RUBY_MAJOR_VERSION =~ $RE ]] ; then
+    BUILD_OPTS="${BUILD_OPTS} --ruby-version='${RUBY_MAJOR_VERSION}'"
+  fi
+  BUILD_OPTS="${BUILD_OPTS} --ruby-agent-version='${RUBY_AGENT_VERSION}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}'"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
     -   id: check-case-conflict
@@ -36,7 +36,7 @@ repos:
         types: [yaml]
         exclude: (^.pre-commit-config.yaml$|^.ci/.yamlint.yml$|^target/)
 
--   repo: git@github.com:elastic/apm-pipeline-library
+-   repo: https://github.com/elastic/apm-pipeline-library
     rev: current
     hooks:
     -   id: check-bash-syntax

--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:latest
+ARG RUBY_VERSION=latest
+FROM ruby:${RUBY_VERSION}
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -351,6 +351,7 @@ class AgentRubyRails(Service):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-ruby"
     DEFAULT_AGENT_VERSION = "latest"
     DEFAULT_AGENT_VERSION_STATE = "release"
+    DEFAULT_RUBY_VERSION = "latest"
     SERVICE_PORT = 8020
 
     @classmethod
@@ -371,12 +372,18 @@ class AgentRubyRails(Service):
             default=cls.DEFAULT_AGENT_REPO,
             help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
+        parser.add_argument(
+            "--ruby-version",
+            default=cls.DEFAULT_RUBY_VERSION,
+            help='Use Ruby version (latest, 2, 3, ...)',
+        )
 
     def __init__(self, **options):
         super(AgentRubyRails, self).__init__(**options)
         self.agent_version = options.get("ruby_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_version_state = options.get("ruby_agent_version_state", self.DEFAULT_AGENT_VERSION_STATE)
         self.agent_repo = options.get("ruby_agent_repo", self.DEFAULT_AGENT_REPO)
+        self.ruby_version = options.get("ruby_version", self.DEFAULT_RUBY_VERSION)
         if options.get("enable_apm_server", True):
             self.depends_on = {
                 "apm-server": {"condition": "service_healthy"},
@@ -435,6 +442,7 @@ class AgentRubyRails(Service):
                 "args": {
                     "RUBY_AGENT_VERSION": self.agent_version,
                     "RUBY_AGENT_REPO": self.agent_repo,
+                    "RUBY_VERSION": self.ruby_version,
                 }
             },
             command="bash -c \"bundle install && RAILS_ENV=production bundle exec rails s -b 0.0.0.0 -p {}\"".format(

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -227,6 +227,7 @@ class AgentServiceTest(ServiceTest):
                         args:
                             RUBY_AGENT_VERSION: latest
                             RUBY_AGENT_REPO: elastic/apm-agent-ruby
+                            RUBY_VERSION: latest
                         dockerfile: Dockerfile
                         context: docker/ruby/rails
                     container_name: railsapp
@@ -285,6 +286,10 @@ class AgentServiceTest(ServiceTest):
     def test_agent_ruby_apm_api_key_with_apm_server(self):
         agent = AgentRubyRails(version="7.6", enable_apm_server=True, elastic_apm_api_key="foo").render()["agent-ruby-rails"]
         self.assertEqual("foo", agent["environment"]["ELASTIC_APM_API_KEY"])
+
+    def test_agent_ruby_version(self):
+        agent = AgentRubyRails(ruby_version="2").render()["agent-ruby-rails"]
+        self.assertEqual("2", agent["build"]["args"]["RUBY_VERSION"])
 
     def test_agent_java_spring(self):
         agent = AgentJavaSpring().render()

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,4 +1,7 @@
-APM_SERVER:
+APM_SERVERasdssssssasda,daldjasld;jsaldaafhjas;dlhjasl;dahl;dhasl;dhas;ldhasd;lhasd;hasdhahsdåfdsfsdfdsfdsdfasaaasadakjhashklahdskhdffffklhjgd;lghdf;lghdfl;ghdf;lghd;glhfd;lghdlfghdfghjdf;lhg:
   - master
   - master --oss
   - master --ubi8
+- Lorem       : ipsum
+  dolor       : sit amet,
+  consectetur : adipiscing elit

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -2,6 +2,3 @@ APM_SERVER:
   - master
   - master --oss
   - master --ubi8
-- Lorem       : ipsum
-  dolor       : sit amet,
-  consectetur : adipiscing elit

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,7 +1,4 @@
-APM_SERVERasdssssssasda,daldjasld;jsaldaafhjas;dlhjasl;dahl;dhasl;dhas;ldhasd;lhasd;hasdhahsdåfdsfsdfdsfdsdfasaaasadakjhashklahdskhdffffklhjgd;lghdf;lghdfl;ghdf;lghd;glhfd;lghdlfghdfghjdf;lhg:
+APM_SERVER:
   - master
   - master --oss
   - master --ubi8
-- Lorem       : ipsum
-  dolor       : sit amet,
-  consectetur : adipiscing elit

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -2,3 +2,6 @@ APM_SERVER:
   - master
   - master --oss
   - master --ubi8
+- Lorem       : ipsum
+  dolor       : sit amet,
+  consectetur : adipiscing elit


### PR DESCRIPTION
## What does this PR do?

Support different ruby version for the `railsapp` docker image, for such it uses the branch from the apm-agent-ruby as long as it's a number, otherwise it uses the latest docker image.

Added a new flag -> `--ruby-version`

## Why is it important?

Fixes some issues with 2.x in ruby:3.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/1017

## Tests

```bash
$ APM_AGENT_RUBY_VERSION="github;2.x" .ci/scripts/ruby.sh
...

python3 scripts/compose.py start 7.0.0  --build-parallel --ruby-version='2' --ruby-agent-version='2.x' --ruby-agent-version-state='github' ...
...
```

```bash
$ APM_AGENT_RUBY_VERSION="github;master" .ci/scripts/ruby.sh 
...
python3 scripts/compose.py start 7.0.0  --build-parallel --ruby-agent-version='master' --ruby-agent-version-state='github'  
...

$ cat docker-compose.yml | jq '.services[].build'
{
  "args": {
    "RUBY_AGENT_REPO": "elastic/apm-agent-ruby",
    "RUBY_AGENT_VERSION": "master",
    "RUBY_VERSION": "latest"
  },
  "context": "docker/ruby/rails",
  "dockerfile": "Dockerfile"
}

```
