### PR TITLE
Validate the pre-requirements

### DIFF
--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -3,6 +3,8 @@
 from __future__ import print_function
 
 import logging
+import os
+import subprocess
 import sys
 
 from modules.cli import LocalSetup
@@ -14,6 +16,14 @@ def main():
     setup = LocalSetup(sys.argv[1:])
     setup()
 
+def verify_if_docker_is_installed():
+    try:
+        subprocess.check_output(
+            'docker ps', stderr=open(os.devnull, 'w'), shell=True).decode('utf8').strip()
+    except subprocess.CalledProcessError:
+        print("Please start Docker before running the apm-integration-testing.")
+        sys.exit(1)
 
 if __name__ == '__main__':
+    verify_if_docker_is_installed()
     main()

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -16,6 +16,7 @@ def main():
     setup = LocalSetup(sys.argv[1:])
     setup()
 
+
 def verify_if_docker_is_installed():
     try:
         subprocess.check_output(
@@ -23,6 +24,7 @@ def verify_if_docker_is_installed():
     except subprocess.CalledProcessError:
         print("Please start Docker before running the apm-integration-testing.")
         sys.exit(1)
+
 
 if __name__ == '__main__':
     verify_if_docker_is_installed()


### PR DESCRIPTION
## What does this PR do?

Verify if docker is configured and enabled in the host machine, otherwise report with a nice error message.

## Why is it important?

Keep the requirements easy to track rather than a long stacktrace.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/1184


NOTE> rather than implementing a loop for waiting the service to be up and ready, let's keep it simple with fail fast, otherwise, how long the script should wait for the command to be ready?


### Test


```bash
➜  apm-integration-testing git:(feature/validate-docker-requirement) ✗ ./scripts/compose.py start master --with-opbeans-java 
Please start Docker before running the apm-integration-testing.
➜  apm-integration-testing git:(feature/validate-docker-requirement) ✗ echo $?
1
```