### PR TITLE
CI: skip timer trigger on a PR basis

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     GIT_REFERENCE_REPO = '/var/lib/jenkins/.git-references/apm-integration-testing.git'
   }
   triggers {
-    cron 'H H(3-4) * * 1-5'
+    cron(env.CHANGE_ID?.trim() ? '' : 'H H(3-4) * * 1-5')
     issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|/test(?:all))')
   }
   options {


### PR DESCRIPTION
## What does this PR do?

Avoid running the builds on a PR basis with a timer trigger

## Why is it important?

It's not required

## Related issues
Closes #ISSUE
