### PR TITLE
fix: do not delete default policy but only apm packages

### DIFF
--- a/docker/apm-server/managed/main.go
+++ b/docker/apm-server/managed/main.go
@@ -52,9 +52,18 @@ func setupManagedAPM() error {
 
 	// fetch apm package installed to default policy and verify if it is aligned with
 	// expected setup
-	apmPackagePolicies, err := client.getPackagePolicies(fmt.Sprintf("kuery=ingest-package-policies.policy_id:%s", policy.ID))
+	defaultPolicyPackages, err := client.getPackagePolicies(fmt.Sprintf("kuery=ingest-package-policies.policy_id:%s", policy.ID))
 	if err != nil {
 		log.Fatal(err)
+	}
+	var apmPackagePolicies []packagePolicy
+	for _, p := range defaultPolicyPackages {
+		for _, input := range p.Inputs {
+			if input.Type == "apm" {
+				apmPackagePolicies = append(apmPackagePolicies, p)
+				break
+			}
+		}
 	}
 	var requiresSetup bool
 	switch len(apmPackagePolicies) {


### PR DESCRIPTION

## What does this PR do?
When introducing the `apm-server-managed` option a small bug was introduced in how existing packages are deleted. Instead of only deleting conflicting APM Server packages, the whole default policy is removed. This PR fixes the behavior to only remove APM packages if necessary. 


follow up on https://github.com/elastic/apm-integration-testing/pull/1016