### PR TITLE
Fix super() calls for dyno proxies

### DIFF
--- a/scripts/modules/proxy.py
+++ b/scripts/modules/proxy.py
@@ -12,8 +12,8 @@ class Dyno(Service):
     SERVICE_PORT = 9999
     opbeans_side_car = False
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **options):
+        super(Dyno, self).__init__(**options)
 
     def _content(self):
         return dict(
@@ -37,9 +37,9 @@ class Toxi(Service):
     SERVICE_PORT = 8474
     opbeans_side_car = False
 
-    def __init__(self):
+    def __init__(self, **options):
         self.service_offset = 10000
-        super().__init__()
+        super(Toxi, self).__init__(**options)
         self.generated_ports = [self.publish_port(self.port, self.SERVICE_PORT, expose=True)]
 
     def _content(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the following stacktrace on newer Pythons:

```
./scripts/compose.py start master --dyno --with-opbeans-python --no-kibana
Traceback (most recent call last):
  File "./scripts/compose.py", line 31, in <module>
    main()
  File "./scripts/compose.py", line 17, in main
    setup()
  File "/Users/casperhubertz/dev/elastic/apm-integration-testing/scripts/modules/cli.py", line 204, in __call__
    self.args.func()
  File "/Users/casperhubertz/dev/elastic/apm-integration-testing/scripts/modules/cli.py", line 586, in start_handler
    self.build_start_handler("start")
  File "/Users/casperhubertz/dev/elastic/apm-integration-testing/scripts/modules/cli.py", line 620, in build_start_handler
    toxi = Toxi()
  File "/Users/casperhubertz/dev/elastic/apm-integration-testing/scripts/modules/proxy.py", line 42, in __init__
    super().__init__()
TypeError: super() takes at least 1 argument (0 given)
```

## Why is it important?

Fixes start up issue

## Related issues
No issue but reported by @formgeist in Slack