### PR TITLE
fix packetbeat config

### DIFF
--- a/scripts/modules/beats.py
+++ b/scripts/modules/beats.py
@@ -249,7 +249,7 @@ class Packetbeat(BeatMixin, StackService, Service):
             environment=self.environment,
             labels=None,
             user="root",
-            privileged="true",
+            privileged=True,
             cap_add=["NET_ADMIN", "NET_RAW"],
             network_mode="service:apm-server",
             healthcheck=curl_healthcheck("5066", "localhost", path="/?pretty"),

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1589,7 +1589,7 @@ class PacketbeatServiceTest(ServiceTest):
                         - /var/run/docker.sock:/var/run/docker.sock
                         - ./scripts/tls/ca/ca.crt:/usr/share/beats/config/certs/stack-ca.crt
                     network_mode: 'service:apm-server'
-                    privileged: 'true'
+                    privileged: true
                     cap_add: ['NET_ADMIN', 'NET_RAW']""")  # noqa: 501
         )
 


### PR DESCRIPTION
Manifests when using `--all`