### PR TITLE
fix: wait a little more for Kibana

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1171,7 +1171,7 @@ class Kibana(StackService, Service):
 
         content = dict(
             healthcheck=curl_healthcheck(
-                self.SERVICE_PORT, "kibana", path="/api/status", retries=20, https=self.kibana_tls),
+                self.SERVICE_PORT, "kibana", path="/api/status", retries=30, https=self.kibana_tls),
             depends_on=self.depends_on,
             environment=self.environment,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -761,7 +761,7 @@ class LocalTest(unittest.TestCase):
                 environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_HOST: 0.0.0.0, SERVER_NAME: kibana.example.org, XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co', XPACK_MONITORING_ENABLED: 'true'}
                 healthcheck:
                     interval: 10s
-                    retries: 20
+                    retries: 30
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana-x-pack:6.2.10-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=6.2.10]
@@ -863,7 +863,7 @@ class LocalTest(unittest.TestCase):
                 environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_HOST: 0.0.0.0, SERVER_NAME: kibana.example.org, XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co', XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
                 healthcheck:
                     interval: 10s
-                    retries: 20
+                    retries: 30
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana:6.3.10-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=6.3.10]
@@ -1026,7 +1026,7 @@ class LocalTest(unittest.TestCase):
                 }
                 healthcheck:
                     interval: 10s
-                    retries: 20
+                    retries: 30
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
                 image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=8.0.0]

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1278,7 +1278,7 @@ class KibanaServiceTest(ServiceTest):
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
                         interval: 10s
-                        retries: 20
+                        retries: 30
                     depends_on:
                         elasticsearch:
                           condition:
@@ -1310,7 +1310,7 @@ class KibanaServiceTest(ServiceTest):
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
                         interval: 10s
-                        retries: 20
+                        retries: 30
                     depends_on:
                         elasticsearch:
                           condition:


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* It increases the retries of the health check.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
We have hit test failures because Kibana do not start on time, there is no errors in logs so is is an issue related to the time we wait for Kibana.

