### PR TITLE
Wait time for services to settle in EC

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -88,6 +88,11 @@ pipeline {
                   stash allowEmpty: true, includes: "${EC_DIR}/ansible/build/config_secrets.yml", name: "secrets-${getElasticStackVersion()}"
                 }
               }
+              stage("Waiting for services to settle") {
+                  steps {
+                      sleep 60
+                  }
+              }
               stage("Test Go") {
                 steps {
                   runTest('go')


### PR DESCRIPTION
## What does this PR do?

Inserts a 60s wait time prior to starting tests as discussed with @axw and @kuisathaverat 

## Why is it important?

Trying to see if there might be an issue with EC wherein services aren't fully ready after they report themselves as being available.


