### PR TITLE
feat: use terraform deployment

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -222,7 +222,7 @@ def withTestEnv(Closure body){
       "CONFIG_HOME=${env.WORKSPACE}",
       "VENV=${env.WORKSPACE}/.venv",
       "PATH=${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.VENV}/bin:${ecWs}/bin:${ecWs}/.ci/scripts:${env.PATH}",
-      "CLUSTER_CONFIG_FILE=${ecWs}/tests/environments/elastic_cloud.yml",
+      "CLUSTER_CONFIG_FILE=${ecWs}/tests/environments/elastic_cloud_tf_gcp.yml",
       "BUILD_NUMBER=${ params.destroy_mode ? params.build_num_to_destroy : env.BUILD_NUMBER}"
     ]){
       withVaultEnv(){


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes to use terraform deployments.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Terraform ec provider is the new way to provision clusters, it improves the reliability and the speed of the deploys.
