### PR TITLE
fix: Elastic Agent with Fleet Server setup

### DIFF
--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1018,9 +1018,6 @@ class LocalTest(unittest.TestCase):
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_SECURITY_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
                     XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
-                    XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST: 'http://elasticsearch:9200',
-                    XPACK_FLEET_AGENTS_KIBANA_HOST: 'http://kibana:5601',
-                    XPACK_FLEET_AGENTS_TLSCHECKDISABLED: 'true',
                     XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
                     XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'


### PR DESCRIPTION

## What does this PR do?

Fix Elastic Agent with Fleet Server setup
* adapt to Kibana breaking changes
* ensure to enroll to fleet-server policy

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
`./scripts/compose.py start <version> --with-elastic-agent --apm-server-managed` is currently broken - will be fixed with this PR (tested with `master`, `7.13` and `7.12`)
