### PR TITLE
fix: add git to opbeans-node testing container in case npm install needs it

### DIFF
--- a/docker/opbeans/node/Dockerfile
+++ b/docker/opbeans/node/Dockerfile
@@ -2,7 +2,7 @@ ARG OPBEANS_NODE_IMAGE=opbeans/opbeans-node
 ARG OPBEANS_NODE_VERSION=latest
 FROM ${OPBEANS_NODE_IMAGE}:${OPBEANS_NODE_VERSION}
 
-RUN apk --no-cache add rsync
+RUN apk --no-cache add rsync git
 COPY entrypoint.sh /app/entrypoint.sh
 
 CMD ["pm2-runtime", "ecosystem-workload.config.js"]


### PR DESCRIPTION
Add git to the "apm-integration-testing_opbeans-node" container in case
the "npm install" of the Node.js APM agent requires it. For example, when one of its
deps is from a github repo.

Fixes: #1106
