### PR TITLE
OSS distribution change for Kibana and Elasticsearch in 7.11+ and 6.8.14+ versions

### DIFF
--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -57,6 +57,10 @@ class Service(object):
                 self.apm_api_key = {"ELASTIC_APM_API_KEY": options.get("elastic_apm_api_key")}
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
+        if self.name() in ("elasticsearch", "kibana"):
+            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")) :
+                print('WARNING: OSS distribution is not supported in 7.11+/6.8.14+. Unset the oss flag.')
+                self._oss = False
 
     @property
     def bc(self):
@@ -97,6 +101,9 @@ class Service(object):
 
     def at_least_version(self, target):
         return parse_version(self.version) >= parse_version(target)
+
+    def version_lower_than(self, target):
+        return parse_version(self.version) < parse_version(target)
 
     @classmethod
     def name(cls):

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 from abc import abstractmethod
 
@@ -59,8 +60,8 @@ class Service(object):
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
         if self.name() in ("elasticsearch", "kibana"):
             if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")):
-                print('WARNING: OSS distribution is not supported in 7.11+/6.8.14+. Unset the oss flag.')
-                self._oss = False
+                print('ERROR: OSS distribution is ONLY supported in 7.11+/6.8.14+ for Kibana and Elasticsearch.')
+                #sys.exit(1)
 
     @property
     def bc(self):

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -58,7 +58,7 @@ class Service(object):
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
         if self.name() in ("elasticsearch", "kibana"):
-            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")) :
+            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")):
                 print('WARNING: OSS distribution is not supported in 7.11+/6.8.14+. Unset the oss flag.')
                 self._oss = False
 

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -58,10 +58,10 @@ class Service(object):
                 self.apm_api_key = {"ELASTIC_APM_API_KEY": options.get("elastic_apm_api_key")}
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
-        if self.name() in ("elasticsearch", "kibana"):
+        if self._oss and self.name() in ("elasticsearch", "kibana"):
             if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")):
                 print('ERROR: OSS distribution is ONLY supported in 7.11+/6.8.14+ for Kibana and Elasticsearch.')
