### PR TITLE
Start PHP/Python tests with --no-kibana

### DIFF
--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -46,6 +46,7 @@ function prepareAndRunAll() {
     --no-xpack-secure \
     --apm-server-enable-tls \
     --no-verify-server-cert  \
+    --no-kibana \
     --apm-server-secret-token=${ELASTIC_APM_SECRET_TOKEN} \
     --apm-server-url=${APM_SERVER_URL} \
     --apm-log-level=debug"

--- a/.ci/scripts/php.sh
+++ b/.ci/scripts/php.sh
@@ -3,7 +3,7 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 . "${srcdir}/common.sh"
 
 if [ -n "${APM_AGENT_PHP_VERSION}" ]; then
@@ -19,6 +19,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-php-apache \
   --apm-server-agent-config-poll=1s \
   --force-build \
+  --no-kibana \
   --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-php docker-test-agent-php

--- a/.ci/scripts/php.sh
+++ b/.ci/scripts/php.sh
@@ -3,7 +3,7 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 . "${srcdir}/common.sh"
 
 if [ -n "${APM_AGENT_PHP_VERSION}" ]; then

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -3,7 +3,7 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 . "${srcdir}/common.sh"
 
 if [ -n "${APM_AGENT_PYTHON_VERSION}" ]; then
@@ -22,6 +22,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-python-flask \
   --apm-server-agent-config-poll=1s \
   --force-build \
+  --no-kibana \
   --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -3,7 +3,7 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 . "${srcdir}/common.sh"
 
 if [ -n "${APM_AGENT_PYTHON_VERSION}" ]; then


### PR DESCRIPTION
## What does this PR do?

Resolves failures in the master branch.

No other test suites use Kibana and in inspecting these test suites, neither do Python or PHP. I ran the test suites manually both with and without the the flags in question and the results were the same. Additionally, I looked over the tests themselves and didn't see anything jump out at me suggesting that Kibana would be required to run these tests in CI.

## Why is it important?

Resolves failures in master branch and also slightly reduces the load we put on CI workers. 

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/1188
