### PR TITLE
Add option and script to inject a custom apm-server into Elastic Agent

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -262,6 +262,14 @@ class LocalSetup(object):
             default='',
         )
 
+        parser.add_argument(
+            '--with-elastic-agent-apm-binary',
+            dest='elastic-agent-apm-binary',
+            help='copy the apm-server binary given as argument to the Elastic Agent "downloads" folder.' +
+            ' NOTE: make sure that the file has the correct name (the one that Elastic Agent would run).',
+            default='',
+        )
+
         # Add option to skip image downloads
         parser.add_argument(
             '--no-download',
@@ -676,6 +684,9 @@ class LocalSetup(object):
             if not sys.stdin.isatty():
                 up_params.extend(["--quiet-pull"])
             self.run_docker_compose_process(docker_compose_cmd + up_params)
+
+        if args.get("enable_elastic_agent", False) and args["elastic-agent-apm-binary"]:
+            subprocess.call(["./scripts/override-agent-apm-server.sh", args["elastic-agent-apm-binary"]])
 
     @staticmethod
     def reset_enterprise_search_password_handler():

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -688,7 +688,7 @@ class LocalSetup(object):
             is_snapshot = args["elastic_agent_snapshot"] or not (
                 any((args["elastic_agent_bc"], args["elastic_agent_release"])))
             version = args["version"] + "-SNAPSHOT" if is_snapshot else args["version"]
-            filename = "apm-server-" + version + "-linux-x86_64.tar.gz" 
+            filename = "apm-server-" + version + "-linux-x86_64.tar.gz"
             subprocess.call(["./scripts/override-agent-apm-server.sh", args["elastic-agent-apm-binary-path"], filename])
 
     @staticmethod

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -263,10 +263,9 @@ class LocalSetup(object):
         )
 
         parser.add_argument(
-            '--with-elastic-agent-apm-binary',
-            dest='elastic-agent-apm-binary',
-            help='copy the apm-server binary given as argument to the Elastic Agent "downloads" folder.' +
-            ' NOTE: make sure that the file has the correct name (the one that Elastic Agent would run).',
+            '--with-elastic-agent-apm-binary-path',
+            dest='elastic-agent-apm-binary-path',
+            help='path of a custom apm-server binary to install in the Elastic Agent container',
             default='',
         )
 
@@ -685,8 +684,11 @@ class LocalSetup(object):
                 up_params.extend(["--quiet-pull"])
             self.run_docker_compose_process(docker_compose_cmd + up_params)
 
-        if args.get("enable_elastic_agent", False) and args["elastic-agent-apm-binary"]:
-            subprocess.call(["./scripts/override-agent-apm-server.sh", args["elastic-agent-apm-binary"]])
+        if args.get("enable_elastic_agent", False) and args["elastic-agent-apm-binary-path"]:
+            is_snapshot = args["elastic_agent_snapshot"] or not (any((args["elastic_agent_bc"], args["elastic_agent_release"])))
+            version = args["version"] + "-SNAPSHOT" if is_snapshot else args["version"]
+            filename = "apm-server-" + version + "-linux-x86_64.tar.gz" 
+            subprocess.call(["./scripts/override-agent-apm-server.sh", args["elastic-agent-apm-binary-path"], filename])
 
     @staticmethod
     def reset_enterprise_search_password_handler():

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -685,7 +685,8 @@ class LocalSetup(object):
             self.run_docker_compose_process(docker_compose_cmd + up_params)
 
         if args.get("enable_elastic_agent", False) and args["elastic-agent-apm-binary-path"]:
-            is_snapshot = args["elastic_agent_snapshot"] or not (any((args["elastic_agent_bc"], args["elastic_agent_release"])))
+            is_snapshot = args["elastic_agent_snapshot"] or not (
+                any((args["elastic_agent_bc"], args["elastic_agent_release"])))
             version = args["version"] + "-SNAPSHOT" if is_snapshot else args["version"]
             filename = "apm-server-" + version + "-linux-x86_64.tar.gz" 
             subprocess.call(["./scripts/override-agent-apm-server.sh", args["elastic-agent-apm-binary-path"], filename])

--- a/scripts/override-agent-apm-server.sh
+++ b/scripts/override-agent-apm-server.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# takes as argument the apm-server binary file
-# it is expected that the checksum exists with the same name with and a ".sha512" postfix
+# Takes as arguments the apm-server binary path and the apm-server binary file name; 
+# and uncompresses it in the right folder inside the elastic-agent container (must be running)
+
+# Path and file name are separated arguments because the former comes from user input, and the later does not
+# This is because if the file name comes from the user and is not what elastic agent expects, 
+# it will be very hard to debug why it doesn't work
 
 elastic_agent_id=$(docker ps -qf "name=elastic-agent")
 sha=$(docker inspect "$elastic_agent_id" | grep org.label-schema.vcs-ref | awk -F ": \"" '{print $2}' | head -c 6)
