### PR TITLE
fix: versions are not correct

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,6 +1,5 @@
 APM_SERVER:
   - '7.x'
-  - '7.12'
   - '7.11'
   - '7.10;--release'
   - '7.9;--release'

--- a/tests/versions/go.yml
+++ b/tests/versions/go.yml
@@ -1,3 +1,3 @@
 GO_AGENT:
   - 'github;master'
-  - 'release;1.9.0'
+  - 'release;v1.9.0'

--- a/tests/versions/rum.yml
+++ b/tests/versions/rum.yml
@@ -1,3 +1,3 @@
 RUM_AGENT:
   - 'github;master'
-  - 'release;5.6.2'
+  - 'release;@elastic/apm-rum@5.6.2'


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Correct go 1.9.0 version name
* Correct RUM 5.6.2 tag name
* Remove Stack 7.12, it is not available yet

