### PR TITLE
Fix APM Server managed by Elastic Agent setup

### DIFF
--- a/docker/apm-server/managed/main.go
+++ b/docker/apm-server/managed/main.go
@@ -44,9 +44,6 @@ func setupManagedAPM() error {
 	if err != nil {
 		return err
 	}
-	if apmPkg == nil {
-		return errors.New("no apm package found")
-	}
 	fmt.Println("apm package fetched")
 
 	// define expected APM package policy
@@ -189,7 +186,7 @@ func (client *kibanaClient) getAPMPackage() (*eprPackage, error) {
 		return &apm.Package, err
 
 	}
-	return nil, nil
+	return nil, errors.New("no apm package found")
 }
 
 func (client *kibanaClient) getAgentPolicies(query string) ([]agentPolicy, error) {

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -734,6 +734,7 @@ class ElasticAgent(StackService, Service):
             "KIBANA_FLEET_SETUP": "1",
             "FLEET_SERVER_ENABLE": "1",
             "FLEET_ENROLL": "1",
+            "FLEET_SERVER_INSECURE_HTTP": "1",
             "FLEET_SERVER_POLICY_NAME": "Default policy",  # TODO(simitt): make configurable
             "KIBANA_HOST": kibana_url,
             "ELASTICSEARCH_HOST": es_url

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -40,7 +40,8 @@ class ApmServer(StackService, Service):
             if not kibana_url:
                 kibana_scheme = "https" if self.options.get("kibana_enable_tls", False) else "http"
                 kibana_url = kibana_scheme + "://admin:changeme@" + self.DEFAULT_KIBANA_HOST
-            self.depends_on = {"kibana": {"condition": "service_healthy"}}
+            self.depends_on = {"kibana": {"condition": "service_healthy"},
+                               "elastic-agent": {"condition": "service_healthy"}}
 
             self.managed_environment = {"KIBANA_HOST": kibana_url,
                                         "APM_SERVER_SECRET_TOKEN": self.options.get("apm_server_secret_token", "")}
@@ -1185,7 +1186,7 @@ def package_registry_url(options):
         return url
     if options.get("enable_package_registry"):
         return "http://package-registry:{}".format(PackageRegistry.SERVICE_PORT)
-    elif options.get("snapshot"):
+    elif options.get("snapshot") or not options.get("release"):
         return "https://epr-snapshot.elastic.co"
     # default to production
     return ""

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -735,7 +735,6 @@ class ElasticAgent(StackService, Service):
             "FLEET_SERVER_ENABLE": "1",
             "FLEET_ENROLL": "1",
             "FLEET_SERVER_INSECURE_HTTP": "1",
-            "FLEET_SERVER_POLICY_NAME": "Default policy",  # TODO(simitt): make configurable
             "KIBANA_HOST": kibana_url,
             "ELASTICSEARCH_HOST": es_url
         }

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -928,7 +928,6 @@ class ElasticAgentServiceTest(ServiceTest):
                                  'FLEET_SERVER_ENABLE': '1',
                                  'FLEET_INSECURE': '1',
                                  "FLEET_SERVER_INSECURE_HTTP": "1",
-                                 'FLEET_SERVER_POLICY_NAME': 'Default policy',
                                  'KIBANA_FLEET_SETUP': '1',
                                  'KIBANA_HOST': 'http://admin:changeme@kibana:5601',
                                  'KIBANA_PASSWORD': 'changeme',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -927,6 +927,7 @@ class ElasticAgentServiceTest(ServiceTest):
                                  'FLEET_ENROLL': '1',
                                  'FLEET_SERVER_ENABLE': '1',
                                  'FLEET_INSECURE': '1',
+                                 "FLEET_SERVER_INSECURE_HTTP": "1",
                                  'FLEET_SERVER_POLICY_NAME': 'Default policy',
                                  'KIBANA_FLEET_SETUP': '1',
                                  'KIBANA_HOST': 'http://admin:changeme@kibana:5601',


### PR DESCRIPTION
The latest docker builds for Kibana and Elastic Agent for `master` and `7.13` are working again; the apm-integration testing setup needs to be adjusted to the latest fixes. 

There seems to be something up with the production package registry - it is not serving an APM package. Snapshot registry works fine. 

This PR includes:
* print statements for APM Server setup for easier debugging in case something goes wrong
* APM Server setup uses Fleet API now for fetching APM package instead of directly calling the EPR. The configured EPR URL already needs to be considered by Kibana. 
* Adding APM Server integration to Fleet Policy, to which the Elastic Agent now enrolls. 
* Using Snapshot EPR if `--snapshot` flag is provided, rather than production one. 



