### PR TITLE
Add mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+        comment:
+          message: |
+            This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+            To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+            ```
+            git fetch upstream
+            git checkout -b {{head}} upstream/{{head}}
+            git merge upstream/{{base}}
+            git push upstream {{head}}
+            ```
+  - name: backport patches to 7.x branch
+    conditions:
+      - base=master
+      - label=backport
+    actions:
+      backport:
+        branches:
+          - "7.x"


### PR DESCRIPTION
## What does this PR do?

Add mergify for the backports to 7.x if PRs were assigned with the `backport` label.

We won't do for 6.x

## Why is it important?

Ensure we don't forget backports

