### PR TITLE
reset postgres sequences after database migration

### DIFF
--- a/docker/opbeans/python/Dockerfile
+++ b/docker/opbeans/python/Dockerfile
@@ -3,6 +3,13 @@ ARG OPBEANS_PYTHON_VERSION=latest
 FROM ${OPBEANS_PYTHON_IMAGE}:${OPBEANS_PYTHON_VERSION}
 ENV ELASTIC_APM_ENABLE_LOG_CORRELATION=true
 
+# postgresql-client is used for the dbshell command in the entrypoint
+RUN apt-get -qq update \
+ && apt-get -qq install -y \
+    postgresql-client \
+	--no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /app/
 
 CMD ["honcho", "start", "--no-prefix"]

--- a/docker/opbeans/python/entrypoint.sh
+++ b/docker/opbeans/python/entrypoint.sh
@@ -7,12 +7,12 @@ if [[ -f /local-install/setup.py ]]; then
     cd ~/local-install && python setup.py install
     cd -
 elif [ -n "$PYTHON_AGENT_VERSION" -a "$PYTHON_AGENT_VERSION" != "latest" ]; then
-    pip install -q -U elastic-apm==$PYTHON_AGENT_VERSION
-elif [[ $PYTHON_AGENT_BRANCH ]]; then
-    if [[ -z ${PYTHON_AGENT_REPO} ]]; then
+    pip install -q -U elastic-apm=="$PYTHON_AGENT_VERSION"
+elif [[ "$PYTHON_AGENT_BRANCH" ]]; then
+    if [[ -z "${PYTHON_AGENT_REPO}" ]]; then
         PYTHON_AGENT_REPO="elastic/apm-agent-python"
     fi
-    pip install -q -U https://github.com/${PYTHON_AGENT_REPO}/archive/${PYTHON_AGENT_BRANCH}.zip
+    pip install -q -U "https://github.com/${PYTHON_AGENT_REPO}/archive/${PYTHON_AGENT_BRANCH}.zip"
 else
     pip install -q -U elastic-apm
 fi

--- a/docker/opbeans/python/entrypoint.sh
+++ b/docker/opbeans/python/entrypoint.sh
@@ -2,7 +2,7 @@
 if [[ -f /local-install/setup.py ]]; then
     echo "Installing from local folder"
     pip uninstall -y elastic-apm
-    # copy to folder inside container to ensure were not poluting the local folder
+    # copy to folder inside container to ensure were not polluting the local folder
     cp -r /local-install ~
     cd ~/local-install && python setup.py install
     cd -
@@ -18,4 +18,6 @@ else
 fi
 rm -f celerybeat.pid
 python manage.py migrate
+python manage.py sqlsequencereset opbeans | python manage.py dbshell
+
 exec "$@"

--- a/docker/opbeans/python/entrypoint.sh
+++ b/docker/opbeans/python/entrypoint.sh
@@ -6,7 +6,7 @@ if [[ -f /local-install/setup.py ]]; then
     cp -r /local-install ~
     cd ~/local-install && python setup.py install
     cd -
-elif [ -n "$PYTHON_AGENT_VERSION" -a "$PYTHON_AGENT_VERSION" != "latest" ]; then
+elif [ -n "$PYTHON_AGENT_VERSION" ] && [ "$PYTHON_AGENT_VERSION" != "latest" ]; then
     pip install -q -U elastic-apm=="$PYTHON_AGENT_VERSION"
 elif [[ "$PYTHON_AGENT_BRANCH" ]]; then
     if [[ -z "${PYTHON_AGENT_REPO}" ]]; then


### PR DESCRIPTION
this resolves a long-standing issue with some views that insert data
and failed with IntegrityErrors because the sequences were not reset
correctly. We did have code for this in the upstream opbeans-python
project, but that code never worked due to an oversight (the necessary
SQL was only generated, but not executed, see https://github.com/elastic/opbeans-python/pull/53).

This approach uses the Django-provided commands to generate the SQL
and execute it. Due to the usage of the `dbshell` command, the `psql`
executable is needed, which is provided by `postgresql-client`.