-                #sys.exit(1)
+                sys.exit(1)
 
     @property
     def bc(self):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1051,6 +1051,33 @@ class LocalTest(unittest.TestCase):
         """)  # noqa: 501
         self.assertDictEqual(got, want)
 
+    def test_start_master_with_oss(self):
+        docker_compose_yml = stringIO()
+        image_cache_dir = "/foo"
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': '8.0.0'}):
+            with self.assertRaises(SystemExit) as cm:
+                setup = LocalSetup(argv=self.common_setup_args + ["master", "--image-cache-dir", image_cache_dir, "--oss"])
+                setup.set_docker_compose_path(docker_compose_yml)
+                setup()
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_start_master_with_apm_oss(self):
+        docker_compose_yml = stringIO()
+        version = "8.0.0"
+        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'master': version}):
+            setup = LocalSetup(argv=self.common_setup_args + ["master", "--apm-server-oss"])
+            setup.set_docker_compose_path(docker_compose_yml)
+            setup()
+        docker_compose_yml.seek(0)
+        got = yaml.safe_load(docker_compose_yml)
+        services = got["services"]
+        self.assertEqual(
+            "docker.elastic.co/elasticsearch/elasticsearch:{}-SNAPSHOT".format(version),
+            services["elasticsearch"]["image"]
+        )
+        self.assertEqual("docker.elastic.co/kibana/kibana:{}-SNAPSHOT".format(version), services["kibana"]["image"])
+        self.assertEqual("docker.elastic.co/apm/apm-server-oss:{}-SNAPSHOT".format(version), services["apm-server"]["image"])
+
     @mock.patch(cli.__name__ + ".load_images")
     def test_start_6_x_xpack_secure(self, _ignore_load_images):
         docker_compose_yml = stringIO()

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1059,10 +1059,9 @@ class ElasticsearchServiceTest(ServiceTest):
         )
 
     def test_6_8_14_oss_release_not_supported(self):
-        elasticsearch = Elasticsearch(version="6.8.14", oss=True, release=True).render()["elasticsearch"]
-        self.assertEqual(
-            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch:6.8.14"
-        )
+        with self.assertRaises(SystemExit) as cm:
+            elasticsearch = Elasticsearch(version="6.8.14", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(cm.exception.code, 1)
 
     def test_6_9_oss_release_supported(self):
         elasticsearch = Elasticsearch(version="6.9", oss=True, release=True).render()["elasticsearch"]
@@ -1071,10 +1070,9 @@ class ElasticsearchServiceTest(ServiceTest):
         )
 
     def test_7_11_oss_release_not_supported(self):
-        elasticsearch = Elasticsearch(version="7.11.0", oss=True, release=True).render()["elasticsearch"]
-        self.assertEqual(
-            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch:7.11.0"
-        )
+        with self.assertRaises(SystemExit) as cm:
+            elasticsearch = Elasticsearch(version="7.11.0", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(cm.exception.code, 1)
 
     def test_data_dir(self):
         # default
@@ -1314,10 +1312,9 @@ class KibanaServiceTest(ServiceTest):
         )
 
     def test_6_8_14_oss_release_not_supported(self):
-        kibana = Kibana(version="6.8.14", oss=True, release=True).render()["kibana"]
-        self.assertEqual(
-            kibana["image"], "docker.elastic.co/kibana/kibana:6.8.14"
-        )
+        with self.assertRaises(SystemExit) as cm:
+            kibana = Kibana(version="6.8.14", oss=True, release=True).render()["kibana"]
+        self.assertEqual(cm.exception.code, 1)
 
     def test_6_9_oss_release_supported(self):
         kibana = Kibana(version="6.9", oss=True, release=True).render()["kibana"]
@@ -1326,10 +1323,9 @@ class KibanaServiceTest(ServiceTest):
         )
 
     def test_7_11_oss_release_not_supported(self):
-        kibana = Kibana(version="7.11.1", oss=True, release=True).render()["kibana"]
-        self.assertEqual(
-            kibana["image"], "docker.elastic.co/kibana/kibana:7.11.1"
-        )
+        with self.assertRaises(SystemExit) as cm:
+            kibana = Kibana(version="7.11.1", oss=True, release=True).render()["kibana"]
+        self.assertEqual(cm.exception.code, 1)
 
     def test_kibana_elasticsearch_urls(self):
         kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=[

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1058,6 +1058,24 @@ class ElasticsearchServiceTest(ServiceTest):
             "xpack.license.self_generated.type=trial" in elasticsearch["environment"], "xpack.license type"
         )
 
+    def test_6_8_14_oss_release_not_supported(self):
+        elasticsearch = Elasticsearch(version="6.8.14", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch:6.8.14"
+        )
+
+    def test_6_9_oss_release_supported(self):
+        elasticsearch = Elasticsearch(version="6.9", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch-oss:6.9"
+        )
+
+    def test_7_11_oss_release_not_supported(self):
+        elasticsearch = Elasticsearch(version="7.11.0", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch:7.11.0"
+        )
+
     def test_data_dir(self):
         # default
         elasticsearch = Elasticsearch(version="6.3.100").render()["elasticsearch"]
@@ -1293,6 +1311,24 @@ class KibanaServiceTest(ServiceTest):
                             service_healthy
                     labels:
                         - co.elastic.apm.stack-version=6.3.5""")  # noqa: 501
+        )
+
+    def test_6_8_14_oss_release_not_supported(self):
+        kibana = Kibana(version="6.8.14", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana:6.8.14"
+        )
+
+    def test_6_9_oss_release_supported(self):
+        kibana = Kibana(version="6.9", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana-oss:6.9"
+        )
+
+    def test_7_11_oss_release_not_supported(self):
+        kibana = Kibana(version="7.11.1", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana:7.11.1"
         )
 
     def test_kibana_elasticsearch_urls(self):

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,4 +1,4 @@
 APM_SERVER:
   - master
-  - master --oss
+  - master --apm-server-oss
   - master --ubi8


### PR DESCRIPTION
## What does this PR do?

Fail if unsupported versions for Kibana and Elasticsearch when using the `oss` distribution.

Configure consumer to use only the `apm-server` oss distribution

## Why is it important?

As a consequence of the license change, Kibana and Elasticsearch OSS distributions from 7.11 and 6.8.14 won't be available.

## Related issues

Supersedes https://github.com/elastic/apm-integration-testing/pull/1037
