### PR TITLE
fix --no-apm-server-profile

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -99,7 +99,7 @@ class ApmServer(StackService, Service):
 
         if options.get("apm_server_self_instrument", True):
             self.apm_server_command_args.append(("apm-server.instrumentation.enabled", "true"))
-            if self.at_least_version("7.6") and options.get("no_apm_server_profile", False) == False:
+            if self.at_least_version("7.6") and not options.get("no_apm_server_profile", False):
                 self.apm_server_command_args.extend([
                     ("apm-server.instrumentation.profiling.cpu.enabled", "true"),
                     ("apm-server.instrumentation.profiling.heap.enabled", "true"),

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -99,7 +99,7 @@ class ApmServer(StackService, Service):
 
         if options.get("apm_server_self_instrument", True):
             self.apm_server_command_args.append(("apm-server.instrumentation.enabled", "true"))
-            if self.at_least_version("7.6") and options.get("apm_server_profile", True):
+            if self.at_least_version("7.6") and options.get("no_apm_server_profile", False):
                 self.apm_server_command_args.extend([
                     ("apm-server.instrumentation.profiling.cpu.enabled", "true"),
                     ("apm-server.instrumentation.profiling.heap.enabled", "true"),

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -99,7 +99,7 @@ class ApmServer(StackService, Service):
 
         if options.get("apm_server_self_instrument", True):
             self.apm_server_command_args.append(("apm-server.instrumentation.enabled", "true"))
-            if self.at_least_version("7.6") and options.get("no_apm_server_profile", False):
+            if self.at_least_version("7.6") and options.get("no_apm_server_profile", False) == False:
                 self.apm_server_command_args.extend([
                     ("apm-server.instrumentation.profiling.cpu.enabled", "true"),
                     ("apm-server.instrumentation.profiling.heap.enabled", "true"),

--- a/scripts/tests/test_service.py
+++ b/scripts/tests/test_service.py
@@ -772,7 +772,7 @@ class ApmServerServiceTest(ServiceTest):
 
         # self instrumentation comes with profiling by default but can be disabled
         apm_server = ApmServer(
-            version="8.0.0", apm_server_self_instrument=True, apm_server_profile=False).render()["apm-server"]
+            version="8.0.0", apm_server_self_instrument=True, no_apm_server_profile=True).render()["apm-server"]
         self.assertIn("apm-server.instrumentation.enabled=true", apm_server["command"])
         self.assertFalse(
             any(e.startswith("apm-server.instrumentation.profiling") for e in apm_server["command"]),
@@ -781,7 +781,7 @@ class ApmServerServiceTest(ServiceTest):
 
         # need self instrumentation enabled to get profiling
         apm_server = ApmServer(
-            version="8.0.0", apm_server_self_instrument=False, apm_server_profile=True).render()["apm-server"]
+            version="8.0.0", apm_server_self_instrument=False, no_apm_server_profile=True).render()["apm-server"]
         self.assertNotIn("apm-server.instrumentation.enabled=true", apm_server["command"])
         self.assertNotIn("apm-server.instrumentation.profiling.cpu.enabled=true", apm_server["command"])
         self.assertNotIn("apm-server.instrumentation.profiling.heap.enabled=true", apm_server["command"])


### PR DESCRIPTION
## What does this PR do?

The wrong flag name was used when checking its value. This fixes it.

## Why is it important?

Agent devs might want to disable apm-server self-profiling to not have the profiling index filled with distracting data.

