### PR TITLE
chore: reduce the day to keep build

### DIFF
--- a/.ci/jobs/apm-it-ec.yml
+++ b/.ci/jobs/apm-it-ec.yml
@@ -5,6 +5,8 @@
     description: It runs integration Test against an Elastic Cloud environment.
     project-type: multibranch
     script-path: .ci/integrationTestEC.groovy
+    logrotate:
+      daysToKeep: 7
     scm:
     - github:
         branch-discovery: no-pr

--- a/.ci/jobs/apm-it-eck.yml
+++ b/.ci/jobs/apm-it-eck.yml
@@ -5,6 +5,8 @@
     description: It runs integration Test against an Elastic Cloud on Kubernetes environment.
     project-type: multibranch
     script-path: .ci/integrationTestECK.groovy
+    logrotate:
+      daysToKeep: 7
     scm:
     - github:
         branch-discovery: no-pr

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -10,7 +10,7 @@
 - job:
     view: APM-CI
     logrotate:
-      daysToKeep: 30
+      daysToKeep: 15
     node: linux
     concurrent: true
     periodic-folder-trigger: 1w


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes to keep 15 days of ITs and 7 days of EC/ECK builds.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
We are keeping 30 day of builds, we do not need those build we have the results on Elasticsearch in case we need historic data.

