### PR TITLE
[7.x] OSS distribution change for Kibana and Elasticsearch in 7.11+ and 6.8.14+ versions (#1040)

### DIFF
--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 from abc import abstractmethod
 
@@ -57,6 +58,10 @@ class Service(object):
                 self.apm_api_key = {"ELASTIC_APM_API_KEY": options.get("elastic_apm_api_key")}
             else:
                 print('WARNING: elastic_apm_api_key is not supported for the current version. Use version +7.6.')
+        if self._oss and self.name() in ("elasticsearch", "kibana"):
+            if self.at_least_version("7.11") or (self.at_least_version("6.8.14") and self.version_lower_than("6.9")):
+                print('ERROR: OSS distribution is ONLY supported in 7.11+/6.8.14+ for Kibana and Elasticsearch.')
+                sys.exit(1)
 
     @property
     def bc(self):
@@ -97,6 +102,9 @@ class Service(object):
 
     def at_least_version(self, target):
         return parse_version(self.version) >= parse_version(target)
+
+    def version_lower_than(self, target):
+        return parse_version(self.version) < parse_version(target)
 
     @classmethod
     def name(cls):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1050,6 +1050,22 @@ class ElasticsearchServiceTest(ServiceTest):
             "xpack.license.self_generated.type=trial" in elasticsearch["environment"], "xpack.license type"
         )
 
+    def test_6_8_14_oss_release_not_supported(self):
+        with self.assertRaises(SystemExit) as cm:
+            elasticsearch = Elasticsearch(version="6.8.14", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_6_9_oss_release_supported(self):
+        elasticsearch = Elasticsearch(version="6.9", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(
+            elasticsearch["image"], "docker.elastic.co/elasticsearch/elasticsearch-oss:6.9"
+        )
+
+    def test_7_11_oss_release_not_supported(self):
+        with self.assertRaises(SystemExit) as cm:
+            elasticsearch = Elasticsearch(version="7.11.0", oss=True, release=True).render()["elasticsearch"]
+        self.assertEqual(cm.exception.code, 1)
+
     def test_data_dir(self):
         # default
         elasticsearch = Elasticsearch(version="6.3.100").render()["elasticsearch"]
@@ -1280,6 +1296,22 @@ class KibanaServiceTest(ServiceTest):
                     labels:
                         - co.elastic.apm.stack-version=6.3.5""")  # noqa: 501
         )
+
+    def test_6_8_14_oss_release_not_supported(self):
+        with self.assertRaises(SystemExit) as cm:
+            kibana = Kibana(version="6.8.14", oss=True, release=True).render()["kibana"]
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_6_9_oss_release_supported(self):
+        kibana = Kibana(version="6.9", oss=True, release=True).render()["kibana"]
+        self.assertEqual(
+            kibana["image"], "docker.elastic.co/kibana/kibana-oss:6.9"
+        )
+
+    def test_7_11_oss_release_not_supported(self):
+        with self.assertRaises(SystemExit) as cm:
+            kibana = Kibana(version="7.11.1", oss=True, release=True).render()["kibana"]
+        self.assertEqual(cm.exception.code, 1)
 
     def test_kibana_elasticsearch_urls(self):
         kibana = Kibana(version="6.3.5", release=True, kibana_elasticsearch_urls=[


### PR DESCRIPTION
Backports the following commits to 7.x:
 - OSS distribution change for Kibana and Elasticsearch in 7.11+ and 6.8.14+ versions (#1040)