### PR TITLE
fix: add normalize function

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -238,3 +238,7 @@ def wrappingup(label){
     archiveArtifacts(artifacts: 'docs.txt')
   }
 }
+
+def normalise(label) {
+  return label?.replace(';','/').replace('--','_').replace('.','_').replace(' ','_')
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it adds a missing function.

```
16:31:19  Error when executing always post condition:
16:31:19  java.lang.NoSuchMethodError: No such DSL method 'normalise' found among steps [addEmbeddableBadgeConfiguration, ansiColor, archive, bat, build, catchError, checkout, compareVersions, deleteDir, dir, dockerFingerprintFrom, dockerFingerprintRun, echo, emailext, emailextrecipients, envVarsForTool, error, fileExists, findBuildScans, findFiles, getContext, getCustomBuildProperty, git, githubNotify, input, isUnix, jiraComment, jiraIssueSelector, jiraSearch, junit, library, libraryResource, load, lock, mail, milestone, node, nodesByLabel, parallel, powershell, properties, publishChecks, publishHTML, pwd, pwsh, readCSV, readFile, readJSON, readManifest, readMavenPom, readProperties, readTrusted, readYaml, resolveScm, retry, script, setCustomBuildProperty, setJUnitCounts, sh, sha1, slackSend, slackUploadFile, slackUserIdFromEmail, slackUserIdsFromCommitters, sleep, sshagent, stage, stash, step, tee, timeout, timestamps, tm, tool, touch, unarchive, unstable, unstash, unzip, vSphere, validateDeclarativePipeline, waitForCustomBuildProperties, waitUntil, warnError, withChecks, withContext, withCredentials, withDockerContainer, withDockerRegistry, withDockerServer, withEnv, withGradle, wrap, writeCSV, writeFile, writeJSON, writeMavenPom, writeYaml, ws, xunit, zip] or symbols [AUnit, BoostTest, CTest, CUnit, Check, CppTest, CppUnit, Custom, FPCUnit, GenericTrigger, GoogleTest, JUnit, MSTest, MbUnit, NUnit2, NUnit3, PHPUnit, QtTest, UnitTest, Valgrind, all, allBranchesSame, allOf, allure, always, ant, antFromApache, antOutcome, antPath, antTarget, any, anyOf, apiToken, architecture, archiveArtifacts, artifactManager, authorizationMatrix, batchFile, bitbucket, bitbucketBranchDiscovery, bitbucketForkDiscovery, bitbucketPublicRepoPullRequestFilter, bitbucketPullRequestDiscovery, bitbucketSshCheckout, bitbucketTagDiscovery, bitbucketTrustEveryone, bitbucketTrustNobody, bitbucketTrustProject, bitbucketTrustTeam, bitbucketWebhookConfiguration, bitbucketWebhookRegistration, booleanParam, branch, brokenBuildSuspects, brokenTestsSuspects, buildAllBranches, buildAnyBranches, buildButton, buildChangeRequests, buildDescription, buildDiscarder, buildDiscarders, buildName, buildNamedBranches, buildNoneBranches, buildParameter, buildRegularBranches, buildRetention, buildSelector, buildTags, buildUser, buildingTag, caseInsensitive, caseSensitive, certificate, changeRequest, changelog, changeset, checkoutToSubdirectory, choice, choiceParam, cleanWs, clock, cobertura, coberturaAdapter, command, copyArtifactPermission, copyArtifacts, copyartifact, credentials, cron, crumb, culprits, defaultFolderConfiguration, defaultView, demand, developers, disableConcurrentBuilds, disableResume, docker, dockerCert, dockerServer, dockerTool, dockerfile, downstream, dumb, durabilityHint, email-ext, embUnit, envInject, envVars, envVarsFilter, environment, equals, exact, expression, extendedEmailPublisher, failed, file, fileParam, filePath, fingerprint, fingerprints, frameOptions, freeStyle, freeStyleJob, fromDocker, fromScm, fromSource, git, gitBranchDiscovery, gitHubBranchDiscovery, gitHubBranchHeadAuthority, gitHubExcludeArchivedRepositories, gitHubExcludePublicRepositories, gitHubForkDiscovery, gitHubPullRequestDiscovery, gitHubSshCheckout, gitHubTagDiscovery, gitHubTopicsFilter, gitHubTrustContributors, gitHubTrustEveryone, gitHubTrustNobody, gitHubTrustPermissions, gitTagDiscovery, github, githubAccessToken, githubPush, googleStorageBucketLifecycle, googleStorageBuildLogUpload, googleStorageDownload, googleStorageUpload, gradle, gtester, hashicorpVault, headRegexFilter, headWildcardFilter, hyperlink, hyperlinkToModels, inheriting, inheritingGlobal, installSource, isRestartedRun, issueCommentTrigger, istanbulCobertura, istanbulCoberturaAdapter, jacoco, jacocoAdapter, javadoc, jdk, jdkInstaller, jgit, jgitapache, jnlp, jobBuildDiscarder, jobDsl, jobName, junitTestResultStorage, label, lastCompleted, lastDuration, lastFailure, lastGrantedAuthorities, lastStable, lastSuccess, lastSuccessful, lastWithArtifacts, latestSavedBuild, legacy, legacySCM, list, local, location, logRotator, loggedInUsersCanDoAnything, mailer, masterBuild, maven, maven3Mojos, mavenErrors, mavenGlobalConfig, mavenMojos, mavenWarnings, modernSCM, myView, namedBranchesDifferent, newContainerPerStage, node, nodeProperties, nonInheriting, none, not, overrideIndexTriggers, paneStatus, parallelsAlwaysFailFast, parameters, passed, password, pattern, permalink, permanent, pipeline-model, pipeline-model-docker, pipelineTriggers, plainText, plugin, pollSCM, preserveStashes, projectNamingStrategy, proxy, pruneTags, publishCoverage, queueItemAuthenticator, quietPeriod, rateLimit, rateLimitBuilds, recipients, regex, requestor, resourceRoot, retainOnlyVariables, run, runParam, s3CopyArtifact, s3Upload, sSHLauncher, schedule, scmRetryCount, script, scriptApproval, scriptApprovalLink, search, security, shell, simpleBuildDiscarder, skipDefaultCheckout, skipStagesAfterUnstable, skipped, slackNotifier, slave, sourceFiles, sourceRegexFilter, sourceWildcardFilter, specific, ssh, sshPublicKey, sshUserPrivateKey, standard, status, string, stringParam, suppressAutomaticTriggering, swapSpace, tag, teamSlugFilter, text, textParam, timestamper, timestamperConfig, timezone, tmpSpace, toolLocation, triggeredBy, unsecured, untrusted, upstream, upstreamDevelopers, url, userSeed, usernameColonPassword, usernamePassword, vaultString, viewsTabBar, weather, wildcards, withAnt, withVault, workspace, x509ClientCert, xUnitDotNet, zip] or globals [abortBuild, agentMapping, apmCli, axis, base64decode, base64encode, beatsStages, beatsWhen, build, buildKibanaDockerImage, buildStatus, cancelPreviousRunningBuilds, checkLicenses, checkout, cmd, codecov, convertGoTestResults, coverageReport, createFileFromTemplate, currentBuild, detailsURL, docker, dockerLogin, dockerLogs, dummy, dummyDeclarativePipeline, echoColor, env, filebeat, generateChangelog, generateReport, getBlueoceanDisplayURL, getBlueoceanRestURLJob, getBlueoceanTabURL, getBuildInfoJsonFiles, getFlakyJobName, getGitCommitSha, getGitMatchingGroup, getGitRepoURL, getGithubToken, getModulesFromCommentTrigger, getStageId, getTraditionalPageURL, getVaultSecret, gh, git, gitChangelog, gitCheckout, gitCmd, gitCreateTag, gitDeleteTag, gitPush, githubApiCall, githubAppToken, githubBranchRef, githubCheck, githubCommentIssue, githubCreateIssue, githubCreatePullRequest, githubEnv, githubIssues, githubPrCheckApproved, githubPrComment, githubPrInfo, githubPrLabels, githubPrLatestComment, githubPrReviews, githubReleaseCreate, githubReleasePublish, githubRepoGetUserPermission, githubTraditionalPrComment, goDefaultVersion, goTestJUnit, googleStorageUpload, googleStorageUploadExt, gsutil, hasCommentAuthorWritePermissions, httpRequest, installTools, is32, is32arm, is32x86, is64, is64arm, is64x86, isArm, isBranch, isBranchIndexTrigger, isBuildFailure, isCommentTrigger, isGitRegionMatch, isInstalled, isInternalCI, isMemberOf, isPR, isStaticWorker, isTag, isTimerTrigger, isUpstreamTrigger, isUserTrigger, isX86, junitAndStore, licenseScan, log, lookForGitHubIssues, matchesPrLabel, matrix, metricbeat, mvnVersion, nexusCloseStagingRepository, nexusCreateStagingRepository, nexusDropStagingRepository, nexusFindStagingId, nexusReleaseStagingRepository, nexusUploadStagingArtifact, nodeArch, nodeOS, notifyBuildResult, opbeansPipeline, params, pipeline, pipelineManager, preCommit, preCommitToJunit, publishToCDN, randomNumber, releaseNotification, retryWithSleep, rubygemsLogin, runWatcher, runbld, scm, sendBenchmarks, sendDataToElasticsearch, setEnvVar, setGithubCommitStatus, setupAPMGitEmail, stackVersions, stageStatusCache, stashV2, superLinter, tap2Junit, tar, toJSON, unstashV2, untar, updateGithubCommitStatus, whenFalse, whenTrue, withAPM, withAzureCredentials, withEnvMask, withEsEnv, withGitRelease, withGithubCheck, withGithubNotify, withGithubStatus, withGoEnv, withGoEnvUnix, withGoEnvWindows, withHubCredentials, withMageEnv, withNode, withNpmrc, withSecretVault, withTotpVault, withVaultToken, writeVaultSecret]
16:31:19  	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:216)
16:31:19  	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
16:31:19  	at sun.reflect.GeneratedMethodAccessor635.invoke(Unknown Source)
16:31:19  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
16:31:19  	at java.lang.reflect.Method.invoke(Method.java:498)
16:31:19  	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
16:31:19  	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
16:31:19  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1213)
16:31:19  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
16:31:19  	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
16:31:19  	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
16:31:19  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
16:31:19  	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:163)
16:31:19  	at org.kohsuke.groovy.sandbox.GroovyInterceptor.onMethodCall(GroovyInterceptor.java:23)
16:31:19  	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:157)
16:31:19  	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:161)
16:31:19  	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:165)
16:31:19  	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:135)
16:31:19  	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17)
16:31:19  	at WorkflowScript.wrappingup(WorkflowScript:229)
```
