### PR TITLE
Add --package-registry-url flag

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -439,6 +439,12 @@ class LocalSetup(object):
             default=False
         )
 
+        parser.add_argument(
+            '--package-registry-url',
+            action="store",
+            help="Elastic Package Registry URL to use for fetching integration packages",
+        )
+
         self.store_options(parser)
 
         return parser

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1081,7 +1081,7 @@ class Kibana(StackService, Service):
                 elif self.at_least_version("7.9"):
                     self.environment["XPACK_INGESTMANAGER_FLEET_TLSCHECKDISABLED"] = "true"
             url = package_registry_url(options)
-            if url :
+            if url:
                 self.environment["XPACK_FLEET_REGISTRYURL"] = url
             if use_local_package_registry:
                 self.depends_on["package-registry"] = {"condition": "service_healthy"}
@@ -1158,4 +1158,5 @@ def package_registry_url(options):
         return "http://package-registry:{}".format(PackageRegistry.SERVICE_PORT)
     elif options.get("snapshot"):
         return "https://epr-snapshot.elastic.co"
-    return "" # default to production
+    # default to production
+    return ""

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1386,6 +1386,10 @@ class KibanaServiceTest(ServiceTest):
         self.assertIn("XPACK_SECURITY_ENCRYPTIONKEY", kibana['environment'])
         self.assertIn("XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY", kibana['environment'])
 
+    def test_kibana_package_registry_url(self):
+        kibana = Kibana(package_registry_url="http://testing.invalid").render()["kibana"]
+        self.assertEqual("http://testing.invalid", kibana['environment']['XPACK_FLEET_REGISTRYURL'])
+
     def test_kibana_yml(self):
         kibana = Kibana(kibana_yml="/path/to.yml").render()["kibana"]
         self.assertIn("/path/to.yml:/usr/share/kibana/config/kibana.yml", kibana['volumes'])


### PR DESCRIPTION
## What does this PR do?

Add a `--package-registry-url` flag to control the Elastic Package Registry URL passed into the managed APM Server service and Kibana service environment variables.

Also, set `XPACK_FLEET_REGISTRYURL` in the Kibana environment (consistently with APM Server) regardless of whether we're using a local package registry or not.

Remove the dependency from APM Server to the local package registry; there is already a transitive dependency through Kibana.

## Why is it important?

When running build candidates in the future we should probably default to running with the production Elastic Package Registry (epr.elastic.co). We will need to test with snapshots and staging though, so we can test with packages before they're promoted.

## Related issues

Closes #1068