### PR TITLE
Create opbeans_user/role with write/read access for the opbeans-python

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -28,3 +28,8 @@ metricbeat:
   indices:
     - names: ['metricbeat-*', 'shrink-metricbeat-*']
       privileges: ['all']
+opbeans:
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
+  indices:
+    - names: ['opbeans-*']
+      privileges: ['write', 'manage']

--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -29,6 +29,7 @@ metricbeat:
     - names: ['metricbeat-*', 'shrink-metricbeat-*']
       privileges: ['all']
 opbeans:
+  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
     - names: ['opbeans-*']
       privileges: ['write', 'read']

--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -29,7 +29,6 @@ metricbeat:
     - names: ['metricbeat-*', 'shrink-metricbeat-*']
       privileges: ['all']
 opbeans:
-  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
     - names: ['opbeans-*']
-      privileges: ['write', 'manage']
+      privileges: ['write', 'read']

--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -29,7 +29,6 @@ metricbeat:
     - names: ['metricbeat-*', 'shrink-metricbeat-*']
       privileges: ['all']
 opbeans:
-  cluster: ['manage_index_templates', 'monitor', 'manage_ingest_pipelines', 'manage_ilm']
   indices:
     - names: ['opbeans-*']
       privileges: ['write', 'read']

--- a/docker/elasticsearch/users
+++ b/docker/elasticsearch/users
@@ -6,3 +6,4 @@ filebeat_user:$2a$10$sFxIEX8tKyOYgsbJLbUhTup76ssvSD3L4T0H6Raaxg4ewuNr.lUFC
 heartbeat_user:$2a$10$nKUGDr/V5ClfliglJhfy8.oEkjrDtklGQfhd9r9NoFqQeoNxr7uUK
 kibana_system_user:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 metricbeat_user:$2a$10$5PyTd121U2ZXnFk9NyqxPuLxdptKbB8nK5egt6M5/4xrKUkk.GReG
+opbeans_user:$2a$10$iTy29qZaCSVn4FXlIjertuO8YfYVLCbvoUAJ3idaXfLRclg9GXdGG

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -7,7 +7,7 @@ filebeat:filebeat_user
 heartbeat:heartbeat_user
 ingest_admin:apm_server_user
 kibana_system:kibana_system_user
-kibana_user:apm_server_user,apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
+kibana_user:apm_server_user,apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user,opbeans_user
 metricbeat:metricbeat_user
 opbeans:opbeans_user
 superuser:admin

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -9,4 +9,5 @@ ingest_admin:apm_server_user
 kibana_system:kibana_system_user
 kibana_user:apm_server_user,apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
 metricbeat:metricbeat_user
+opbeans:opbeans_user
 superuser:admin

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -522,6 +522,8 @@ class OpbeansPython(OpbeansService):
                 "ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES",
                 "REDIS_URL=redis://redis:6379",
                 "ELASTICSEARCH_URL={}".format(self.es_urls),
+                "OPBEANS_USER=opbeans_user",
+                "OPBEANS_PASS=changeme",
                 "OPBEANS_SERVER_URL=http://opbeans-python:{}".format(self.APPLICATION_PORT),
                 "PYTHON_AGENT_BRANCH=" + self.agent_branch,
                 "PYTHON_AGENT_REPO=" + self.agent_repo,

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -355,7 +355,8 @@ class OpbeansServiceTest(ServiceTest):
                         - ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES
                         - REDIS_URL=redis://redis:6379
                         - ELASTICSEARCH_URL=http://elasticsearch:9200
-                        - OPBEANS_SERVER_URL=http://opbeans-python:3000
+                        - OPBEANS_USER=opbeans_user
+                        - OPBEANS_PASS=changeme
                         - PYTHON_AGENT_BRANCH=
                         - PYTHON_AGENT_REPO=
                         - PYTHON_AGENT_VERSION

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -357,6 +357,7 @@ class OpbeansServiceTest(ServiceTest):
                         - ELASTICSEARCH_URL=http://elasticsearch:9200
                         - OPBEANS_USER=opbeans_user
                         - OPBEANS_PASS=changeme
+                        - OPBEANS_SERVER_URL=http://opbeans-python:3000
                         - PYTHON_AGENT_BRANCH=
                         - PYTHON_AGENT_REPO=
                         - PYTHON_AGENT_VERSION


### PR DESCRIPTION
## What does this PR do?

* Create opbeans role and opbeans_user with write/read access in Elasticsearch
* Default password: `changeme`
* Create `OPBEANS_USER` and `OPBEANS_PASS` environment variables.
* Expose those env variables for the `opbeans-python` container

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/1032

## Test

UI

![image](https://user-images.githubusercontent.com/2871786/108513348-62ae3680-72ba-11eb-9cfe-d798e68374d2.png)


```bash
$ hub pr checkout 1063
$ scripts/compose.py start master --with-opbeans-python
$ docker exec -ti localtesting_latest_opbeans-python env | grep OPBEANS
OPBEANS_USER=opbeans_user
OPBEANS_PASS=changeme
OPBEANS_SERVER_URL=http://opbeans-python:3000
OPBEANS_DT_PROBABILITY=0.50
OPBEANS_SERVICES=opbeans-python
```
