### PR TITLE
ci: force a unique ephemeral worker

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -187,7 +187,7 @@ class IntegrationTestingParallelTaskGenerator extends DefaultParallelTaskGenerat
   */
   public Closure generateStep(x, y){
     return {
-      steps.node('linux && immutable'){
+      steps.withNode(labels: 'linux && immutable', forceWorker: true){
         def env = ["APM_SERVER_BRANCH=${y}",
           "${steps.agentMapping.envVar(tag)}=${x}",
           "REUSE_CONTAINERS=true",


### PR DESCRIPTION
## What does this PR do?

Use ephemeral workers

## Why is it important?

Avoid to reuse any existing ephemeral worker
