### PR TITLE
enable kibana-port

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1090,6 +1090,7 @@ class Kibana(StackService, Service):
 
     @classmethod
     def add_arguments(cls, parser):
+        super(Kibana, cls).add_arguments(parser)
         parser.add_argument(
             "--kibana-elasticsearch-url",
             action="append",


### PR DESCRIPTION
## What does this PR do?

Enable `--kibana-port <port>` flag

## Why is it important?

I think this is a regression when the big refactoring was done.

## Tests

```
$ ./scripts/compose.py start master --kibana-port 5801

$ docker ps                                                               
CONTAINER ID        IMAGE                                                          COMMAND                  CREATED             STATUS                             PORTS                                NAMES
478863d53c14        docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT                 "/bin/tini -- /usr/l…"   15 seconds ago      Up 14 seconds (health: starting)   127.0.0.1:5801->5601/tcp             localtesting_8.0.0_kibana
68111eb6f356        docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT   "/bin/tini -- /usr/l…"   51 seconds ago      Up 45 seconds (healthy)            127.0.0.1:9200->9200/tcp, 9300/tcp   localtesting_8.0.0_elasticsearch

$ curl http://127.0.0.1:5801 -i
HTTP/1.1 302 Found
location: /login?next=%2F
kbn-name: kibana.example.org
kbn-license-sig: 89883f40c1770109233be55d1dc84cdf29845ca50d1ca8d092d9f377345d9866
cache-control: private, no-cache, no-store, must-revalidate
content-length: 0
Date: Thu, 21 Jan 2021 13:52:47 GMT
Connection: keep-alive
Keep-Alive: timeout=120
```
