### PR TITLE
fix: bump go version

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -13,7 +13,7 @@ RUN apt -qq remove -y python2 && apt -qq autoremove -y
 
 # install make update prerequisites
 RUN apt-get -qq update \
-    && apt-get -qq install -y python3 python3-pip python3-venv
+    && apt-get -qq install -y python3 python3-pip python3-venv rsync
 
 RUN pip3 install --upgrade pip
 

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.14.12
+ARG go_version=1.15.7
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It bumps the Go version for the APM Server Docker cntainer.


## Related issues
related to https://github.com/elastic/apm-server/pull/4663
