### PR TITLE
Disabling flaky Java test in 6.x

### DIFF
--- a/tests/agent/test_java.py
+++ b/tests/agent/test_java.py
@@ -10,6 +10,7 @@ def test_req_java_spring(java_spring):
         java_spring.foo, java_spring.apm_server.elasticsearch)
 
 
+@pytest.mark.skip(reason="Very unstable on CI. Disabling in 6.x")
 @pytest.mark.java_spring
 def test_java_spring_error(java_spring):
     utils.check_agent_error(


### PR DESCRIPTION
## What does this PR do?

Disables flaky Java Spring test in 6.x branch
## Why is it important?

Make branch stable until it is removed.

## Related issues
Closes https://github.com/elastic/apm-agent-java/issues/2243
