### PR TITLE
No Kibana for opbeans-app

### DIFF
--- a/.ci/scripts/opbeans-app.sh
+++ b/.ci/scripts/opbeans-app.sh
@@ -3,7 +3,7 @@
 
 srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "${srcdir}/common.sh"
 
 AGENT=$1
@@ -15,6 +15,7 @@ DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-opbeans-${OPBEANS_APP} \
   --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
+  --no-kibana \
   --apm-server-agent-config-poll=1s \
   --force-build --no-xpack-secure"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}


### PR DESCRIPTION
## What does this PR do?
We shouldn't need Kibana running.

## Why is it important?

Fixes failing tests and shortens test time.

## Related issues
Refs https://github.com/elastic/apm-integration-testing/issues/1188
