### PR TITLE
Use remote repos in 7.x for opbeans-go

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -20,8 +20,6 @@ RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/go.elastic.co/apm
 RUN (cd /src/go.elastic.co/apm \
     && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \
     && git checkout ${GO_AGENT_BRANCH})
-# Add "replace" stanzas to go.mod to use the local agent repo
-RUN go list -m all | grep apm | cut -d' ' -f1 | xargs -i go mod edit -replace {}=/src/{}
 RUN go build
 
 # Stage 1: copy static assets from opbeans/opbeans-frontend and


### PR DESCRIPTION
## What does this PR do?

This is a partial revert of 6b383210f7c8666d3711f76008df95f47f177478 . Specifically, it reverts the change to[ try and use the a local repo for APM-related modules.](https://github.com/elastic/apm-integration-testing/commit/6b383210f7c8666d3711f76008df95f47f177478#diff-daca2c3258c605cf898c97ad369aa183b2503d6b8c41639e1bdb4b12550dd280R16-L17) 

While this works fine on the master branch, it [is broken on 7.x](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-tests-upgrade-mbp/detail/7.x/487/pipeline). By including this fix, the container builds properly and should restore functionality to our 7.x upgrade tests in the APM Integration Test suite.

## Why is it important?

Broken tests bad. Working tests good.
