### PR TITLE
fix: set destructive_requires_name to false

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -850,6 +850,7 @@ class Elasticsearch(StackService, Service):
             try_to_set_slowlog(options.get("apm_server_elasticsearch_password"))
         if self.at_least_version("8.0"):
             self.environment.append("indices.id_field_data.enabled=true")
+            self.environment.append("action.destructive_requires_name=false")
         if not self.oss:
             xpack_security_enabled = "false"
             if self.xpack_secure:

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -967,6 +967,7 @@ class LocalTest(unittest.TestCase):
                     'ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g',
                     path.data=/usr/share/elasticsearch/data/8.0.0,
                     indices.id_field_data.enabled=true,
+                    action.destructive_requires_name=false,
                     xpack.security.authc.anonymous.roles=remote_monitoring_collector,
                     xpack.security.authc.realms.file.file1.order=0,
                     xpack.security.authc.realms.native.native1.order=1,


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It sets the action.destructive_requires_name to false

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
A recent change has changed this setting to true by default and `elasticsearch.clean()` method stops working breaking all tests.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/1095
