### PR TITLE
fix: remove the uninstall of the Python2

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -9,8 +9,6 @@ ARG apm_server_binary=apm-server
 FROM golang:${go_version} AS build
 ARG apm_server_binary
 
-RUN apt -qq remove -y python2 && apt -qq autoremove -y
-
 # install make update prerequisites
 RUN apt-get -qq update \
     && apt-get -qq install -y python3 python3-pip python3-venv rsync


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* fix the apm-server container build, the golang:1.17.1 Docker container does not have Python installed anymore.
