### PR TITLE
add --apm-server-enable-data-streams option

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -247,6 +247,9 @@ class ApmServer(StackService, Service):
                     ("output.file.path", self.options.get("apm_server_output_file", os.devnull)),
                 ])
 
+        if self.options.get("apm_server_enable_data_streams"):
+            self.apm_server_command_args.append(("apm-server.data_streams.enabled", "true"))
+
         for opt in options.get("apm_server_opt", []):
             self.apm_server_command_args.append(opt.split("=", 1))
 
@@ -386,6 +389,11 @@ class ApmServer(StackService, Service):
             dest="apm_server_jaeger",
             action="store_false",
             help="make apm-server act as a Jaeger collector (HTTP and gRPC).",
+        )
+        parser.add_argument(
+            "--apm-server-enable-data-streams",
+            action="store_true",
+            help='enable writing to data streams'
         )
         parser.add_argument(
             '--apm-server-enable-tls',

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import json
 import os
-import pytest
 import unittest
 
 import yaml

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import json
 import os
+import pytest
 import unittest
 
 import yaml
@@ -916,6 +917,10 @@ class ApmServerServiceTest(ServiceTest):
         apm_server = ApmServer(version="8.0", apm_server_pipeline_path="foo").render()["apm-server"]
         self.assertIn("foo:/usr/share/apm-server/ingest/pipeline/definition.json", apm_server["volumes"])
         self.assertIn("apm-server.register.ingest.pipeline.overwrite=true", apm_server["command"])
+
+    def test_data_streams(self):
+        apm_server = ApmServer(version="7.16.0", apm_server_enable_data_streams=True).render()["apm-server"]
+        self.assertIn("apm-server.data_streams.enabled=true", apm_server["command"])
 
     def test_debug(self):
         apm_server = ApmServer(version="6.8.0", apm_server_enable_debug=True).render()["apm-server"]


### PR DESCRIPTION
## What does this PR do?

adds `--apm-server-enable-data-streams` option for instructing APM Server to write to data streams.  This is valid in 7.16 and 8.0 (and maybe 7.15? it's not important to prevent it from being set in earlier versions)

## Related issues
related to https://github.com/elastic/apm-server/issues/5949 - apm-server remains unhealthy until the integration is installed, not ideal but not blocked on that.