### PR TITLE
chore: update EOL stack versions for 6.x

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,5 +1,3 @@
 APM_SERVER:
+  - '6.8'
   - '6.8;--release'
-  - '6.7;--release'
-  - '6.6;--release'
-  - '6.5;--release'


### PR DESCRIPTION
## What does this PR do?

It updates the Elastic Stack versions to test based on https://www.elastic.co/support/eol and include the `6.8` branch validation in addition to the releases.

## Why is it important?

Test EOL versions use resources we can use in other builds.


![image](https://user-images.githubusercontent.com/2871786/105385251-0993aa00-5c0b-11eb-980f-86036239a8ef.png)

