### PR TITLE
Increase time from 60s -> 300s for cloud services to settle

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -90,7 +90,7 @@ pipeline {
               }
               stage("Waiting for services to settle") {
                   steps {
-                      sleep 60
+                      sleep 300
                   }
               }
               stage("Test Go") {


### PR DESCRIPTION
## What does this PR do?

Increases the wait time from 60s to 300s for the APM Integration test which run on Elastic Cloud.

## Why is it important?

Requested by @axw as a part of the investigative process for [the failing cloud tests](https://apm-ci.elastic.co/job/apm-it-ec/job/master/).

## Related issues
Refs https://github.com/elastic/apm-integration-testing/pull/1247
