### PR TITLE
add --elasticsearch-snapshot-repo option

### DIFF
--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -137,6 +137,31 @@ class StatsD(Service):
         )
 
 
+class CommandService(object):
+    def __init__(self, command, service="command", image="busybox", depends_on=None):
+        self.command = command
+
+        self.depends_on = depends_on
+        self.image = image
+        self.service = service
+
+    def name(self):
+        return self.service
+
+    @staticmethod
+    def image_download_url():
+        return None
+
+    def render(self):
+        content = {
+            "command": self.command,
+            "image": self.image,
+        }
+        if self.depends_on:
+            content["depends_on"] = {d: {"condition": "service_healthy"} for d in self.depends_on}
+        return {self.service: content}
+
+
 class WaitService(Service):
     """Create a service that depends on all services ."""
 

--- a/scripts/tests/test_service.py
+++ b/scripts/tests/test_service.py
@@ -1126,6 +1126,15 @@ class ElasticsearchServiceTest(ServiceTest):
         java_opts = [e for e in elasticsearch["environment"] if e.startswith("ES_JAVA_OPTS=")]
         self.assertListEqual(["ES_JAVA_OPTS=-XX:+UseConcMarkSweepGC"], java_opts)
 
+    def test_snapshot(self):
+        elasticsearch = Elasticsearch(version="7.11.100", elasticsearch_snapshot_repo=["http://single_repo.url/p/ath"]).render()["elasticsearch"]
+        repos_allowed = [e for e in elasticsearch["environment"] if e.startswith("repositories.url.allowed_urls=")]
+        self.assertEqual(["repositories.url.allowed_urls=http://single_repo.url/p/ath"], repos_allowed)
+
+        elasticsearch = Elasticsearch(version="7.11.100", elasticsearch_snapshot_repo=["http://first_repo.url/p/ath", "http://second_repo.url/p/ath"]).render()["elasticsearch"]
+        repos_allowed = [e for e in elasticsearch["environment"] if e.startswith("repositories.url.allowed_urls=")]
+        self.assertEqual(["repositories.url.allowed_urls=http://first_repo.url/p/ath,http://second_repo.url/p/ath"], repos_allowed)
+
     def test_tls(self):
         elasticsearch = Elasticsearch(version="7.11.100", elasticsearch_tls_enable=True).render()["elasticsearch"]
         self.assertListEqual(["co.elastic.apm.stack-version=7.11.100",


### PR DESCRIPTION
## What does this PR do?

Enables command line configuration of elasticsearch [Read-only URL snapshot repository](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-register-repository.html#snapshots-read-only-repository).  Use like:

```
./scripts/compose.py start 8.0.0 --elasticsearch-snapshot-repo https://storage.googleapis.com/my-es-snapshots/are/here/
```

... wait for containers to come up ...

```
$ curl http://admin:changeme@localhost:9200/_cat/snapshots
opbeans-go-only repo0 SUCCESS 1613048309 12:58:29 1613048317 12:58:37  8.8s 6 6 0 6
test            repo0 SUCCESS 1613076320 20:45:20 1613076373 20:46:13 52.4s 7 7 0 7
```

## Why is it important?

For easy searchable snapshot usage.