### PR TITLE
Healthcheck timeouts

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1211,7 +1211,7 @@ class Kibana(StackService, Service):
 
         content = dict(
             healthcheck=curl_healthcheck(
-                self.SERVICE_PORT, "kibana", path="/api/status", retries=30, https=self.kibana_tls),
+                self.SERVICE_PORT, "kibana", path="/api/status", retries=30, https=self.kibana_tls, start_period="10s"),
             depends_on=self.depends_on,
             environment=self.environment,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],

--- a/scripts/modules/helpers.py
+++ b/scripts/modules/helpers.py
@@ -84,6 +84,7 @@ def load_images(urls, cache_dir):
 
 DEFAULT_HEALTHCHECK_INTERVAL = "10s"
 DEFAULT_HEALTHCHECK_RETRIES = 12
+DEFAULT_HEALTHCHECK_TIMEOUT = "5s"
 
 
 def _print_done(service_name):
@@ -154,20 +155,30 @@ def _set_slowlog_json(password):
                 break
 
 
-def curl_healthcheck(port, host="localhost", path="/healthcheck",
-                     interval=DEFAULT_HEALTHCHECK_INTERVAL, retries=DEFAULT_HEALTHCHECK_RETRIES, https=False):
-
+def curl_healthcheck(
+    port,
+    host="localhost",
+    path="/healthcheck",
+    interval=DEFAULT_HEALTHCHECK_INTERVAL,
+    retries=DEFAULT_HEALTHCHECK_RETRIES,
+    https=False,
+    timeout=DEFAULT_HEALTHCHECK_TIMEOUT,
+    start_period=None,
+):
     protocol = 'http'
     if https:
         protocol = 'https'
-
-    return {
+    ret = {
         "interval": interval,
         "retries": retries,
+        "timeout": timeout,
         "test": ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent",
                  "--output", "/dev/null",
                  "{}://{}:{}{}".format(protocol, host, port, path)]
     }
+    if start_period:
+        ret['start_period'] = start_period
+    return ret
 
 
 def wget_healthcheck(port, host="localhost", path="/healthcheck",

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -88,6 +88,7 @@ class OpbeansServiceTest(ServiceTest):
                           service_healthy
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-dotnet:3000/"]
+                        timeout: 5s
                         interval: 10s
                         retries: 36""")
         )
@@ -225,6 +226,7 @@ class OpbeansServiceTest(ServiceTest):
                           service_healthy
                     healthcheck:
                       test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-java:3000/"]
+                      timeout: 5s
                       interval: 10s
                       retries: 36""")  # noqa: 501
         )
@@ -378,6 +380,7 @@ class OpbeansServiceTest(ServiceTest):
                             service_healthy
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
+                        timeout: 5s
                         interval: 10s
                         retries: 12
             """)  # noqa: 501
@@ -511,6 +514,7 @@ class OpbeansServiceTest(ServiceTest):
                             service_healthy
                      healthcheck:
                          test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://localhost:9222/"]
+                         timeout: 5s
                          interval: 10s
                          retries: 12""")  # noqa: 501
         )
@@ -733,6 +737,7 @@ class LocalTest(unittest.TestCase):
                     interval: 10s
                     retries: 12
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
+                    timeout: 5s
                 image: docker.elastic.co/apm/apm-server:6.2.10-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=6.2.10]
                 logging:
@@ -765,7 +770,9 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 10s
                     retries: 30
+                    start_period: 10s
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
+                    timeout: 5s
                 image: docker.elastic.co/kibana/kibana-x-pack:6.2.10-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=6.2.10]
                 logging:
@@ -833,6 +840,7 @@ class LocalTest(unittest.TestCase):
                     interval: 10s
                     retries: 12
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
+                    timeout: 5s
                 image: docker.elastic.co/apm/apm-server:6.3.10-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=6.3.10]
                 logging:
@@ -869,7 +877,9 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 10s
                     retries: 30
+                    start_period: 10s
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
+                    timeout: 5s
                 image: docker.elastic.co/kibana/kibana:6.3.10-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=6.3.10]
                 logging:
@@ -956,6 +966,7 @@ class LocalTest(unittest.TestCase):
                     interval: 10s
                     retries: 12
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://localhost:8200/']
+                    timeout: 5s
                 image: docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=8.0.0]
                 logging:
@@ -1035,7 +1046,9 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 10s
                     retries: 30
+                    start_period: 10s
                     test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
+                    timeout: 5s
                 image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=8.0.0]
                 logging:

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -47,6 +47,7 @@ class AgentServiceTest(ServiceTest):
                         interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://gonethttpapp:8080/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8080:8080
             """)  # noqa: 501
@@ -104,6 +105,7 @@ class AgentServiceTest(ServiceTest):
                         interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://expressapp:8010/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8010:8010
             """)  # noqa: 501
@@ -156,6 +158,7 @@ class AgentServiceTest(ServiceTest):
                         interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://djangoapp:8003/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8003:8003
             """)  # noqa: 501
@@ -204,6 +207,7 @@ class AgentServiceTest(ServiceTest):
                         interval: 10s
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://flaskapp:8001/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8001:8001
             """)  # noqa: 501
