### PR TITLE
[mergify]: assign author and backport when merged

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,9 +15,12 @@ pull_request_rules:
             ```
   - name: backport patches to 7.x branch
     conditions:
+      - merged
       - base=master
       - label=backport
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.x"


### PR DESCRIPTION
## What does this PR do?

Update mergify to backport after the original PR was merged and assign the original author.

## Why is it important?

Avoid GH commit checks that are waiting for.