### PR TITLE
Massage handling of --elasticsearch-java-opts arg

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -923,7 +923,10 @@ class Elasticsearch(StackService, Service):
         class storeDict(argparse.Action):
             def __call__(self, parser, namespace, value, option_string=None):
                 items = getattr(namespace, self.dest)
-                items.update(dict([value.split("=", 1)]))
+                if '=' in value:
+                    items.update({value.lstrip('-'): ''})
+                else:
+                    items.update(dict([value.split("=", 1)]))
 
         # this is a dict to enable deduplication
         # eg --elasticsearch-java-opts a==z --elasticsearch-java-opts a==b will add only -a=b to ES_JAVA_OPTS


### PR DESCRIPTION
## What does this PR do?

This handles cases where a "raw" option is passed to `--elasticsearch-java-opts`. In these cases, we detect the "raw" condition by searching for an equals sign. If one is found, we assume it to be raw and if a leading dash is found, we remove it as well since one will be appended when the environment is constructed.

I tried to make this as non-invasive as possible. I can't definitively say that this won't break any existing workflows which are out there currently, but we should be able to adapt them to this new options handling relatively easily. 

## Related issues
Closes https://github.com/elastic/observability-robots/issues/472
