### PR TITLE
Temporarily turn APM log level to debug

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
   }
   parameters {
     string(name: 'ELASTIC_STACK_VERSION', defaultValue: "", description: "Elastic Stack Git branch/tag to use")
-    string(name: 'BUILD_OPTS', defaultValue: "", description: "Additional build options to pass to compose.py")
+    string(name: 'BUILD_OPTS', defaultValue: "--apm-log-level=DEBUG", description: "Additional build options to pass to compose.py")
     string(name: 'SLACK_CHANNEL', defaultValue: 'observablt-bots', description: 'The Slack channel where errors will be posted')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
   }


### PR DESCRIPTION
## What does this PR do?

Temporarily turn the log level for APM agents up to the debug level.

A full discussion on this issue may be found here: https://github.com/elastic/apm-agent-java/issues/2176

## Why is it important?

Debugging off-by-one errors which make the APM Integration Tests unstable.

## Related issues
Refs: https://github.com/elastic/apm-agent-java/issues/2176
