### PR TITLE
docker/opbeans/go: use -mod=mod

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -20,6 +20,11 @@ RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/go.elastic.co/apm
 RUN (cd /src/go.elastic.co/apm \
     && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
     && git checkout ${GO_AGENT_BRANCH})
+
+# Don't complain if there are missing dependencies in go.mod,
+# as we may be building against an unreleased branch.
+ENV GOFLAGS=-mod=mod
+
 # Add "replace" stanzas to go.mod to use the local agent repo
 RUN go list -m all | grep apm | cut -d' ' -f1 | xargs -i go mod edit -replace {}=/src/{}
 RUN go build


### PR DESCRIPTION
## What does this PR do?

Fix Go integration tests when building against apm-agent-go@master. The tests are failing because `go.mod` and `go.sum` don't contain entries for dependencies of apm-agent-go on the master branch. This started failing with Go 1.16, which is more strict by default. Reinstate pre-Go1.16 behaviour.

## Why is it important?

The integration tests are failing.