@@ -264,6 +268,7 @@ class AgentServiceTest(ServiceTest):
                         interval: 10s
                         retries: 60
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://railsapp:8020/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8020:8020
             """)  # noqa: 501
@@ -334,6 +339,7 @@ class AgentServiceTest(ServiceTest):
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output",
                         "/dev/null", "http://javaspring:8090/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8090:8090
             """)
@@ -406,6 +412,7 @@ class AgentServiceTest(ServiceTest):
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output",
                         "/dev/null", "http://dotnetapp:8100/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8100:8100
             """)
@@ -468,6 +475,7 @@ class AgentServiceTest(ServiceTest):
                         retries: 12
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output",
                         "/dev/null", "http://phpapacheapp:80/healthcheck"]
+                        timeout: 5s
                     ports:
                         - 127.0.0.1:8030:80
             """)
@@ -977,6 +985,7 @@ class PackageRegistryServiceTest(ServiceTest):
                   'environment': {},
                   'healthcheck': {'interval': '5s',
                                   'retries': 10,
+                                  'timeout': '5s',
                                   'test': ['CMD',
                                            'curl',
                                            '--write-out',
@@ -1002,6 +1011,7 @@ class PackageRegistryServiceTest(ServiceTest):
                   'environment': {},
                   'healthcheck': {'interval': '5s',
                                   'retries': 10,
+                                  'timeout': '5s',
                                   'test': ['CMD',
                                            'curl',
                                            '--write-out',
@@ -1162,6 +1172,7 @@ class FilebeatServiceTest(ServiceTest):
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://localhost:5066/?pretty"]
                         interval: 10s
                         retries: 12
+                        timeout: 5s
                     volumes:
                         - ./docker/filebeat/filebeat.simple.yml:/usr/share/filebeat/filebeat.yml
                         - /var/lib/docker/containers:/var/lib/docker/containers
@@ -1195,6 +1206,7 @@ class FilebeatServiceTest(ServiceTest):
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://localhost:5066/?pretty"]
                         interval: 10s
                         retries: 12
+                        timeout: 5s
                     volumes:
                         - ./docker/filebeat/filebeat.6.x-compat.yml:/usr/share/filebeat/filebeat.yml
                         - /var/lib/docker/containers:/var/lib/docker/containers
@@ -1288,6 +1300,8 @@ class KibanaServiceTest(ServiceTest):
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
                         interval: 10s
                         retries: 30
+                        timeout: 5s
+                        start_period: 10s
                     depends_on:
                         elasticsearch:
                           condition:
@@ -1318,8 +1332,10 @@ class KibanaServiceTest(ServiceTest):
                             max-file: '5'
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://kibana:5601/api/status"]
+                        timeout: 5s
                         interval: 10s
                         retries: 30
+                        start_period: 10s
                     depends_on:
                         elasticsearch:
                           condition:
@@ -1439,6 +1455,7 @@ class LogstashServiceTest(ServiceTest):
             environment: {ELASTICSEARCH_URL: 'http://elasticsearch:9200'}
             healthcheck:
                 test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://logstash:9600/"]
+                timeout: 5s
                 interval: 10s
                 retries: 12
             image: docker.elastic.co/logstash/logstash:6.3.0
@@ -1510,6 +1527,7 @@ class MetricbeatServiceTest(ServiceTest):
                             service_healthy
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://localhost:5066/?pretty"]
+                        timeout: 5s
                         interval: 10s
                         retries: 12
                     volumes:
@@ -1595,6 +1613,7 @@ class PacketbeatServiceTest(ServiceTest):
                             service_healthy
                     healthcheck:
                         test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "-k", "--fail", "--silent", "--output", "/dev/null", "http://localhost:5066/?pretty"]
+                        timeout: 5s
                         interval: 10s
                         retries: 12
                     volumes:


### PR DESCRIPTION
## What does this PR do?

This is an attempt to possibly improve the situation with the recent round of APM Integration Test failures.

I have tried as many ways as I can think of to reproduce the errors, which [seem to be related to the health-check for the Kibana container failing on start](https://apm-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/apm-integration-test-downstream/branches/master/runs/10415/nodes/96/steps/399/log/?start=0). I've run it locally, run it on the same type of Jenkins worker instance, and at no point have I been able to reproduce the 5-minute timeouts that we've been seeing.

We've also reported this problem to Kibana, and [they also cannot seem to replicate it](https://github.com/elastic/kibana/issues/107300).

The only theory I really have at this point is that perhaps there is something specific in our health-check that is causing the issue, like perhaps cURL is getting the socket half-open and the health-check is just hanging.

This PR introduces a few means of trying to prevent that case from happening:

* Default timeout of 5s for all health-check calls
* A 10s period at the top of the Kibana health-check to wait for Kibana to become operational

## Why is it important?

Trying to get our ITs back online.


