### PR TITLE
fix: correct Makefile syntax to spawn a subshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ stop-env: venv ## Stop the test environment
 	docker-compose down -v --remove-orphans || true
 
 destroy-env: venv ## Destroy the test environment
-	[ -n "$(docker ps -aqf network=apm-integration-testing)" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
+	[ -n "$$(docker ps -aqf network=apm-integration-testing)" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
 
 # default (all) built for now
 build-env-%: venv


### PR DESCRIPTION
This fixes a buglet (IIUC) in the Makefile `destroy-env` target.  With the single `$` it is trying to do variable expansion, which resolves tothe empty string and you get a no-op everytime:

```
% make destroy-env
[ -n "" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
```


(Sorry for the branch on the main repo, I hit the wrong option with `gh pr create ...` that pushed to this repo instead of to my fork.)