### PR TITLE
Fix dotnet concurrency tests

### DIFF
--- a/docker/dotnet/aspnetcore/Program.cs
+++ b/docker/dotnet/aspnetcore/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace TestAspNetCoreApp
 {
@@ -9,6 +10,11 @@ namespace TestAspNetCoreApp
 
 		public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
 			WebHost.CreateDefaultBuilder(args)
+				.ConfigureLogging(logger =>
+				{
+					logger.ClearProviders();
+					logger.AddConsole();
+				})
 				.UseStartup<Startup>();
 	}
 }

--- a/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
+++ b/docker/dotnet/aspnetcore/TestAspNetCoreApp.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.3" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.11.0" />
     </ItemGroup>
 
 </Project>

--- a/docker/dotnet/aspnetcore/appsettings.json
+++ b/docker/dotnet/aspnetcore/appsettings.json
@@ -7,7 +7,9 @@
   "AllowedHosts": "*",
   "ElasticApm":
     {
-      "LogLevel":  "Debug",
+      "CloudProvider": "none",
+      "DisableMetrics": "*",
+      "LogLevel": "Debug",
       "TransactionSampleRate": 1.0
     }
 }


### PR DESCRIPTION
## What does this PR do?

This commits fixes the dotnet concurrency tests by disabling metrics and cloud provider metadata discovery, through agent configuration.

The concurrency tests are failing an assertion on the count of expected spans, where the failure is typically a difference of one or two spans. What I believe is happening is that the volume of metrics produced within tests is flooding the payload queue such that when the application shuts down, there are spans remaining in the queue that do not end up getting sent to APM server.

The agent does not currently drain remaining items from the payload queue to send on shutdown, which is something to consider implementing in future to help with this issue.

## Why is it important?

The intermittent failing dotnet concurrency tests are causing unrelated PRs to fail

## Related issues
Closes https://github.com/elastic/apm-agent-dotnet/issues/1353
