### PR TITLE
Support Enterprise Search in Kibana

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1135,7 +1135,6 @@ class Kibana(StackService, Service):
         if self.at_least_version("8.0"):
             self.environment["ENTERPRISESEARCH_HOST"] = "http://enterprise-search:" + str(EnterpriseSearch.SERVICE_PORT)
 
-
     @classmethod
     def add_arguments(cls, parser):
         super(Kibana, cls).add_arguments(parser)

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1028,7 +1028,10 @@ class EnterpriseSearch(StackService, Service):
         self.environment = {
             "allow_es_settings_modification": "true",
             "ent_search.external_url": "http://localhost:{}".format(self.port),
+            "kibana.external_url": "http://localhost:5601",
             "secret_management.encryption_keys": '[4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09]',
+            "apm.enabled": "true",
+            "apm.server_url": options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_ACTIVE": "true",
             "ELASTIC_APM_SERVER_URL": options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ENT_SEARCH_DEFAULT_PASSWORD": options.get("enterprise_search_password", "changeme")
@@ -1129,6 +1132,9 @@ class Kibana(StackService, Service):
                 self.environment["XPACK_FLEET_REGISTRYURL"] = url
             if use_local_package_registry:
                 self.depends_on["package-registry"] = {"condition": "service_healthy"}
+        if self.at_least_version("8.0"):
+            self.environment["ENTERPRISESEARCH_HOST"] = "http://enterprise-search:" + str(EnterpriseSearch.SERVICE_PORT)
+
 
     @classmethod
     def add_arguments(cls, parser):

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -1017,6 +1017,7 @@ class LocalTest(unittest.TestCase):
                     ELASTICSEARCH_PASSWORD: changeme,
                     ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200',
                     ELASTICSEARCH_USERNAME: kibana_system_user,
+                    ENTERPRISESEARCH_HOST: 'http://enterprise-search:3002',
                     SERVER_HOST: 0.0.0.0,
                     SERVER_NAME: kibana.example.org,
                     STATUS_ALLOWANONYMOUS: 'true',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1125,6 +1125,15 @@ class EnterpriseSearchServiceTest(ServiceTest):
             entsearch["image"], "docker.elastic.co/enterprise-search/enterprise-search:7.12.20"
         )
 
+    def test_8_0_0(self):
+        entsearch = EnterpriseSearch(version="8.0.0").render()["enterprise-search"]
+        self.assertEqual(
+            entsearch["image"], "docker.elastic.co/enterprise-search/enterprise-search:8.0.0-SNAPSHOT"
+        )
+        self.assertDictContainsSubset({"apm.enabled": "true", "kibana.external_url": "http://localhost:5601"}, entsearch["environment"])
+        kibana = Kibana(version="8.0.0", with_enterprise_search=True).render()["kibana"]
+        self.assertDictContainsSubset({"ENTERPRISESEARCH_HOST": "http://enterprise-search:3002"}, kibana["environment"])
+
 
 class FilebeatServiceTest(ServiceTest):
     def test_filebeat_pre_6_1(self):


### PR DESCRIPTION
## What does this PR do?

Allows Enterprise Search to start again.

## Why is it important?

For running enterprise search, particularly for testing the new JRuby JVM metric colllection.


<img width="1390" alt="image" src="https://user-images.githubusercontent.com/83483/129404571-4dd35426-b5a2-4d92-8d22-3b62a0e2a068.png">
