### PR TITLE
fix(README): add linebreak to bash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ and using the version name `test-demo`
 APM_SERVER_URL=https://apm.example.com \
 APM_TOKEN=MySuPerApMToKen \
 python3 ./scripts/compose.py start 8.0.0 \
-  --no-kibana
+  --no-kibana \
   --no-elasticsearch \
   --dyno  \
   --apm-server-url "${APM_SERVER_URL}" \


### PR DESCRIPTION
## What does this PR do?

Fixes a syntax error when starting a local dev environment. The missing part here is the `\` linebreak that is now added.

## Why is it important?

Copy & paste does not work.
