### PR TITLE
fix lint

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -935,7 +935,7 @@ class AgentNodejsExpress(Service):
         return dict(
             build={"context": "docker/nodejs/express", "dockerfile": "Dockerfile"},
             command="bash -c \"npm install {} && node app.js\"".format(
-                self.agent_package, self.SERVICE_PORT),
+                self.agent_package),
             container_name="expressapp",
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "expressapp"),
             image=None,
@@ -2216,7 +2216,7 @@ class LocalSetup(object):
             '-F service_name="{service_name}" '
             '-F service_version="{service_version}" '
             '-F bundle_filepath="{bundle_path}" '
-            '-F sourcemap=@/tmp/sourcemap '
+            '-F sourcemap=@{sourcemap_file} '
             '{auth_header}'
             '{server_url}/v1/client-side/sourcemaps'
         ).format(


### PR DESCRIPTION
This fixes a couple lint errors on the 6.x branch:

```
% make lint
flake8 tests/ scripts/compose.py
scripts/compose.py:937:21: F523 '...'.format(...) has unused arguments at position(s): 1
scripts/compose.py:2214:15: F522 '...'.format(...) has unused named argument(s): sourcemap_file
make: *** [lint] Error 1
```

These same fixes were effectively made in separate changes in 7.x and master, but in larger changes that can't easily just be backported.  Getting this in unblocks looking at possible errors in the node.js agent integration tests.
