### PR TITLE
[6.x] fix: correct Makefile syntax to spawn a subshell (#1105)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ stop-env: venv
 	docker-compose down -v --remove-orphans || true
 
 destroy-env: venv
-	[ -n "$(docker ps -aqf network=apm-integration-testing)" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
+	[ -n "$$(docker ps -aqf network=apm-integration-testing)" ] && (docker ps -aqf network=apm-integration-testing | xargs -t docker rm -f && docker network rm apm-integration-testing) || true
 
 # default (all) started for now
 env-%: venv
@@ -76,9 +76,9 @@ docker-test-%:
 dockerized-test:
 	@echo waiting for services to be healthy
 	docker-compose-wait || (./scripts/docker-summary.sh; echo "[ERROR] Failed waiting for all containers are healthy"; exit 1)
-	
+
 	./scripts/docker-summary.sh
-	
+
 	@echo running make $(TARGET) inside a container
 	docker build --pull -t apm-integration-testing .
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix: correct Makefile syntax to spawn a subshell (#1105)