### PR TITLE
do not set apm server es pipeline with data streams enabled

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -221,11 +221,10 @@ class ApmServer(StackService, Service):
             self.apm_server_command_args.extend([
                 ("output.elasticsearch.enabled", "true"),
             ])
-            if options.get("apm_server_enable_pipeline", True) and self.at_least_version("6.5"):
-                if self.enable_data_streams:
-                    # TODO(gr): make it configurable if not aligning with stack
-                    pipeline_name = "traces-apm-0.3.0"
-                elif self.at_least_version("7.2"):
+            # pipeline is defined in the data stream settings, don't set a pipeline in that case, no overrides
+            if options.get("apm_server_enable_pipeline", True) and self.at_least_version("6.5") and \
+                    not self.enable_data_streams:
+                if self.at_least_version("7.2"):
                     pipeline_name = "apm"
                 else:
                     pipeline_name = "apm_user_agent"
@@ -234,14 +233,13 @@ class ApmServer(StackService, Service):
                     ("output.elasticsearch.pipelines", "[{pipeline: '%s'}]" % pipeline_name)
                 )
 
-                if not self.enable_data_streams:
-                    self.apm_server_command_args.extend([
-                        ("apm-server.register.ingest.pipeline.enabled", "true"),
-                    ])
-                    if options.get("apm_server_pipeline_path"):
-                        self.apm_server_command_args.append(
-                            ("apm-server.register.ingest.pipeline.overwrite", "true"),
-                        )
+                self.apm_server_command_args.extend([
+                    ("apm-server.register.ingest.pipeline.enabled", "true"),
+                ])
+                if options.get("apm_server_pipeline_path"):
+                    self.apm_server_command_args.append(
+                        ("apm-server.register.ingest.pipeline.overwrite", "true"),
+                    )
         else:
             add_es_config(self.apm_server_command_args,
                           prefix="monitoring" if self.at_least_version("7.2") else "xpack.monitoring")

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -920,6 +920,10 @@ class ApmServerServiceTest(ServiceTest):
     def test_data_streams(self):
         apm_server = ApmServer(version="7.16.0", apm_server_enable_data_streams=True).render()["apm-server"]
         self.assertIn("apm-server.data_streams.enabled=true", apm_server["command"])
+        self.assertFalse(
+            any(a.startswith("output.elasticsearch.pipelines=") for a in apm_server["command"]),
+            "output.elasticsearch.pipelines with data streams enabled",
+        )
 
     def test_debug(self):
         apm_server = ApmServer(version="6.8.0", apm_server_enable_debug=True).render()["apm-server"]


### PR DESCRIPTION
## What does this PR do?

allows apm-server writing to data streams without additional configuration

## Why is it important?

with the update of the apm integration package `--apm-server-enable-data-streams` no longer works as the pipeline configuration is invalid.  This fixes the issue going forward by relying on the data stream configuration of pipeline instead of apm-server.  This disallows configuration of pipelines with data streams enabled but that's a fine trade for now.

Thanks to @simitt for pointing out that the data stream configures the pipeline.
