### PR TITLE
[mergify] automate merge for backports created by mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -40,18 +40,21 @@ pull_request_rules:
     actions:
       queue:
         name: auto-merge
+        method: squash
   - name: automatic merge when CI passes and the file tests/versions/apm_server.yml is modified.
     conditions:
       - files~=^tests/versions/apm_server.yml$
     actions:
       queue:
         name: auto-merge
+        method: squash
   - name: automatic merge when CI passes and the file scripts/modules/cli.py is modified.
     conditions:
       - files~=^scripts/modules/cli.py$
     actions:
       queue:
         name: auto-merge
+        method: squash
   - name: delete upstream branch after merging changes on dev-tools/integration/.env
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

- Tidy up the `mergify` rules
- Enable the `merge-queue` with `squash`
- Automerge the backported PRs from mergify if they pass in the CI

## Why is it important?

Avoid https://github.com/elastic/apm-integration-testing/pull/1295 
Start using the `merge-queue` feature since `strict merge` is deprecated and will be removed in early January. See https://docs.mergify.io/actions/merge/#strict-merge


