### PR TITLE
Pin go version of go opbean to 1.15

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -2,7 +2,7 @@
 #
 # GO_AGENT_REPO and GO_AGENT_BRANCH parameterise the Go agent
 # repo and branch (or commit) to use.
-FROM golang:stretch
+FROM golang:1.15
 ENV GO111MODULE=on
 ARG OPBEANS_GO_REPO=elastic/opbeans-go
 ARG OPBEANS_GO_BRANCH=master


### PR DESCRIPTION
## What does this PR do?
Pins Go version to 1.15

Supercedes https://github.com/elastic/apm-integration-testing/pull/1137

## Why is it important?

Suggested here: https://github.com/elastic/apm-integration-testing/pull/1137#pullrequestreview-652887728

Should resolve failures in 7.x APM integration tests.

