### PR TITLE
chore: update EOL stack versions

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -8,6 +8,3 @@ APM_SERVER:
   - '7.6;--release'
   - '7.5;--release'
   - '7.4;--release'
-  - '7.3;--release'
-  - '7.2;--release'
-  - '7.1;--release'


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It updates the Elastic Stack versions to test based on https://www.elastic.co/support/eol

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Test EOL versions use resources we can use in other builds.
