### PR TITLE
List images

### DIFF
--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -223,11 +223,11 @@ def runScript(Map params = [:]){
     deleteDir()
     unstash "source"
     filebeat(output: "docker-${dockerLogs}.log", archiveOnlyOnFail: true){
-      sh 'docker ps -a'
+      sh 'docker ps -a && docker images -a'
       dir("${BASE_DIR}"){
         withEnv(env){
           sh(label: "Testing ${agentType}", script: ".ci/scripts/${agentType}.sh")
-          sh 'docker ps -a'
+          sh 'docker ps -a && docker images -a'
         }
       }
     }

--- a/.ci/integrationTestDownstream.groovy
+++ b/.ci/integrationTestDownstream.groovy
@@ -223,11 +223,11 @@ def runScript(Map params = [:]){
     deleteDir()
     unstash "source"
     filebeat(output: "docker-${dockerLogs}.log", archiveOnlyOnFail: true){
-      sh 'docker ps -a && docker images -a'
+      sh 'docker ps -a && docker images -a && docker volume ls && docker network ls'
       dir("${BASE_DIR}"){
         withEnv(env){
           sh(label: "Testing ${agentType}", script: ".ci/scripts/${agentType}.sh")
-          sh 'docker ps -a && docker images -a'
+          sh 'docker ps -a && docker images -a && docker volume ls && docker network ls'
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Adds a `docker images -a`, `docker volume ls` and `docker network ls` before and after test runs

## Why is it important?

We are seeing odd behavior that makes me think that these CI workers are either being re-used very often or that they have pre-populated Docker caches. This will just help us debug this issue if it occurs. 

## Related issues
Refs https://github.com/elastic/apm-integration-testing/issues/1188