### PR TITLE
Bump Go version '1.14.12'

### DIFF
--- a/.ci/bump/bump-go.sh
+++ b/.ci/bump/bump-go.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# This script is in charge to read the latest go version supported in apm-server and upgrade its references
+# The contract will be always:
+#  1) Gather the go version from the upstream
+#  2) Update the references
+#  3) Commit changes
+
+GO_VERSION=$(curl -s https://raw.githubusercontent.com/elastic/apm-server/master/.go-version)
+
+sed -i.bck "s#go_version=.*#go_version=${GO_VERSION}#g" docker/apm-server/Dockerfile
+git add docker/apm-server/Dockerfile
+git commit -m "Bump Go version '${GO_VERSION}'"
+
+# The push is now delegated to the executor of this script.

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules
 docker-info/
 .vscode/
 *.swp
+*.bck
 
 # For the BATS testing
 bats-core/

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.14
+ARG go_version=1.14.12
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

Bump Go version '1.14.12'
Provide a script with the process to do it

## Why is it important?

A proposal to automate the process

