### PR TITLE
[CI] use obltGitHubComments

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
   }
   triggers {
     cron(env.CHANGE_ID?.trim() ? '' : 'H H(3-4) * * 1-5')
-    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|/test(?:all))')
+    issueCommentTrigger("(${obltGitHubComments()}|^/testall)")
   }
   options {
     timeout(time: 3, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/elastic/apm-pipeline-library/blob/master/vars/obltGitHubComments.txt

## Why is it important?

Avoid hardcoded strings and normalise the GitHub comments in all the oblt projects