### PR TITLE
fix apm-server when data_streams enabled

### DIFF
--- a/docker/elasticsearch/roles.yml
+++ b/docker/elasticsearch/roles.yml
@@ -2,7 +2,7 @@
 apm_server:
   cluster: ['manage_ilm', 'manage_security', 'manage_api_key']
   indices:
-    - names: ['apm-*']
+    - names: ['apm-*', 'logs-apm*', 'metrics-apm*', 'traces-apm*']
       privileges: ['write', 'create_index', 'manage', 'manage_ilm']
   applications:
     - application: 'apm'


### PR DESCRIPTION
## What does this PR do?

see https://github.com/elastic/apm-integration-testing/pull/1229#issuecomment-906747371, in summary this changes:

* configure apm-server to use a superuser when communicating to kibana (used for checking integration installation status)
* use the integration pipeline id instead of apm
* allows writes to data stream patterns

## Related issues
This relies on a fix to ES that has not been published in a snapshot yet.  see https://github.com/elastic/apm-integration-testing/issues/1232#issuecomment-906714862
