### PR TITLE
check agent liveness via version subcommand

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -739,7 +739,7 @@ class ElasticAgent(StackService, Service):
             depends_on=self.depends_on,
             environment=self.environment,
             healthcheck={
-                "test": ["CMD", "/bin/true"],
+                "test": ["CMD", "elastic-agent", "version"],
             },
             ports=self.ports,
             volumes=[

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -927,7 +927,7 @@ class ElasticAgentServiceTest(ServiceTest):
                                  "KIBANA_HOST": "http://admin:changeme@kibana:5601",
                                  "KIBANA_PASSWORD": "changeme",
                                  "KIBANA_USERNAME": "admin"},
-                 "healthcheck": {"test": ["CMD", "/bin/true"]},
+                 "healthcheck": {"test": ["CMD", "elastic-agent", "version"]},
                  "image": "docker.elastic.co/beats/elastic-agent:7.12.345-SNAPSHOT",
                  "labels": ["co.elastic.apm.stack-version=7.12.345"],
                  "logging": {"driver": "json-file",


### PR DESCRIPTION
## What does this PR do?

Improves elastic agent docker healthcheck

## Why is it important?

Right now health is not actually checked
