### PR TITLE
disable elastic agent container healthcheck temporarily

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -766,7 +766,7 @@ class ElasticAgent(StackService, Service):
             depends_on=self.depends_on,
             environment=self.environment,
             healthcheck={
-                "test": ["CMD", "elastic-agent", "version"],
+                "test": ["CMD", "/bin/true"],
             },
             ports=self.ports,
             volumes=[

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -935,7 +935,7 @@ class ElasticAgentServiceTest(ServiceTest):
                                  'KIBANA_HOST': 'http://admin:changeme@kibana:5601',
                                  'KIBANA_PASSWORD': 'changeme',
                                  'KIBANA_USERNAME': 'admin'},
-                 "healthcheck": {"test": ["CMD", "elastic-agent", "version"]},
+                 "healthcheck": {"test": ["CMD", "/bin/true"]},
                  "image": "docker.elastic.co/beats/elastic-agent:7.12.345-SNAPSHOT",
                  "labels": ["co.elastic.apm.stack-version=7.12.345"],
                  "logging": {"driver": "json-file",


### PR DESCRIPTION
can be reverted (and changed to `status`) once https://github.com/elastic/beats/issues/24956 is resolved