### PR TITLE
fix: drop ancient and conflicting maxQueueSize setting for node.js agent

### DIFF
--- a/docker/nodejs/express/app.js
+++ b/docker/nodejs/express/app.js
@@ -4,8 +4,6 @@ var apm = require('elastic-apm-node').start({
   frameworkName: 'express',
   frameworkVersion: 'unknown',
   serviceName: process.env.EXPRESS_SERVICE_NAME,
-  flushInterval: 1,
-  maxQueueSize: 1,
   apiRequestTime: "50ms",
   ignoreUrls: ['/healthcheck']
 })
@@ -58,4 +56,3 @@ app.use(function (err, req, res, next) {
 var server = app.listen(process.env.EXPRESS_PORT, '0.0.0.0', function () {
     console.log("Listening on %s...", server.address().port);
 });
-


### PR DESCRIPTION
The maxQueueSize and flushInterval vars are settings from v1 of the
node.js agent -- EOL'd more than 2 years ago:
https://www.elastic.co/guide/en/apm/agent/nodejs/current/upgrade-to-v2.html#v2-removed-config-options

Now, https://github.com/elastic/apm-agent-nodejs/pull/2024 is adding a
maxQueueSize config variable with a different meaning. This old
`maxQueueSize: 1` breaks integration tests for the new code by telling
the agent to drop any transactions/span/errors if there is already a
single event that hasn't yet been sent to the APM server.
