### PR TITLE
Skip RUM tests in 6.x branch

### DIFF
--- a/tests/agent/test_rum.py
+++ b/tests/agent/test_rum.py
@@ -1,8 +1,10 @@
 from tests.endpoint import Endpoint
 from tests import utils
+from pytest import skip
+import pytest
 import requests
 
-
+@pytest.mark.skip(reason="Versions below 7.x not supported by this agent")
 def test_rum(rum):
     elasticsearch = rum.apm_server.elasticsearch
     elasticsearch.clean()


### PR DESCRIPTION
## What does this PR do?

This skips RUM tests in the 6.x branch because they are not supported. [Suggested by RUM agent team](https://github.com/elastic/apm-agent-rum-js/issues/1063#issuecomment-889610758).

## Why is it important?

Fixes 6.x branch tests. 


