### PR TITLE
More Enterprise Search Kibana Support

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1044,6 +1044,7 @@ class EnterpriseSearch(StackService, Service):
         kibana_scheme = "https" if self.kibana_tls else "http"
         self.environment.update({
             "kibana.external_url": kibana_scheme + "://localhost:5601",
+            "kibana.host": kibana_scheme + "://kibana:5601",
         })
 
         default_creds = {"username": "admin", "password": "changeme"}

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1028,7 +1028,6 @@ class EnterpriseSearch(StackService, Service):
         self.environment = {
             "allow_es_settings_modification": "true",
             "ent_search.external_url": "http://localhost:{}".format(self.port),
-            "kibana.external_url": "http://localhost:5601",
             "secret_management.encryption_keys": '[4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09]',
             "apm.enabled": "true",
             "apm.server_url": options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
@@ -1042,6 +1041,10 @@ class EnterpriseSearch(StackService, Service):
         es_urls = self.options.get("enterprise_search_elasticsearch_urls") or \
             [self.default_elasticsearch_hosts(self.es_tls)]
         self.environment["elasticsearch.host"] = es_urls[0]
+        kibana_scheme = "https" if self.kibana_tls else "http"
+        self.environment.update({
+            "kibana.external_url": kibana_scheme + "://localhost:5601",
+        })
 
         default_creds = {"username": "admin", "password": "changeme"}
         for cfg in ("username", "password"):

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -1140,7 +1140,7 @@ class EnterpriseSearchServiceTest(ServiceTest):
         self.assertEqual(
             entsearch["image"], "docker.elastic.co/enterprise-search/enterprise-search:8.0.0-SNAPSHOT"
         )
-        self.assertDictContainsSubset({"apm.enabled": "true", "kibana.external_url": "http://localhost:5601"}, entsearch["environment"])
+        self.assertDictContainsSubset({"apm.enabled": "true", "kibana.external_url": "http://localhost:5601", "kibana.host": "http://kibana:5601"}, entsearch["environment"])
         kibana = Kibana(version="8.0.0", with_enterprise_search=True).render()["kibana"]
         self.assertDictContainsSubset({"ENTERPRISESEARCH_HOST": "http://enterprise-search:3002"}, kibana["environment"])
 


### PR DESCRIPTION
## What does this PR do?

Again keeps up with required enterprise search settings, `kibana.url` in this case per https://github.com/elastic/ent-search/pull/4242.  Follow up to #1225.

## Why is it important?

allows enterprise search to start successfully
