### PR TITLE
[7.x] fix: add git to opbeans-node testing container in case npm install needs it (#1107)

### DIFF
--- a/docker/opbeans/node/Dockerfile
+++ b/docker/opbeans/node/Dockerfile
@@ -2,7 +2,7 @@ ARG OPBEANS_NODE_IMAGE=opbeans/opbeans-node
 ARG OPBEANS_NODE_VERSION=latest
 FROM ${OPBEANS_NODE_IMAGE}:${OPBEANS_NODE_VERSION}
 
-RUN apk --no-cache add rsync
+RUN apk --no-cache add rsync git
 COPY entrypoint.sh /app/entrypoint.sh
 
 CMD ["pm2-runtime", "ecosystem-workload.config.js"]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: add git to opbeans-node testing container in case npm install needs it (#1107)