### PR TITLE
Upgrade urllib3, py, and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ idna==2.6
 jsonschema==2.6.0
 mccabe==0.6.1
 pluggy==0.13.1
-py==1.5.2
+py==1.10.0
 pycodestyle==2.7.0
 pyflakes==2.3.0
 pytest-base-url==1.4.2
@@ -28,7 +28,7 @@ pytest-rerunfailures==9.0
 pytest-selenium==1.17.0
 pytest-variables==1.9.0
 pytest==5.4.3
-requests==2.22.0
+requests==2.26.0
 selenium==3.8.0
 setuptools==49.6.0
 singledispatch==3.4.0.3
@@ -36,7 +36,7 @@ six==1.11.0
 texttable==0.9.1
 timeout-decorator==0.4.0
 tornado==5.1
-urllib3==1.25.7
+urllib3>=1.26.5
 virtualenv==16.7.9
 waiting==1.4.1
 webium==1.2.1


### PR DESCRIPTION
## What does this PR do?

* Upgrades urllib3 to avoid CVE-2020-26137
* Upgrades py to avoid CVE-2020-29651
* Upgrades requests (due to urllib3 upgrade)

## Why is it important?

This isn't a particularly urgent security concern. Just keeping things tidy. :)

