### PR TITLE
[CI] Restore pre-commit run in the worker

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -80,13 +80,8 @@ pipeline {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
               unstash 'source'
-              script {
-                docker.image('python:3.7-stretch').inside("-v ${GIT_REFERENCE_REPO}:${GIT_REFERENCE_REPO}") {
-                  dir("${BASE_DIR}"){
-                    // registry: '' will help to disable the docker login
-                    preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true, registry: '')
-                  }
-                }
+              dir("${BASE_DIR}"){
+                preCommit(commit: "${env.GIT_BASE_COMMIT}", junit: true)
               }
             }
           }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         exclude: (^mvnw$|^target/)
 
 -   repo: https://github.com/adrienverge/yamllint.git
-    rev: master
+    rev: v1.25.0
     hooks:
     -   id: yamllint
         name: "Yaml: lint"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
         exclude: ^target/
     -   id: check-merge-conflict
         exclude: ^target/
-    -   id: check-yaml
-        exclude: ^target/
     -   id: check-xml
         exclude: ^target/
     -   id: end-of-file-fixer


### PR DESCRIPTION
## What does this PR do?

Restore run in the CI worker and fix the end of support for python2 -> https://github.com/adrienverge/yamllint/commit/a3fc64d13407869607c07096d8591bdc17ff645f

## Why is it important?

See if we can fix the issue when installing the pre-commit hooks with python

```
stderr:

[2021-01-07T09:43:59.210Z]     DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.

[2021-01-07T09:43:59.210Z]     ERROR: Package 'yamllint' requires a different Python: 2.7.17 not in '>=3.5.*'

[2021-01-07T09:43:59.210Z]     WARNING: You are using pip version 20.3.1; however, version 20.3.3 is available.

[2021-01-07T09:43:59.210Z]     You should consider upgrading via the '/var/lib/jenkins/workspace/apm-integration-tests_PR-1019/.cache/pre-commit/repowoXqWN/py_env-python2.7/bin/python -m pip install --upgrade pip' command.
```
