### PR TITLE
OSS distribution change for 7.11+ and 6.8.14+

### DIFF
--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -57,6 +57,10 @@ class Service(object):
                 self.apm_api_key = {"ELASTIC_APM_API_KEY": options.get("elastic_apm_api_key")}
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
+        if self.name() in ("elasticsearch", "kibana"):
+            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")) :
+                print('WARNING: OSS distribution is not supported in 7.11+/6.8.14+. Unset the oss flag.')
+                self._oss = False
 
     @property
     def bc(self):
@@ -97,6 +101,9 @@ class Service(object):
 
     def at_least_version(self, target):
         return parse_version(self.version) >= parse_version(target)
+
+    def version_lower_than(self, target):
+        return parse_version(self.version) < parse_version(target)
 
     @classmethod
     def name(cls):

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -58,7 +58,7 @@ class Service(object):
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
         if self.name() in ("elasticsearch", "kibana"):
-            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")) :
+            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")):
                 print('WARNING: OSS distribution is not supported in 7.11+/6.8.14+. Unset the oss flag.')
                 self._oss = False
 

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1050,6 +1050,24 @@ class ElasticsearchServiceTest(ServiceTest):
             "xpack.license.self_generated.type=trial" in elasticsearch["environment"], "xpack.license type"
         )
 
+    def test_6_8_14_oss_release_not_supported(self):
+        elasticsearch = Elasticsearch(version="6.8.14", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch:6.8.14"
+        )
+
+    def test_6_9_oss_release_supported(self):
+        elasticsearch = Elasticsearch(version="6.9", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch-oss:6.9"
+        )
+
+    def test_7_11_oss_release_not_supported(self):
+        elasticsearch = Elasticsearch(version="7.11.0", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch:7.11.0"
+        )
+
     def test_data_dir(self):
         # default
         elasticsearch = Elasticsearch(version="6.3.100").render()["elasticsearch"]
@@ -1279,6 +1297,24 @@ class KibanaServiceTest(ServiceTest):
                             condition: service_healthy
                     labels:
                         - co.elastic.apm.stack-version=6.3.5""")  # noqa: 501
+        )
+
+    def test_6_8_14_oss_release_not_supported(self):
+        kibana = Kibana(version="6.8.14", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana:6.8.14"
+        )
+
+    def test_6_9_oss_release_supported(self):
+        kibana = Kibana(version="6.9", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana-oss:6.9"
+        )
+
+    def test_7_11_oss_release_not_supported(self):
+        kibana = Kibana(version="7.11.1", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana:7.11.1"
         )
 
     def test_kibana_elasticsearch_urls(self):


### PR DESCRIPTION
## What does this PR do?

If `--oss` then let's fallback to the `non-oss` distribution for `Kibana` and `Elasticsearch` when `7.11+` and `6.8.14+`

## Why is it important?

As a consequence of the license change, Kibana and Elasticsearch OSS distributions from 7.11 and 6.8.14 won't be available. 

Even though I don't like much to change behaviours under the hood, I've found it's the best way to support the Elasticstack for Kibana, Elasticsearch and APM Server when using the `--oss` flag.

Otherwise we need to change the consumers logic such as:

- https://github.com/elastic/apm-integration-testing/blob/master/tests/versions/apm_server.yml#L3

That particular file is used in our nightly testing with all the APM agents/servers versions.

