### PR TITLE
[7.x] fix: correct Makefile syntax to spawn a subshell (#1105)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ stop-env: venv ## Stop the test environment
 	docker-compose down -v --remove-orphans || true
 
 destroy-env: venv ## Destroy the test environment
-	[ -n "$(docker ps -aqf network=apm-integration-testing)" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
+	[ -n "$$(docker ps -aqf network=apm-integration-testing)" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
 
 # default (all) started for now
 env-%: venv


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: correct Makefile syntax to spawn a subshell (#1105)