### PR TITLE
Enable health verbose log

### DIFF
--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -5,3 +5,4 @@ monitoring.ui.container.elasticsearch.enabled: true
 
 elastic.apm.active: true
 elastic.apm.serverUrl: "http://apm-server:8200"
+xpack.task_manager.monitored_stats_health_verbose_log.enabled: true

--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -6,3 +6,9 @@ monitoring.ui.container.elasticsearch.enabled: true
 elastic.apm.active: true
 elastic.apm.serverUrl: "http://apm-server:8200"
 xpack.task_manager.monitored_stats_health_verbose_log.enabled: true
+
+logging:
+  loggers:
+      - context: plugins.taskManager
+        appenders: [console]
+        level: debug


### PR DESCRIPTION
## What does this PR do?

Enables more verbose logging in Kibana for possible performance issues
## Why is it important?

Trying to troubleshoot https://github.com/elastic/apm-integration-testing/issues/1188

I was able to reproduce this error once locally and when I did, I saw the following:

```
localtesting_8.0.0_kibana | {"type":"log","@timestamp":"2021-08-19T09:57:29+00:00","tags":["warning","plugins","taskManager"],"pid":1198,"message":"Detected potential performance issue with Task Manager. Set 'xpack.task_manager.monitored_stats_health_verbose_log.enabled: true' in your Kibana.yml$
localtesting_8.0.0_kibana | {"type":"log","@timestamp":"2021-08-19T09:57:30+00:00","tags":["info","status"],"pid":1198,"message":"Kibana is now unavailable (was available)"}
localtesting_8.0.0_kibana | {"type":"log","@timestamp":"2021-08-19T09:57:35+00:00","tags":["info","status"],"pid":1198,"message":"Kibana is now available (was unavailable)"}
localtesting_8.0.0_kibana | {"type":"log","@timestamp":"2021-08-19T09:59:59+00:00","tags":["info","plugins","security","routes"],"pid":1198,"message":"Logging in with provider \"basic\" (basic)"}
```

This enables logging as the error suggests.
