### PR TITLE
[7.x] Create opbeans_user/role with write/read access for the opbeans-python (#1063)

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -28,3 +28,7 @@ metricbeat:
   indices:
     - names: ['metricbeat-*', 'shrink-metricbeat-*']
       privileges: ['all']
+opbeans:
+  indices:
+    - names: ['opbeans-*']
+      privileges: ['write', 'read']

--- a/docker/elasticsearch/users
+++ b/docker/elasticsearch/users
@@ -6,3 +6,4 @@ filebeat_user:$2a$10$sFxIEX8tKyOYgsbJLbUhTup76ssvSD3L4T0H6Raaxg4ewuNr.lUFC
 heartbeat_user:$2a$10$nKUGDr/V5ClfliglJhfy8.oEkjrDtklGQfhd9r9NoFqQeoNxr7uUK
 kibana_system_user:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 metricbeat_user:$2a$10$5PyTd121U2ZXnFk9NyqxPuLxdptKbB8nK5egt6M5/4xrKUkk.GReG
+opbeans_user:$2a$10$iTy29qZaCSVn4FXlIjertuO8YfYVLCbvoUAJ3idaXfLRclg9GXdGG

--- a/docker/elasticsearch/users_roles
+++ b/docker/elasticsearch/users_roles
@@ -7,6 +7,7 @@ filebeat:filebeat_user
 heartbeat:heartbeat_user
 ingest_admin:apm_server_user
 kibana_system:kibana_system_user
-kibana_user:apm_server_user,apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
+kibana_user:apm_server_user,apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user,opbeans_user
 metricbeat:metricbeat_user
+opbeans:opbeans_user
 superuser:admin

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -514,6 +514,8 @@ class OpbeansPython(OpbeansService):
                 "ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES",
                 "REDIS_URL=redis://redis:6379",
                 "ELASTICSEARCH_URL={}".format(self.es_urls),
+                "OPBEANS_USER=opbeans_user",
+                "OPBEANS_PASS=changeme",
                 "OPBEANS_SERVER_URL=http://opbeans-python:3000",
                 "PYTHON_AGENT_BRANCH=" + self.agent_branch,
                 "PYTHON_AGENT_REPO=" + self.agent_repo,

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -342,6 +342,8 @@ class OpbeansServiceTest(ServiceTest):
                         - ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES
                         - REDIS_URL=redis://redis:6379
                         - ELASTICSEARCH_URL=http://elasticsearch:9200
+                        - OPBEANS_USER=opbeans_user
+                        - OPBEANS_PASS=changeme
                         - OPBEANS_SERVER_URL=http://opbeans-python:3000
                         - PYTHON_AGENT_BRANCH=
                         - PYTHON_AGENT_REPO=


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Create opbeans_user/role with write/read access for the opbeans-python (#1063)