### PR TITLE
Enable inferred spans by default for Java

### DIFF
--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -268,18 +268,20 @@ class OpbeansJava(OpbeansService):
             default=cls.DEFAULT_OPBEANS_VERSION,
             help=cls.name() + " version for the docker image of opbeans java"
         )
-        # only support by the java agent for now
         parser.add_argument(
-            '--' + cls.name() + '-infer-spans',
+            '--' + cls.name() + '-no-infer-spans',
             action="store_true",
-            help=cls.name() + " enable inferred span collection"
+            help=cls.name() + " disable inferred span collection",
         )
 
     def __init__(self, **options):
         super(OpbeansJava, self).__init__(**options)
         self.opbeans_image = options.get('opbeans_java_image')
         self.opbeans_version = options.get('opbeans_java_version')
-        self.infer_spans = options.get('opbeans_java_infer_spans')
+        self.infer_spans = self._resolve_span_setting(options)
+
+    def _resolve_span_setting(self, options):
+        return not options.get('opbeans_java_no_infer_spans')
 
     @add_agent_environment([
         ("apm_server_secret_token", "ELASTIC_APM_SECRET_TOKEN")

--- a/scripts/tests/localsetup_tests.py
+++ b/scripts/tests/localsetup_tests.py
@@ -209,6 +209,7 @@ class OpbeansServiceTest(ServiceTest):
                       - JAVA_AGENT_VERSION
                       - OPBEANS_DT_PROBABILITY=0.50
                       - ELASTIC_APM_ENVIRONMENT=production
+                      - ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true
                     logging:
                       driver: 'json-file'
                       options:
@@ -236,10 +237,14 @@ class OpbeansServiceTest(ServiceTest):
         branch = [e for e in opbeans["build"]["args"] if e.startswith("OPBEANS_JAVA_IMAGE")]
         self.assertEqual(branch, ["OPBEANS_JAVA_IMAGE=foo"])
 
-    def test_opbeans_java_infer_spans(self):
-        opbeans = OpbeansJava(opbeans_java_infer_spans=True).render()["opbeans-java"]
-        infer = [e for e in opbeans["environment"] if e.startswith("ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED")]
-        self.assertEqual(infer, ["ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true"])
+    def test_opbeans_java_no_infer_spans(self):
+        opbeans = OpbeansJava(opbeans_java_no_infer_spans=True).render()["opbeans-java"]
+        self.assertTrue("ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true" not in opbeans['environment'])
+
+    def opbeans_java_infer_spans_default_spans(self):
+        opbeans = OpbeansJava().render()["opbeans-java"]
+        self.assertTrue("ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true" in opbeans['environment'])
+
 
     def test_opbeans_java_version(self):
         opbeans = OpbeansJava(opbeans_java_version="bar").render()["opbeans-java"]


### PR DESCRIPTION
## What does this PR do?

1. Makes `ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true` the default.
1. Adds a new flag: `--opbeans-java-no-infer-spans`. When set, this flag ensures that `ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED=true` is **not** present.
1. Removes the `--opbeans-java-infer-spans` flag.


## Why is it important?

Requested by APM Java Agent team.

## Related issues
Closes https://github.com/elastic/apm-integration-testing/issues/997
