### PR TITLE
Update dotnet sdk 5.0 docker image

### DIFF
--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -3,7 +3,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -4,7 +4,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS opbeans-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS opbeans-dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master


### PR DESCRIPTION


## What does this PR do?

Relates: https://github.com/NuGet/Announcements/issues/49

## Why is it important?

From the linked issue:

> This is because of an [issue reported](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962596) in the ca-certificates package in which the root CA being used are not trusted and must be installed manually due to [Symantec Issues](https://wiki.mozilla.org/CA:Symantec_Issues). Debian removed the impacted Symantec certificate from their ca-certificates package in buster (Debian 10) impacting all uses. The expected behavior was for CA stores to be updated to remove the Symantec certificate from TLS usage only. The Debian patch was too broad in removing the certificate for all uses and created the error messages seen today.

Essentially, builds using this image are unable to compile applications that resolve dependencies from Nuget, with errors like

```
2021-01-29T04:13:02.766Z] /var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1140/apm-agent-dotnet/build/scripts/scripts.fsproj : error NU3028: Package 'Microsoft.NETFramework.ReferenceAssemblies 1.0.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain

[2021-01-29T04:13:02.766Z] /var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1140/apm-agent-dotnet/build/scripts/scripts.fsproj : error NU3037: Package 'Microsoft.NETFramework.ReferenceAssemblies 1.0.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.

[2021-01-29T04:13:02.766Z] /var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1140/apm-agent-dotnet/build/scripts/scripts.fsproj : error NU3028: Package 'Microsoft.NETFramework.ReferenceAssemblies 1.0.0' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain

[2021-01-29T04:13:02.766Z] /var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1140/apm-agent-dotnet/build/scripts/scripts.fsproj : error NU3028: Package 'System.CommandLine 2.0.0-beta1.20427.1' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain

[2021-01-29T04:13:02.766Z] /var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1140/apm-agent-dotnet/build/scripts/scripts.fsproj : error NU3037: Package 'System.CommandLine 2.0.0-beta1.20427.1' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.
```
