### PR TITLE
Add backport label for automating the backport

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,14 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
+  - name: add backport label
+    conditions:
+      - merged
+      - base=master
+    actions:
+      label:
+        add:
+          - backport
   - name: backport patches to 7.x branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Add the label backport once the original PR was merged 

## Why is it important?

Avoid forgetting the backport to 7.x

