### PR TITLE
Update to serviced dotnet/sdk tag

### DIFF
--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -3,7 +3,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -4,7 +4,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS opbeans-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS opbeans-dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=master


### PR DESCRIPTION
This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?