-dst=/usr/share/elastic-agent/data/elastic-agent-"$sha"/downloads/
-echo "copying ${1} and its sha512 to $elastic_agent_id:$dst"
-docker cp "${1}" "$elastic_agent_id":"$dst"
-docker cp "${1}".sha512 "$elastic_agent_id":"$dst"
+dst=/usr/share/elastic-agent/data/elastic-agent-"$sha"/install/${2%".tar.gz"}
+
+echo "copying ${1}/${2} to $elastic_agent_id:$dst"
+docker exec $elastic_agent_id mkdir $dst
+docker cp "${1}/${2}" "$elastic_agent_id":"$dst"
+
+echo "uncompressing $dst/${2}"
+# we need to set the destination folder explicitly to avoid errors in case the user has manually renamed the binary file 
+# (ie, after mage package)
+docker exec $elastic_agent_id tar zxvf $dst/${2} -C $dst --strip-components 1
+docker exec $elastic_agent_id rm $dst/${2}
+

--- a/scripts/override-agent-apm-server.sh
+++ b/scripts/override-agent-apm-server.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# takes as argument the apm-server binary file
+# it is expected that the checksum exists with the same name with and a ".sha512" postfix
+
+elastic_agent_id=$(docker ps -qf "name=elastic-agent")
+sha=$(docker inspect "$elastic_agent_id" | grep org.label-schema.vcs-ref | awk -F ": \"" '{print $2}' | head -c 6)
+dst=/usr/share/elastic-agent/data/elastic-agent-"$sha"/downloads/
+echo "copying ${1} and its sha512 to $elastic_agent_id:$dst"
+docker cp "${1}" "$elastic_agent_id":"$dst"
+docker cp "${1}".sha512 "$elastic_agent_id":"$dst"

--- a/scripts/override-agent-apm-server.sh
+++ b/scripts/override-agent-apm-server.sh
@@ -13,12 +13,12 @@ sha=$(docker inspect "$elastic_agent_id" | grep org.label-schema.vcs-ref | awk -
 dst=/usr/share/elastic-agent/data/elastic-agent-"$sha"/install/${2%".tar.gz"}
 
 echo "copying ${1}/${2} to $elastic_agent_id:$dst"
-docker exec $elastic_agent_id mkdir $dst
+docker exec "$elastic_agent_id" mkdir "$dst"
 docker cp "${1}/${2}" "$elastic_agent_id":"$dst"
 
 echo "uncompressing $dst/${2}"
 # we need to set the destination folder explicitly to avoid errors in case the user has manually renamed the binary file 
 # (ie, after mage package)
-docker exec $elastic_agent_id tar zxvf $dst/${2} -C $dst --strip-components 1
-docker exec $elastic_agent_id rm $dst/${2}
+docker exec "$elastic_agent_id" tar zxvf "$dst"/${2} -C "$dst" --strip-components 1
+docker exec "$elastic_agent_id" rm "$dst"/${2}
 

--- a/scripts/override-agent-apm-server.sh
+++ b/scripts/override-agent-apm-server.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 elastic_agent_id=$(docker ps -qf "name=elastic-agent")
 sha=$(docker inspect "$elastic_agent_id" | grep org.label-schema.vcs-ref | awk -F ": \"" '{print $2}' | head -c 6)
-dst=/usr/share/elastic-agent/data/elastic-agent-"$sha"/install/${2%".tar.gz"}
+dst="/usr/share/elastic-agent/data/elastic-agent-${sha}/install/${2%'.tar.gz'}"
 
 echo "copying ${1}/${2} to $elastic_agent_id:$dst"
 docker exec "$elastic_agent_id" mkdir "$dst"
@@ -19,6 +19,5 @@ docker cp "${1}/${2}" "$elastic_agent_id":"$dst"
 echo "uncompressing $dst/${2}"
 # we need to set the destination folder explicitly to avoid errors in case the user has manually renamed the binary file 
 # (ie, after mage package)
-docker exec "$elastic_agent_id" tar zxvf "$dst"/${2} -C "$dst" --strip-components 1
-docker exec "$elastic_agent_id" rm "$dst"/${2}
-
+docker exec "$elastic_agent_id" tar zxvf "${dst}/${2}" -C "$dst" --strip-components 1
+docker exec "$elastic_agent_id" rm "${dst}/${2}"


### PR DESCRIPTION
## What does this PR do?

This should enable us to run elastic-agent with an arbitrary apm-server binary.

## Why is it important?

To run tests in pull requests with elastic agent and the apm-server from the current branch 


Depends on https://github.com/elastic/apm-integration-testing/pull/1016