### PR TITLE
chore: drop old branch from backport config

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,5 @@
 {
   "upstream": "elastic/apm-integration-testing",
-  "branches": [{ "name": "7.x", "checked": true }, { "name": "6.x", "checked": true }, { "name": "6.x-v1", "checked": true } ],
+  "branches": [{ "name": "7.x", "checked": true }, { "name": "6.x", "checked": true } ],
   "labels": ["backport"]
 }


### PR DESCRIPTION
IIUC the "6.x-v1" branch is gone.