### PR TITLE
fix: elastic-agent ensure 7.12 backwards compatibility, add bugfix fleet server

### DIFF
--- a/docker/apm-server/managed/main.go
+++ b/docker/apm-server/managed/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -110,8 +111,13 @@ func setupManagedAPM() error {
 }
 
 func fetchDefaultPolicy(client *kibanaClient) (agentPolicy, error) {
+	fleetServer := ""
+	if enable, err := strconv.ParseBool(os.Getenv("FLEET_SERVER_ENABLE")); err == nil && enable {
+		fleetServer = "_fleet_server"
+	}
+	kuery := fmt.Sprintf("kuery=ingest-agent-policies.is_default%s:true", fleetServer)
 	for ct := 0; ct < 20; ct++ {
-		agentPolicies, err := client.getAgentPolicies("kuery=ingest-agent-policies.is_default_fleet_server:true")
+		agentPolicies, err := client.getAgentPolicies(kuery)
 		if err != nil {
 			return agentPolicy{}, err
 		}

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -737,21 +737,26 @@ class ElasticAgent(StackService, Service):
             "FLEET_ENROLL": "1",
             "FLEET_SERVER_INSECURE_HTTP": "1",
             "KIBANA_HOST": kibana_url,
-            "ELASTICSEARCH_HOST": es_url
+            "ELASTICSEARCH_HOST": es_url,
+            "FLEET_SERVER_HOST": "0.0.0.0"
         }
+        if self.version_lower_than("7.13"):
+            self.environment["FLEET_SETUP"] = "1"
         if kibana_parsed_url.password:
             self.environment["KIBANA_PASSWORD"] = kibana_parsed_url.password
         if kibana_parsed_url.username:
             self.environment["KIBANA_USERNAME"] = kibana_parsed_url.username
         if not kibana_url.startswith("https://"):
             self.environment["FLEET_INSECURE"] = "1"
+            if self.version_lower_than("7.13"):
+                self.environment["FLEET_ENROLL_INSECURE"] = 1
         if es_parsed_url.password:
             self.environment["ELASTICSEARCH_PASSWORD"] = es_parsed_url.password
         if es_parsed_url.username:
             self.environment["ELASTICSEARCH_USERNAME"] = es_parsed_url.username
 
         # set ports for defined integrations
-        self.ports = []
+        self.ports = [self.publish_port("8220")]
         if self.options.get("enable_apm_server") and self.options.get("apm_server_managed"):
             self.ports.append(self.publish_port(self.options.get(
                 "apm_server_port", ApmServer.SERVICE_PORT), ApmServer.SERVICE_PORT))

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -925,9 +925,12 @@ class ElasticAgentServiceTest(ServiceTest):
                                  'ELASTICSEARCH_PASSWORD': 'changeme',
                                  'ELASTICSEARCH_USERNAME': 'admin',
                                  'FLEET_ENROLL': '1',
+                                 'FLEET_ENROLL_INSECURE': 1,
                                  'FLEET_SERVER_ENABLE': '1',
                                  'FLEET_INSECURE': '1',
                                  "FLEET_SERVER_INSECURE_HTTP": "1",
+                                 'FLEET_SERVER_HOST': '0.0.0.0',
+                                 'FLEET_SETUP': '1',
                                  'KIBANA_FLEET_SETUP': '1',
                                  'KIBANA_HOST': 'http://admin:changeme@kibana:5601',
                                  'KIBANA_PASSWORD': 'changeme',
@@ -937,7 +940,7 @@ class ElasticAgentServiceTest(ServiceTest):
                  "labels": ["co.elastic.apm.stack-version=7.12.345"],
                  "logging": {"driver": "json-file",
                              "options": {"max-file": "5", "max-size": "2m"}},
-                 'ports': ['127.0.0.1:8200:8200'],
+                 'ports': ['127.0.0.1:8220:8220', '127.0.0.1:8200:8200'],
                  "volumes": ["/var/run/docker.sock:/var/run/docker.sock"]}
         )
 


### PR DESCRIPTION
## What does this PR do?
* Ensure backwards comaptibility with Elastic Agent for `7.12.`
* Fix current bug with Fleet Server URL
* Expose Fleet Server Port

## Why is it important?
fix issues when running `./scripts/compose.py start 7.12 --with-elastic-agent --apm-server-managed` 