### PR TITLE
[6.x] fix: update flake8 and deps to work with Python 3.8+ (#1085)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ docker==3.7.3
 dockerpty==0.4.1
 docopt==0.6.2
 elasticsearch==6.3.1
-flake8==3.6.0
+flake8==3.9.0
 funcsigs==1.0.2
 future==0.16.0
 idna==2.6
@@ -19,8 +19,8 @@ jsonschema==2.6.0
 mccabe==0.6.1
 pluggy==0.13.1
 py==1.5.2
-pycodestyle==2.4.0
-pyflakes==2.0.0
+pycodestyle==2.7.0
+pyflakes==2.3.0
 pytest-base-url==1.4.2
 pytest-html==2.1.1
 pytest-metadata==1.10.0


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix: update flake8 and deps to work with Python 3.8+ (#1085)