### PR TITLE
Add missing sleep backport to ES check

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from timeout_decorator import TimeoutError
+import time
 import requests
 
 
@@ -45,6 +46,7 @@ def check_elasticsearch_count(elasticsearch,
         try:
             actual = elasticsearch.count(query)
             retries += 1
+            time.sleep(10)
         except TimeoutError:
             retries = max_retries
             actual = -1


### PR DESCRIPTION
## What does this PR do?

In the 7.x branch and the master branch, we have a sleep in between the retries. In the 6.x branch, that change was never applied. I believe this may be the root cause of a l[arge number of errors on the 6.x branch](https://jenkins-stats-oblt.elastic.dev/goto/fa14b837e0779427ad6c8fc39219ac73) which do not occur in 7.x and master.

## Why is it important?

Hopefully increased test stability on 6.x branch
