### PR TITLE
fix: remove EOL versions

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -8,5 +8,3 @@ APM_SERVER:
   - '7.8;--release'
   - '7.7;--release'
   - '7.6;--release'
-  - '7.5;--release'
-  - '7.4;--release'

--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -7,4 +7,3 @@ APM_SERVER:
   - '7.9;--release'
   - '7.8;--release'
   - '7.7;--release'
-  - '7.6;--release'


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* remove two versions that raise its EOL

![image](https://user-images.githubusercontent.com/5400788/126629902-1a90fa54-a016-4c7d-913a-fb6723c059af.png)

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

We no need to test them any longer. 

https://www.elastic.co/support/eol