### PR TITLE
Fix missing environment variable

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1092,7 +1092,7 @@ class Kibana(StackService, Service):
             if self.at_least_version("7.7"):
                 self.environment["XPACK_SECURITY_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
                 self.environment["XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
-            if self.at_least_version("7.8") and self.version_lower_than("7.13"):
+            if self.at_least_version("7.8"):
                 self.environment["XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST"] = urls[0]
                 self.environment["XPACK_FLEET_AGENTS_KIBANA_HOST"] = "{}://kibana:{}".format(
                     "https" if self.kibana_tls else "http", self.SERVICE_PORT)

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1018,6 +1018,8 @@ class LocalTest(unittest.TestCase):
                     XPACK_MONITORING_ENABLED: 'true',
                     XPACK_SECURITY_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
                     XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
+                    XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST: 'http://elasticsearch:9200',
+                    XPACK_FLEET_AGENTS_KIBANA_HOST: 'http://kibana:5601',
                     XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
                     XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'


### PR DESCRIPTION
## What does this PR do?

Uses a very important environment variable.

## Why is it important?

Without this patch: no data flows after running`scripts/compose.py start master --with-elastic-agent --apm-server-managed`, because apm-server has not the right connection to Elasticsearch.

This should fix it. It would be great if someone can replicate. Not sure why the removed condition was there in first place, so I might be breaking something else unintentionally... I couldn't find anything wrong with this, thou.


