### PR TITLE
docker/go/nethttp: go build -mod=mod

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -8,7 +8,7 @@ RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/apm-agent-go
 RUN (cd /src/apm-agent-go \
   && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
   && git checkout ${GO_AGENT_BRANCH})
-RUN CGO_ENABLED=0 go build
+RUN CGO_ENABLED=0 go build -mod=mod
 
 FROM alpine:latest
 RUN apk add --update curl && rm -rf /var/cache/apk/*


### PR DESCRIPTION
## What does this PR do?

Pass in `-mod=mod` to update go.mod/go.sum as necessary when building the Go "nethttp" test service.

## Why is it important?

Go 1.16 changed the "go build" command so that it no longer automatically updates go.mod and go.sum. See https://golang.org/doc/go1.16#go-command. Because we dynamically change the Go agent version, we cannot set go.mod and go.sum ahead of time.