### PR TITLE
[ruby] Support 2.x ruby version and latest and backport #635 #995 #1013

### DIFF
--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -1,12 +1,22 @@
 #!/bin/bash -e
 # for details about how it works see https://github.com/elastic/apm-integration-testing#continuous-integration
 
-srcdir=`dirname $0`
+srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
+# shellcheck disable=SC1090
 . ${srcdir}/common.sh
 
 if [ -n "${APM_AGENT_RUBY_VERSION}" ]; then
-  BUILD_OPTS="${BUILD_OPTS} --ruby-agent-version='${APM_AGENT_RUBY_VERSION#*;}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}'"
+  RUBY_AGENT_VERSION=${APM_AGENT_RUBY_VERSION#*;}
+  RUBY_MAJOR_VERSION=${RUBY_AGENT_VERSION%.*}
+
+  ## For 2.x and some other apm-agent-ruby branches let's use the major version to configure
+  ## the railsapp docker image with the correct ruby version. By default, it uses latest.
+  RE='^[0-9]+$'
+  if [[ $RUBY_MAJOR_VERSION =~ $RE ]] ; then
+    BUILD_OPTS="${BUILD_OPTS} --ruby-version='${RUBY_MAJOR_VERSION}'"
+  fi
+  BUILD_OPTS="${BUILD_OPTS} --ruby-agent-version='${RUBY_AGENT_VERSION}' --ruby-agent-version-state='${APM_AGENT_RUBY_VERSION%;*}'"
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --with-agent-ruby-rails --force-build"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         exclude: (^mvnw$|^target/)
 
 -   repo: https://github.com/adrienverge/yamllint.git
-    rev: master
+    rev: v1.25.0
     hooks:
     -   id: yamllint
         name: "Yaml: lint"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
         exclude: ^target/
     -   id: check-merge-conflict
         exclude: ^target/
-    -   id: check-yaml
-        exclude: ^target/
     -   id: check-xml
         exclude: ^target/
     -   id: end-of-file-fixer

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -12,11 +12,11 @@ COPY . /src
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app
-## Alpine image produces a segmentation fault:
-##        further details: https://github.com/aspnet/EntityFrameworkCore/issues/14504
-## FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=build /src/aspnetcore/build ./
+RUN apk update \
+    && apk add --no-cache curl \
+    && rm -rf /var/cache/apk/*
 EXPOSE 8100
 ENTRYPOINT ["dotnet", "TestAspNetCoreApp.dll", "--urls=http://0.0.0.0:8100"]

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -3,12 +3,18 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=
+# Workaround for https://github.com/dotnet/sdk/issues/14497
+ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
+# install SDK version in global.json of elastic/apm-agent-dotnet
+# Needed when building branches that specify 3.1.100 SDK in global.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -17,8 +17,8 @@ COPY . /src
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 
-# Stage 2: Run the opbeans-dotnet app
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
+# Stage 2: Run the TestAspNetCoreApp app
+FROM mcr.microsoft.com/dotnet/aspnet:3.1-alpine AS runtime
 WORKDIR /app
 COPY --from=build /src/aspnetcore/build ./
 RUN apk update \

--- a/docker/dotnet/aspnetcore/Startup.cs
+++ b/docker/dotnet/aspnetcore/Startup.cs
@@ -15,7 +15,7 @@ namespace TestAspNetCoreApp
 		private readonly IConfiguration _configuration;
 		public Startup(IConfiguration configuration) => _configuration = configuration;
 
-		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 		{
 			// /healthcheck is mapped before app.UseAllElasticApm -> as specified in the spec, it won't be traced.
 			app.Map("/healthcheck", HealthCheck);

--- a/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
+++ b/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.3" />
-        <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -30,6 +30,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
+
   dotnet restore
   dotnet pack -c Release -o /src/local-packages
 

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -4,14 +4,20 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100 AS opbeans-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS opbeans-dotnet
+ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master
 ARG DOTNET_AGENT_VERSION=
 ARG OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
 ARG OPBEANS_DOTNET_BRANCH=master
+# Workaround for https://github.com/dotnet/sdk/issues/14497
+ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet
 WORKDIR /src
 COPY . /src
+# install SDK version in global.json of elastic/apm-agent-dotnet
+# Needed when building branches that specify 3.1.100 SDK in global.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-d
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:3.1-alpine AS runtime
 WORKDIR /app
 COPY --from=opbeans-dotnet /src/opbeans-dotnet/opbeans-dotnet/build ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -15,12 +15,12 @@ COPY . /src
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app
-## Alpine image produces a segmentation fault:
-##        further details: https://github.com/aspnet/EntityFrameworkCore/issues/14504
-## FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=opbeans-dotnet /src/opbeans-dotnet/opbeans-dotnet/build ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
+RUN apk update \
+    && apk add --no-cache curl \
+    && rm -rf /var/cache/apk/*
 EXPOSE 80
 ENTRYPOINT ["dotnet", "opbeans-dotnet.dll"]

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -33,6 +33,7 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
     dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
   fi
+
   dotnet restore
   dotnet pack -c Release -o /src/local-packages
 

--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:latest
+ARG RUBY_VERSION=latest
+FROM ruby:${RUBY_VERSION}
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1423,6 +1423,7 @@ class AgentRubyRails(Service):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-ruby"
     DEFAULT_AGENT_VERSION = "latest"
     DEFAULT_AGENT_VERSION_STATE = "release"
+    DEFAULT_RUBY_VERSION = "latest"
     SERVICE_PORT = 8020
 
     @classmethod
@@ -1443,12 +1444,18 @@ class AgentRubyRails(Service):
             default=cls.DEFAULT_AGENT_REPO,
             help="GitHub repo to be used. Default: {}".format(cls.DEFAULT_AGENT_REPO),
         )
+        parser.add_argument(
+            "--ruby-version",
+            default=cls.DEFAULT_RUBY_VERSION,
+            help='Use Ruby version (latest, 2, 3, ...)',
+        )
 
     def __init__(self, **options):
         super(AgentRubyRails, self).__init__(**options)
         self.agent_version = options.get("ruby_agent_version", self.DEFAULT_AGENT_VERSION)
         self.agent_version_state = options.get("ruby_agent_version_state", self.DEFAULT_AGENT_VERSION_STATE)
         self.agent_repo = options.get("ruby_agent_repo", self.DEFAULT_AGENT_REPO)
+        self.ruby_version = options.get("ruby_version", self.DEFAULT_RUBY_VERSION)
         self.depends_on = {
             "apm-server": {"condition": "service_healthy"},
         }
@@ -1464,6 +1471,7 @@ class AgentRubyRails(Service):
                 "args": {
                     "RUBY_AGENT_VERSION": self.agent_version,
                     "RUBY_AGENT_REPO": self.agent_repo,
+                    "RUBY_VERSION": self.ruby_version,
                 }
             },
             command="bash -c \"bundle install && RAILS_ENV=production bundle exec rails s -b 0.0.0.0 -p {}\"".format(

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -159,6 +159,7 @@ class AgentServiceTest(ServiceTest):
                         args:
                             RUBY_AGENT_VERSION: latest
                             RUBY_AGENT_REPO: elastic/apm-agent-ruby
+                            RUBY_VERSION: latest
                         dockerfile: Dockerfile
                         context: docker/ruby/rails
                     container_name: railsapp
@@ -200,6 +201,10 @@ class AgentServiceTest(ServiceTest):
     def test_agent_ruby_with_version(self):
         agent = AgentRubyRails(ruby_agent_version="1.0").render()["agent-ruby-rails"]
         self.assertEqual("1.0", agent["environment"]["RUBY_AGENT_VERSION"])
+
+    def test_agent_ruby_version(self):
+        agent = AgentRubyRails(ruby_version="2").render()["agent-ruby-rails"]
+        self.assertEqual("2", agent["build"]["args"]["RUBY_VERSION"])
 
     def test_agent_java_spring(self):
         agent = AgentJavaSpring().render()

--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -280,7 +280,7 @@ class Concurrent:
 
                 if 'stacktrace' in span.keys():
                     stacktrace = span['stacktrace']
-                    assert 15 < len(stacktrace) < 70, \
+                    assert 1 < len(stacktrace) < 70, \
                         "number of frames not expected, got {}, but this assertion might be too strict".format(
                             len(stacktrace))
 


### PR DESCRIPTION
## What does this PR do?

* Support different ruby version for the `railsapp` docker image, for such it uses the branch from the apm-agent-ruby as long as it's a number, otherwise it uses the latest docker image.

* Added a new flag -> `--ruby-version`
* Backport:
  * 6f4f77162896feca54ebcbeee4047332a2ed3d67
  * 518d6099831d99ff1e08a5ea5e5f1d9eb3e1f066
  * 18b7e55d5f23e3ee69befb3c348b679d90200a0d

## Why is it important?

Fixes some issues with 2.x in ruby:3.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/1017

Similar implementation to https://github.com/elastic/apm-integration-testing/pull/1018

## Tests

```bash
$ APM_AGENT_RUBY_VERSION="github;2.x" .ci/scripts/ruby.sh
...

python3 scripts/compose.py start 7.10  --build-parallel --ruby-version='2' --ruby-agent-version='2.x' --ruby-agent-version-state='github' ...
...
```

