### PR TITLE
[mergify] backport label for the backported PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,8 +29,7 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.x"
-      label:
-        add:
+        labels:
           - backport
   - name: automatic merge backported Pull Requests from mergify when CI passes.
     conditions:


### PR DESCRIPTION
## What does this PR do?

Rather than labelling the original PR, let's label the backported PR instead.

Otherwise the auto-merge won't work