### PR TITLE
Bring Node to 12.x for 7.x branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7
 
 #Install elasticdump
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get -yqq update \
     && apt-get install -yqq nodejs \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## What does this PR do?

Fixes [errors in 7.x branch](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-test-downstream/detail/7.x/7774/pipeline):

```
[2021-08-31T03:34:40.121Z] docker build --pull -t apm-integration-testing .

[2021-08-31T03:34:40.121Z] Sending build context to Docker daemon  1.272MB

[2021-08-31T03:34:40.121Z] Step 1/8 : FROM python:3.7

[2021-08-31T03:34:40.692Z] 3.7: Pulling from library/python

[2021-08-31T03:34:40.692Z] Digest: sha256:6790dfb201d2fa06b0935ea0bfa1227d2240280af56d0fe08772b11eb31402b5

[2021-08-31T03:34:40.692Z] Status: Image is up to date for python:3.7

[2021-08-31T03:34:40.692Z]  ---> af86b73e120c

[2021-08-31T03:34:40.692Z] Step 2/8 : RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -     && apt-get -yqq update     && apt-get install -yqq nodejs     && rm -rf /var/lib/apt/lists/*     && npm install elasticdump -g

[2021-08-31T03:34:40.692Z]  ---> Running in 6cfa314891d1

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z] ================================================================================

[2021-08-31T03:34:41.263Z] ================================================================================

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]                               DEPRECATION WARNING                            

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]   Node.js 11.x is no longer actively supported!

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]   You will not receive security or critical stability updates for this version.

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]   You should migrate to a supported version of Node.js as soon as possible.

[2021-08-31T03:34:41.263Z]   Use the installation script that corresponds to the version of Node.js you

[2021-08-31T03:34:41.263Z]   wish to install. e.g.

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]    * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"

[2021-08-31T03:34:41.263Z]    * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)

[2021-08-31T03:34:41.263Z]    * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]   Please see https://github.com/nodejs/Release for details about which

[2021-08-31T03:34:41.263Z]   version may be appropriate for you.

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z]   The NodeSource Node.js distributions repository contains

[2021-08-31T03:34:41.263Z]   information both about supported versions of Node.js and supported Linux

[2021-08-31T03:34:41.263Z]   distributions. To learn more about usage, see the repository:

[2021-08-31T03:34:41.263Z]     https://github.com/nodesource/distributions

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z] ================================================================================

[2021-08-31T03:34:41.263Z] ================================================================================

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:34:41.263Z] Continuing in 20 seconds ...

[2021-08-31T03:34:41.263Z] 

[2021-08-31T03:35:03.289Z] 

[2021-08-31T03:35:03.289Z] ## Installing the NodeSource Node.js 11.x repo...

[2021-08-31T03:35:03.289Z] 

[2021-08-31T03:35:03.289Z] 

[2021-08-31T03:35:03.289Z] ## Populating apt-get cache...

[2021-08-31T03:35:03.289Z] 

[2021-08-31T03:35:03.289Z] + apt-get update

[2021-08-31T03:35:03.289Z] Get:1 http://deb.debian.org/debian bullseye InRelease [113 kB]

[2021-08-31T03:35:03.289Z] Get:2 http://security.debian.org/debian-security bullseye-security InRelease [44.1 kB]

[2021-08-31T03:35:03.289Z] Get:3 http://deb.debian.org/debian bullseye-updates InRelease [36.8 kB]

[2021-08-31T03:35:03.289Z] Get:4 http://security.debian.org/debian-security bullseye-security/main amd64 Packages [28.2 kB]

[2021-08-31T03:35:03.289Z] Get:5 http://deb.debian.org/debian bullseye/main amd64 Packages [8178 kB]

[2021-08-31T03:35:03.289Z] Fetched 8399 kB in 2s (4489 kB/s)

[2021-08-31T03:35:03.859Z] Reading package lists...

[2021-08-31T03:35:03.859Z] 

[2021-08-31T03:35:03.859Z] ## Installing packages required for setup: lsb-release...

[2021-08-31T03:35:03.859Z] 

[2021-08-31T03:35:03.859Z] + apt-get install -y lsb-release > /dev/null 2>&1

[2021-08-31T03:35:05.776Z] 

[2021-08-31T03:35:05.776Z] ## Confirming "bullseye" is supported...

[2021-08-31T03:35:05.776Z] 

[2021-08-31T03:35:05.776Z] + curl -sLf -o /dev/null 'https://deb.nodesource.com/node_11.x/dists/bullseye/Release'

[2021-08-31T03:35:05.776Z] 

[2021-08-31T03:35:05.776Z] ## Your distribution, identified as "bullseye", is not currently supported, please contact NodeSource at https://github.com/nodesource/distributions/issues if you think this is incorrect or would like your distribution to be considered for support

[2021-08-31T03:35:05.776Z] 

[2021-08-31T03:35:06.036Z] The command '/bin/sh -c curl -sL https://deb.nodesource.com/setup_11.x | bash -     && apt-get -yqq update     && apt-get install -yqq nodejs     && rm -rf /var/lib/apt/lists/*     && npm install elasticdump -g' returned a non-zero code: 1

```

Tested this locally on a 7.x branch and it appears to resolve the issue.

## Why is it important?

No 7.x testing until this is resolved.


