### PR TITLE
Use multi-stage Docker build instead of cURL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM python:3.7
+FROM node:12-buster
+RUN npm install elasticdump -g
 
-#Install elasticdump
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get -yqq update \
-    && apt-get install -yqq nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install elasticdump -g
-
+FROM python:3.7-buster
 COPY requirements.txt requirements.txt
 RUN pip install -q -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:12-buster
-RUN npm install elasticdump -g
+FROM node:12-buster as BUILD_IMAGE
+WORKDIR /app
+RUN npm install elasticdump
 
 FROM python:3.7-buster
 COPY requirements.txt requirements.txt
 RUN pip install -q -r requirements.txt
 
 RUN useradd -U -m -s /bin/bash -d /app tester
-
 COPY . /app
 WORKDIR /app
+COPY --from=BUILD_IMAGE /app .
+RUN ln -s /app/node_modules/elasticdump/bin/elasticdump /usr/local/bin/elasticdump
+RUN ln -s /app/node_modules/elasticdump/bin/multielasticdump /usr/local/bin/multielasticdump
+COPY --from=BUILD_IMAGE /usr/local/bin/node /usr/local/bin/node
 USER tester


### PR DESCRIPTION
## What does this PR do?

This simplifies the Dockerfile used by the APM Integration Test suite to use a Docker multi-stage build instead of a more error-prone cURL-based approach for installing NodeJS.

## Why is it important?

We occasionally see failures [such as this one](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-test-downstream/detail/master/10814/pipeline) in which the script-based approach for installing NodeJS fails. By using multi-stage builds, the hope is that we'll avoid those types of issues.


