### PR TITLE
Adapt to breaking changes in 8.0

### DIFF
--- a/.ci/integrationTestEC.groovy
+++ b/.ci/integrationTestEC.groovy
@@ -29,7 +29,7 @@ pipeline {
     quietPeriod(10)
   }
   parameters {
-    string(name: 'BUILD_OPTS', defaultValue: "--no-elasticsearch --no-apm-server --no-kibana --no-apm-server-dashboards --no-apm-server-self-instrument", description: "Addicional build options to passing compose.py")
+    string(name: 'BUILD_OPTS', defaultValue: "--no-elasticsearch --no-apm-server --no-kibana --no-apm-server-self-instrument", description: "Addicional build options to passing compose.py")
     booleanParam(name: 'destroy_mode', defaultValue: false, description: 'Run the script in destroy mode to destroy any cluster provisioned and delete vault secrets.')
     string(name: 'build_num_to_destroy', defaultValue: "", description: "Build number to destroy, it is needed on destroy_mode")
   }

--- a/.ci/integrationTestECK.groovy
+++ b/.ci/integrationTestECK.groovy
@@ -30,7 +30,7 @@ pipeline {
     quietPeriod(10)
   }
   parameters {
-    string(name: 'BUILD_OPTS', defaultValue: "--no-elasticsearch --no-apm-server --no-kibana --no-apm-server-dashboards --no-apm-server-self-instrument", description: "Addicional build options to passing compose.py")
+    string(name: 'BUILD_OPTS', defaultValue: "--no-elasticsearch --no-apm-server --no-kibana --no-apm-server-self-instrument", description: "Addicional build options to passing compose.py")
     booleanParam(name: 'update_docker_images', defaultValue: true, description: 'Enable/Disable the Docker images update.')
     booleanParam(name: 'destroy_mode', defaultValue: false, description: 'Run the script in destroy mode to destroy any cluster provisioned and delete vault secrets.')
     string(name: 'build_num_to_destroy', defaultValue: "", description: "Build number to destroy, it is needed on destroy_mode")

--- a/.ci/scripts/8.0-upgrade.sh
+++ b/.ci/scripts/8.0-upgrade.sh
@@ -7,12 +7,10 @@ test -z "$srcdir" && srcdir=.
 
 export COMPOSE_ARGS="7.2 --force-build --no-xpack-secure \
   --build-parallel \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --apm-server-count 2 \
   --apm-server-tee \
   --elasticsearch-data-dir '' \
-  --no-apm-server-pipeline \
   --all \
   --no-kibana"
 make start-env docker-compose-wait

--- a/.ci/scripts/agent.sh
+++ b/.ci/scripts/agent.sh
@@ -24,10 +24,9 @@ fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-${APP} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --apm-server-agent-config-poll=1s \
-  --force-build --no-xpack-secure \
+  --force-build \
   ${APM_DEBUG}"
 
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}

--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -32,7 +32,6 @@ function prepareAndRunAll() {
   export APM_SERVER_URL=${APM_SERVER_URL:-"https://apm-server:8200"}
   export PYTHONHTTPSVERIFY=0
   DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS}\
-    --no-apm-server-dashboards \
     --no-apm-server-self-instrument \
     --with-agent-rumjs \
     --with-agent-dotnet \
@@ -43,10 +42,8 @@ function prepareAndRunAll() {
     --with-agent-java-spring \
     --with-agent-python-django \
     --with-agent-python-flask \
-    --no-xpack-secure \
     --apm-server-enable-tls \
     --no-verify-server-cert  \
-    --no-kibana \
     --apm-server-secret-token=${ELASTIC_APM_SECRET_TOKEN} \
     --apm-server-url=${APM_SERVER_URL} \
     --apm-log-level=debug"
@@ -57,10 +54,7 @@ function prepareAndRunAll() {
 
 function prepareAndRunGoals() {
   DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} \
-    --no-apm-server-dashboards \
-    --no-apm-server-self-instrument \
-    --no-kibana \
-    --no-xpack-secure"
+    --no-apm-server-self-instrument"
   export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
   runTests "$@"
 }

--- a/.ci/scripts/dotnet.sh
+++ b/.ci/scripts/dotnet.sh
@@ -14,11 +14,9 @@ if [ -n "${APM_AGENT_DOTNET_VERSION}" ]; then
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana --with-agent-dotnet \
+  --with-agent-dotnet \
   --force-build \
-  --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-dotnet docker-test-agent-dotnet

--- a/.ci/scripts/go.sh
+++ b/.ci/scripts/go.sh
@@ -14,12 +14,9 @@ if [ -n "${APM_AGENT_GO_VERSION}" ]; then
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
   --with-agent-go-net-http \
   --force-build \
-  --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 

--- a/.ci/scripts/java.sh
+++ b/.ci/scripts/java.sh
@@ -23,12 +23,9 @@ else
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
   --with-agent-java-spring \
   --force-build \
-  --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-java docker-test-agent-java

--- a/.ci/scripts/kibana.sh
+++ b/.ci/scripts/kibana.sh
@@ -7,7 +7,6 @@ test -z "$srcdir" && srcdir=.
 . "${srcdir}/common.sh"
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-kibana docker-test-kibana

--- a/.ci/scripts/nodejs.sh
+++ b/.ci/scripts/nodejs.sh
@@ -13,12 +13,9 @@ if [ -n "${APM_AGENT_NODEJS_VERSION}" ]; then
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
   --with-agent-nodejs-express \
   --force-build \
-  --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-nodejs docker-test-agent-nodejs

--- a/.ci/scripts/opbeans-app.sh
+++ b/.ci/scripts/opbeans-app.sh
@@ -13,10 +13,8 @@ OPBEANS_APP=$3
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-agent-${APP} \
   --with-opbeans-${OPBEANS_APP} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
   --apm-server-agent-config-poll=1s \
-  --force-build --no-xpack-secure"
+  --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-${AGENT}"

--- a/.ci/scripts/opbeans-rum.sh
+++ b/.ci/scripts/opbeans-rum.sh
@@ -8,10 +8,9 @@ test -z "$srcdir" && srcdir=.
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
   --with-opbeans-go \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --apm-server-agent-config-poll=1s \
-  --force-build --no-xpack-secure"
+  --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests "env-agent-go"
 

--- a/.ci/scripts/opbeans.sh
+++ b/.ci/scripts/opbeans.sh
@@ -7,10 +7,7 @@ test -z "$srcdir" && srcdir=.
 . "${srcdir}/common.sh"
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
-  --force-build \
-  --no-xpack-secure"
+  --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-server test-compose lint test-helps

--- a/.ci/scripts/php.sh
+++ b/.ci/scripts/php.sh
@@ -14,12 +14,9 @@ if [ -n "${APM_AGENT_PHP_VERSION}" ]; then
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --with-agent-php-apache \
   --apm-server-agent-config-poll=1s \
-  --force-build \
-  --no-kibana \
-  --no-xpack-secure"
+  --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-php docker-test-agent-php

--- a/.ci/scripts/python.sh
+++ b/.ci/scripts/python.sh
@@ -16,14 +16,11 @@ if [ -n "${APM_AGENT_PYTHON_VERSION}" ]; then
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
   --with-agent-python-django \
   --with-agent-python-flask \
   --apm-server-agent-config-poll=1s \
   --force-build \
-  --no-kibana \
-  --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-python docker-test-agent-python

--- a/.ci/scripts/ruby.sh
+++ b/.ci/scripts/ruby.sh
@@ -20,12 +20,9 @@ if [ -n "${APM_AGENT_RUBY_VERSION}" ]; then
 fi
 
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
   --with-agent-ruby-rails \
   --force-build \
-  --no-xpack-secure \
   --apm-log-level=debug"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-ruby docker-test-agent-ruby

--- a/.ci/scripts/rum.sh
+++ b/.ci/scripts/rum.sh
@@ -15,11 +15,8 @@ fi
 
 #--with-agent-python-django
 DEFAULT_COMPOSE_ARGS="${ELASTIC_STACK_VERSION} ${BUILD_OPTS} \
-  --no-apm-server-dashboards \
   --no-apm-server-self-instrument \
-  --no-kibana \
   --with-agent-rumjs \
-  --force-build \
-  --no-xpack-secure"
+  --force-build"
 export COMPOSE_ARGS=${COMPOSE_ARGS:-${DEFAULT_COMPOSE_ARGS}}
 runTests env-agent-rum docker-test-agent-rum

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PHP_APACHE_URL ?= http://phpapacheapp
 RAILS_URL ?= http://railsapp:8020
 RUM_URL ?= http://rum:8000
 
-ES_USER ?= elastic
+ES_USER ?= admin
 ES_PASS ?= changeme
 ELASTIC_APM_SECRET_TOKEN ?= SuPeRsEcReT
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ We have a list with the most common flags combination that we internally use whe
 
 |Persona | Flags | Motivation / Use Case | Team | Comments |
 |--------|-------|-----------------------|------|----------|
-| CI Server | `python scripts/compose.py start 8.0.0 --java-agent-version ${COMMIT_SHA} --build-parallel --with-agent-java-spring --no-apm-server-dashboards --no-apm-server-self-instrument --no-kibana --force-build` | Prepare environment for running tests for APM Java agent | APM Agents |
-| CI Server	| `python scripts/compose.py start 8.0.0 --apm-server-build https://github.com/elastic/apm-server@${COMMIT_HASH} --build-parallel --no-apm-server-dashboards --no-apm-server-self-instrument --with-agent-rumjs --with-agent-dotnet --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --with-agent-python-django --with-agent-python-flask --force-build`	| Prepare environment for running tests for APM Server	| APM Server | |
+| CI Server | `python scripts/compose.py start 8.0.0 --java-agent-version ${COMMIT_SHA} --build-parallel --with-agent-java-spring --no-apm-server-self-instrument --force-build` | Prepare environment for running tests for APM Java agent | APM Agents |
+| CI Server	| `python scripts/compose.py start 8.0.0 --apm-server-build https://github.com/elastic/apm-server@${COMMIT_HASH} --build-parallel --no-apm-server-self-instrument --with-agent-rumjs --with-agent-dotnet --with-agent-go-net-http --with-agent-nodejs-express --with-agent-ruby-rails --with-agent-java-spring --with-agent-python-django --with-agent-python-flask --force-build`	| Prepare environment for running tests for APM Server	| APM Server | |
 | Demos & Screenshots	| `./scripts/compose.py start --release --with-opbeans-dotnet --with-opbeans-go --with-opbeans-java --opbeans-java-agent-branch=pr/588/head --force-build --with-opbeans-node --with-opbeans-python --with-opbeans-ruby --with-opbeans-rum --with-filebeat --with-metricbeat 7.3.0`	| demos, screenshots, ad hoc QA. It's also used to send heartbeat data to the cluster for Uptime | PMM	| Used for snapshots when close to a release, without the `--release` flag |
 | Development | `./scripts/compose.py start 7.3 --bc --with-opbeans-python --opbeans-python-agent-local-repo=~/elastic/apm-agent-python` | Use current state of local agent repo with opbeans | APM Agents | |
 | | `./scripts/compose.py start 7.3 --bc --start-opbeans-deps` | This flag would start all opbeans dependencies (postgres, redis, apm-server, ...), but not any opbeans instances | APM Agents | This would help when developing with a locally running opbeans. Currently, we start the environment with a `--with-opbeans-python` flag, then stop the opbeans-python container manually |
@@ -291,12 +291,9 @@ Omit `--skip-download` to just download images.
 
 ### Jaeger
 
-APM Server can work as a drop-in replacement for a Jaeger collector and ingest traces directly from a Jaeger agent via gRPC,
-or from a Jaeger client via HTTP/Thrift (deprecated).
+APM Server can work as a drop-in replacement for a Jaeger collector and ingest traces directly from a Jaeger agent via gRPC.
 
-#### gRPC
-
-To test gRPC, start apm-integration-testing, run the Jaeger Agent, and start the Jaeger hotrod demo:
+To test Jaeger/gRPC, start apm-integration-testing, run the Jaeger Agent, and start the Jaeger hotrod demo:
 
 ```
 ./scripts/compose.py start 7.13 \
@@ -318,12 +315,6 @@ docker run --rm -it --network apm-integration-testing \
 ```
 
 Finally, navigate to http://localhost:8080/ and click around to generate data.
-
-#### HTTP/Thrift (deprecated)
-
-To test HTTP/Thrift with a Jaeger microservice demo, run separately:
-
-    docker run --rm -it -p8080-8083:8080-8083 -e JAEGER_ENDPOINT=http://apm-server:14268/api/traces  --network apm-integration-testing  jaegertracing/example-hotrod:latest  all
 
 ## Running Tests
 
@@ -481,7 +472,7 @@ For example, to test an update to the Python agent from user `elasticcontributor
 ```bash
 # start test deps: apm-server, elasticsearch, and the two python test applications
 # the test applications will use elasticcontributor's newfeature1 apm agent
-./scripts/compose.py start master --no-kibana --with-agent-python-django --with-agent-python-flask --python-agent-package=git+https://github.com/elasticcontributor/apm-agent-python.git@newfeature1 --force-build
+./scripts/compose.py start master --with-agent-python-django --with-agent-python-flask --python-agent-package=git+https://github.com/elasticcontributor/apm-agent-python.git@newfeature1 --force-build
 
 # wait for healthiness
 docker-compose ps

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docker-compose==1.27.4
 docker==4.3.1
 dockerpty==0.4.1
 docopt==0.6.2
-elasticsearch==6.3.1
+elasticsearch==7.15.2
 flake8==3.9.0
 funcsigs==1.0.2
 future==0.16.0

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -405,13 +405,6 @@ class LocalSetup(object):
         )
 
         parser.add_argument(
-            "--apm-server-experimental-mode",
-            action="store_true",
-            help="start apm-server in experimental mode",
-            default=True,
-        )
-
-        parser.add_argument(
             '--opbeans-apm-js-server-url',
             action='store',
             help='server_url to use for Opbeans frontend service',
@@ -467,13 +460,6 @@ class LocalSetup(object):
             '--package-registry-url',
             action="store",
             help="Elastic Package Registry URL to use for fetching integration packages",
-        )
-
-        parser.add_argument(
-            '--drop-unsampled',
-            action='store_true',
-            help='Drop unsampled transactions',
-            default=None
         )
 
         self.store_options(parser)
@@ -663,6 +649,13 @@ class LocalSetup(object):
                 "http://admin:changeme@elasticsearch:9200/_snapshot/{:s}".format(repo_label),
             ]
             selections.add(CommandService(cmd, service=repo_label, image=curl_image, depends_on=["elasticsearch"]))
+
+        # Add a container to call the Fleet setup API. This is necessary for installing the APM integration.
+        if args.get("enable_kibana"):
+            kibana_scheme = "https" if args.get("kibana_enable_tls", False) else "http"
+            kibana_url = kibana_scheme + "://admin:changeme@kibana:5601"
+            cmd = ["curl", "-X", "POST", "-H", "kbn-xsrf: 1", kibana_url + "/api/fleet/setup"]
+            selections.add(CommandService(cmd, service="fleet_setup", image=curl_image, depends_on=["kibana"]))
 
         # `docker load` images if necessary, usually only for build candidates
         services_to_load = {}

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -16,8 +16,6 @@ class ApmServer(StackService, Service):
 
     SERVICE_PORT = "8200"
     DEFAULT_MONITOR_PORT = "6060"
-    DEFAULT_JAEGER_HTTP_PORT = "14268"
-    DEFAULT_JAEGER_GRPC_PORT = "14250"
     DEFAULT_OUTPUT = "elasticsearch"
     OUTPUTS = {"elasticsearch", "file", "kafka", "logstash"}
     DEFAULT_KIBANA_HOST = "kibana:5601"
@@ -83,26 +81,21 @@ class ApmServer(StackService, Service):
             ("apm-server.write_timeout", "1m"),
             ("logging.json", "true"),
             ("logging.metrics.enabled", "false"),
-            ("setup.template.settings.index.number_of_replicas", "0"),
-            ("setup.template.settings.index.number_of_shards", "1"),
-            ("setup.template.settings.index.refresh_interval",
-                "{}".format(self.options.get("apm_server_index_refresh_interval"))),
             ("monitoring.elasticsearch" if self.at_least_version("7.2") else "xpack.monitoring.elasticsearch", "true"),
             ("monitoring.enabled" if self.at_least_version("7.2") else "xpack.monitoring.enabled", "true"),
-            ("apm-server.rum.allow_headers", "[\"x-custom-header\"]")
+            ("apm-server.rum.allow_headers", "[\"x-custom-header\"]"),
         ])
 
-        self.enable_data_streams = bool(self.options.get("apm_server_enable_data_streams"))
-        if self.enable_data_streams:
+        if self.at_least_version("8.0"):
+            # TODO(axw) remove this once data streams are always enabled in 8.0.
             self.apm_server_command_args.append(("apm-server.data_streams.enabled", "true"))
-            default_apm_server_kibana_creds = {"username": "admin", "password": "changeme"}
 
         if options.get("apm_server_self_instrument", True):
-            self.apm_server_command_args.append(("apm-server.instrumentation.enabled", "true"))
+            self.apm_server_command_args.append(("instrumentation.enabled", "true"))
             if self.at_least_version("7.6") and options.get("apm_server_profile", True):
                 self.apm_server_command_args.extend([
-                    ("apm-server.instrumentation.profiling.cpu.enabled", "true"),
-                    ("apm-server.instrumentation.profiling.heap.enabled", "true"),
+                    ("instrumentation.profiling.cpu.enabled", "true"),
+                    ("instrumentation.profiling.heap.enabled", "true"),
                 ])
         self.depends_on = {"elasticsearch": {"condition": "service_healthy"}} if options.get(
             "enable_elasticsearch", True) else {}
@@ -111,25 +104,7 @@ class ApmServer(StackService, Service):
         self.es_tls = self.options.get("elasticsearch_enable_tls", False)
         self.kibana_tls = self.options.get("kibana_enable_tls", False)
 
-        if self.options.get("apm_server_experimental_mode", True) and self.at_least_version("7.2"):
-            self.apm_server_command_args.append(("apm-server.mode", "experimental"))
-
-        index_suffix = self.options.get("index_suffix")
-        if index_suffix and self.at_least_version("7.9"):
-            mapping = []
-            for et in ["profile", "error", "transaction", "span", "metric"]:
-                mapping.append({"event_type": et, "index_suffix": index_suffix})
-            mapping_str = json.dumps(mapping)
-            self.apm_server_command_args.append(("apm-server.ilm.setup.mapping", mapping_str))
-
-        if self.options.get("apm_server_ilm_disable"):
-            self.apm_server_command_args.append(("apm-server.ilm.enabled", "false"))
-        elif self.at_least_version("7.2") and not self.at_least_version("7.3") and not self.oss:
-            self.apm_server_command_args.append(("apm-server.ilm.enabled", "true"))
-
-        if self.options.get("apm_server_acm_disable") or not self.options.get("enable_kibana", True):
-            self.apm_server_command_args.append(("apm-server.kibana.enabled", "false"))
-        elif self.at_least_version("7.3") and self.options.get("enable_kibana", True):
+        if self.at_least_version("7.3") and self.options.get("enable_kibana", True):
             self.apm_server_command_args.extend([
                 ("apm-server.kibana.enabled", "true"),
                 ("apm-server.kibana.host", self.options.get("apm_server_kibana_url", self.DEFAULT_KIBANA_HOST))])
@@ -152,26 +127,13 @@ class ApmServer(StackService, Service):
 
         if self.options.get("enable_kibana", True):
             self.depends_on["kibana"] = {"condition": "service_healthy"}
-            if options.get("apm_server_dashboards", True) and not self.at_least_version("7.0") \
-                    and not self.options.get("xpack_secure"):
-                self.apm_server_command_args.append(
-                    ("setup.dashboards.enabled", "true")
-                )
-
-        if self.at_least_version("7.6"):
-            if options.get("apm_server_jaeger"):
-                self.apm_server_command_args.extend([
-                    ("apm-server.jaeger.http.enabled", "true"),
-                    ("apm-server.jaeger.http.host", "0.0.0.0:" + self.DEFAULT_JAEGER_HTTP_PORT),
-                    ("apm-server.jaeger.grpc.enabled", "true"),
-                    ("apm-server.jaeger.grpc.host", "0.0.0.0:" + self.DEFAULT_JAEGER_GRPC_PORT)
-                ])
 
         # configure authentication
         if options.get("apm_server_api_key_auth", False):
-            self.apm_server_command_args.append(("apm-server.api_key.enabled", "true"))
+            self.apm_server_command_args.append(("apm-server.auth.api_key.enabled", "true"))
         if self.options.get("apm_server_secret_token"):
-            self.apm_server_command_args.append(("apm-server.secret_token", self.options["apm_server_secret_token"]))
+            self.apm_server_command_args.append(
+                ("apm-server.auth.secret_token", self.options["apm_server_secret_token"]))
 
         if self.options.get("apm_server_enable_tls"):
             self.apm_server_command_args.extend([
@@ -201,11 +163,6 @@ class ApmServer(StackService, Service):
                 q.pop("write")
             self.apm_server_command_args.append(("queue.spool", json.dumps(q)))
 
-        if options.get('drop_unsampled') or (options.get('drop_unsampled') is None and self.at_least_version("7.16")):
-            self.apm_server_command_args.extend([
-                ("apm-server.sampling.keep_unsampled", "true")
-            ])
-
         es_urls = []
 
         def add_es_config(args, prefix="output", tls=self.es_tls):
@@ -227,25 +184,6 @@ class ApmServer(StackService, Service):
             self.apm_server_command_args.extend([
                 ("output.elasticsearch.enabled", "true"),
             ])
-            # pipeline is defined in the data stream settings, don't set a pipeline in that case, no overrides
-            if options.get("apm_server_enable_pipeline", True) and self.at_least_version("6.5") and \
-                    not self.enable_data_streams:
-                if self.at_least_version("7.2"):
-                    pipeline_name = "apm"
-                else:
-                    pipeline_name = "apm_user_agent"
-
-                self.apm_server_command_args.append(
-                    ("output.elasticsearch.pipelines", "[{pipeline: '%s'}]" % pipeline_name)
-                )
-
-                self.apm_server_command_args.extend([
-                    ("apm-server.register.ingest.pipeline.enabled", "true"),
-                ])
-                if options.get("apm_server_pipeline_path"):
-                    self.apm_server_command_args.append(
-                        ("apm-server.register.ingest.pipeline.overwrite", "true"),
-                    )
         else:
             add_es_config(self.apm_server_command_args,
                           prefix="monitoring" if self.at_least_version("7.2") else "xpack.monitoring")
@@ -304,12 +242,6 @@ class ApmServer(StackService, Service):
             help='build apm-server from a git repo[@branch|sha], eg https://github.com/elastic/apm-server.git@v2'
         )
         parser.add_argument(
-            "--apm-server-ilm-disable",
-            "--no-apm-server-ilm",
-            action="store_true",
-            help='disable ILM (enabled by default in 7.2+)'
-        )
-        parser.add_argument(
             '--apm-server-output',
             choices=cls.OUTPUTS,
             default='elasticsearch',
@@ -319,16 +251,6 @@ class ApmServer(StackService, Service):
             '--apm-server-output-file',
             default=os.devnull,
             help='apm-server output path (when output=file)'
-        )
-        parser.add_argument(
-            "--apm-server-pipeline-path",
-            help='custom apm-server pipeline definition.'
-        )
-        parser.add_argument(
-            "--no-apm-server-pipeline",
-            action="store_false",
-            dest="apm_server_enable_pipeline",
-            help='disable apm-server pipelines.'
         )
         parser.add_argument(
             "--no-apm-server-self-instrument",
@@ -404,17 +326,6 @@ class ApmServer(StackService, Service):
             help="apm-server secret token.",
         )
         parser.add_argument(
-            '--no-apm-server-jaeger',
-            dest="apm_server_jaeger",
-            action="store_false",
-            help="make apm-server act as a Jaeger collector (HTTP and gRPC).",
-        )
-        parser.add_argument(
-            "--apm-server-enable-data-streams",
-            action="store_true",
-            help='enable writing to data streams'
-        )
-        parser.add_argument(
             '--apm-server-enable-tls',
             action="store_true",
             dest="apm_server_enable_tls",
@@ -425,12 +336,6 @@ class ApmServer(StackService, Service):
             default="30s",
             dest="agent_config_poll",
             help="agent config polling interval.",
-        )
-        parser.add_argument(
-            "--no-apm-server-dashboards",
-            action="store_false",
-            dest="apm_server_dashboards",
-            help="skip loading apm-server dashboards (setup.dashboards.enabled=false)",
         )
         parser.add_argument(
             '--apm-server-record',
@@ -453,20 +358,9 @@ class ApmServer(StackService, Service):
             help="arbitrary additional configuration to set for apm-server"
         )
         parser.add_argument(
-            "--apm-server-acm-disable",
-            "--no-apm-server-acm",
-            action="store_true",
-            help="disable Agent Config Management",
-        )
-        parser.add_argument(
             "--apm-server-kibana-url",
             default=cls.DEFAULT_KIBANA_HOST,
             help="Change the default kibana URL (kibana:5601)"
-        )
-        parser.add_argument(
-            "--apm-server-index-refresh-interval",
-            default="1ms",
-            help="change the index refresh interval (default 1ms)",
         )
         parser.add_argument(
             '--elastic-apm-api-key',
@@ -520,21 +414,20 @@ class ApmServer(StackService, Service):
         for param, value in self.apm_server_command_args:
             command_args.extend(["-E", param + "=" + value])
 
-        healthcheck_path = "/" if self.at_least_version("6.5") else "/healthcheck"
-
         ports = [
             self.publish_port(self.port, self.SERVICE_PORT),
             self.publish_port(self.apm_server_monitor_port, self.DEFAULT_MONITOR_PORT),
         ]
-        if ("apm-server.jaeger.http.enabled", "true") in self.apm_server_command_args:
-            ports.append(self.publish_port(self.DEFAULT_JAEGER_HTTP_PORT))
-
-        if ("apm-server.jaeger.grpc.enabled", "true") in self.apm_server_command_args:
-            ports.append(self.publish_port(self.DEFAULT_JAEGER_GRPC_PORT))
 
         command = ["apm-server", "-e", "--httpprof", ":{}".format(self.apm_server_monitor_port)] + command_args
         if self.options.get("apm_server_enable_debug"):
             command = command + ["-d", "*"]
+
+        healthcheck_path = "/" if self.at_least_version("6.5") else "/healthcheck"
+        healthcheck = curl_healthcheck(self.SERVICE_PORT, path=healthcheck_path)
+        if self.at_least_version("8.0"):
+            curl_command = "curl -s http://localhost:{}/ | grep -q 'publish_ready.*true'".format(self.SERVICE_PORT)
+            healthcheck["test"] = ["CMD-SHELL", curl_command]
 
         content = dict(
             cap_add=["CHOWN", "DAC_OVERRIDE", "SETGID", "SETUID"],
@@ -544,7 +437,7 @@ class ApmServer(StackService, Service):
             environment=[
                 "BEAT_STRICT_PERMS=false"  # Workaround https://github.com/elastic/beats/issues/18858
             ],
-            healthcheck=curl_healthcheck(self.SERVICE_PORT, path=healthcheck_path),
+            healthcheck=healthcheck,
             labels=["co.elastic.apm.stack-version=" + self.version],
             ports=ports
         )
@@ -1175,6 +1068,8 @@ class Kibana(StackService, Service):
                 self.environment["XPACK_FLEET_REGISTRYURL"] = url
             if use_local_package_registry:
                 self.depends_on["package-registry"] = {"condition": "service_healthy"}
+            if self.at_least_version("8.0"):
+                self.environment["XPACK_FLEET_PACKAGES"] = '[{"name":"apm","version":"latest"}]'
         if self.at_least_version("8.0"):
             self.environment["ENTERPRISESEARCH_HOST"] = "http://enterprise-search:" + str(EnterpriseSearch.SERVICE_PORT)
 
@@ -1252,9 +1147,19 @@ class Kibana(StackService, Service):
         if self.kibana_yml:
             volumes.append("{}:/usr/share/kibana/config/kibana.yml".format(self.kibana_yml))
 
+        scheme = 'https' if self.kibana_tls else 'http'
+        kibana_healthy_string = "All services are available" if self.at_least_version("8.0") else "Looking good"
         content = dict(
-            healthcheck=curl_healthcheck(
-                self.SERVICE_PORT, "kibana", path="/api/status", retries=30, https=self.kibana_tls, start_period="10s"),
+            healthcheck={
+                "interval": "10s",
+                "retries": 30,
+                "start_period": "10s",
+                "test": [
+                    "CMD-SHELL",
+                    "curl -s -k {}://kibana:{}/api/status | grep -q '{}'".format(
+                        scheme, self.SERVICE_PORT, kibana_healthy_string),
+                ]
+            },
             depends_on=self.depends_on,
             environment=self.environment,
             ports=[self.publish_port(self.port, self.SERVICE_PORT)],
@@ -1280,8 +1185,9 @@ class Kibana(StackService, Service):
             self.environment["NODE_OPTIONS"] = "--max-old-space-size=4096"
             self.environment["BABEL_DISABLE_CACHE"] = "true"
             self.environment["HOME"] = "/usr/share/kibana"
-            content["healthcheck"] = curl_healthcheck(
-                self.SERVICE_PORT, "kibana", path="/api/status", retries=300, https=self.kibana_tls)
+            content["healthcheck"]["retries"] = 300
+            del content["healthcheck"]["start_period"]
+
         return content
 
     @staticmethod

--- a/scripts/tests/test_localsetup.py
+++ b/scripts/tests/test_localsetup.py
@@ -703,217 +703,6 @@ class LocalTest(unittest.TestCase):
         registry = discover_services()
         self.assertIn(ApmServer, registry)
 
-    def test_start_6_2_default(self):
-        docker_compose_yml = stringIO()
-        image_cache_dir = "/foo"
-        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.2': '6.2.10'}):
-            setup = LocalSetup(argv=self.common_setup_args +
-                               ["6.2", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
-            setup.set_docker_compose_path(docker_compose_yml)
-            setup()
-        docker_compose_yml.seek(0)
-        got = yaml.safe_load(docker_compose_yml)
-        want = yaml.safe_load("""
-        version: '2.4'
-        services:
-            apm-server:
-                cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
-                cap_drop: [ALL]
-                command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
-                    -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
-                    -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, setup.template.settings.index.number_of_replicas=0,
-                    -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
-                    -E, xpack.monitoring.elasticsearch=true,
-                    -E, xpack.monitoring.enabled=true,
-                    -E, 'apm-server.rum.allow_headers=["x-custom-header"]',
-                    -E, setup.dashboards.enabled=true,
-                    -E, 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', -E, output.elasticsearch.enabled=true]
-                container_name: localtesting_6.2.10_apm-server
-                depends_on:
-                    elasticsearch:
-                        condition:
-                            service_healthy
-                    kibana:
-                        condition:
-                            service_healthy
-                environment: [
-                    BEAT_STRICT_PERMS=false
-                ]
-                healthcheck:
-                    interval: 10s
-                    retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
-                    timeout: 5s
-                image: docker.elastic.co/apm/apm-server:6.2.10-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=6.2.10]
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:8200:8200', '127.0.0.1:6060:6060']
-
-            elasticsearch:
-                container_name: localtesting_6.2.10_elasticsearch
-                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, cluster.routing.allocation.disk.threshold_enabled=false, discovery.type=single-node, path.repo=/usr/share/elasticsearch/data/backups, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.2.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial]
-                healthcheck:
-                    interval: 20s
-                    retries: 10
-                    test: [CMD-SHELL, 'curl -s -k http://localhost:9200/_cluster/health | grep -vq ''"status":"red"''']
-                image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.2.10-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=6.2.10]
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:9200:9200']
-                ulimits:
-                    memlock: {hard: -1, soft: -1}
-                volumes: ['esdata:/usr/share/elasticsearch/data']
-
-            kibana:
-                container_name: localtesting_6.2.10_kibana
-                depends_on:
-                    elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_HOST: 0.0.0.0, SERVER_NAME: kibana.example.org, XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co', XPACK_MONITORING_ENABLED: 'true'}
-                healthcheck:
-                    interval: 10s
-                    retries: 30
-                    start_period: 10s
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
-                    timeout: 5s
-                image: docker.elastic.co/kibana/kibana-x-pack:6.2.10-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=6.2.10]
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:5601:5601']
-            wait-service:
-                container_name: wait
-                depends_on:
-                    apm-server:
-                        condition:
-                            service_healthy
-                    elasticsearch:
-                        condition:
-                            service_healthy
-                    kibana:
-                        condition:
-                            service_healthy
-                image: busybox
-        networks:
-            default: {name: apm-integration-testing}
-        volumes:
-            esdata: {driver: local}
-            pgdata: {driver: local}
-        """)  # noqa: 501
-        self.assertDictEqual(got, want)
-
-    def test_start_6_3_default(self):
-        docker_compose_yml = stringIO()
-        image_cache_dir = "/foo"
-        with mock.patch.dict(LocalSetup.SUPPORTED_VERSIONS, {'6.3': '6.3.10'}):
-            setup = LocalSetup(argv=self.common_setup_args +
-                               ["6.3", "--image-cache-dir", image_cache_dir, "--no-xpack-secure"])
-            setup.set_docker_compose_path(docker_compose_yml)
-            setup()
-        docker_compose_yml.seek(0)
-        got = yaml.safe_load(docker_compose_yml)
-        want = yaml.safe_load("""
-        version: '2.4'
-        services:
-            apm-server:
-                cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
-                cap_drop: [ALL]
-                command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.frontend.enabled=true, -E, apm-server.frontend.rate_limit=100000,
-                    -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
-                    -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, setup.template.settings.index.number_of_replicas=0,
-                    -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
-                    -E, xpack.monitoring.elasticsearch=true, -E, xpack.monitoring.enabled=true,
-                    -E, 'apm-server.rum.allow_headers=["x-custom-header"]',
-                    -E, setup.dashboards.enabled=true,
-                    -E, 'output.elasticsearch.hosts=["http://elasticsearch:9200"]', -E, output.elasticsearch.enabled=true ]
-                container_name: localtesting_6.3.10_apm-server
-                depends_on:
-                    elasticsearch:
-                        condition:
-                            service_healthy
-                    kibana:
-                        condition:
-                            service_healthy
-                environment: [
-                    BEAT_STRICT_PERMS=false
-                ]
-                healthcheck:
-                    interval: 10s
-                    retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://localhost:8200/healthcheck']
-                    timeout: 5s
-                image: docker.elastic.co/apm/apm-server:6.3.10-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=6.3.10]
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:8200:8200', '127.0.0.1:6060:6060']
-
-            elasticsearch:
-                container_name: localtesting_6.3.10_elasticsearch
-                environment: [bootstrap.memory_lock=true, cluster.name=docker-cluster, cluster.routing.allocation.disk.threshold_enabled=false, discovery.type=single-node, path.repo=/usr/share/elasticsearch/data/backups, 'ES_JAVA_OPTS=-Xms1g -Xmx1g', path.data=/usr/share/elasticsearch/data/6.3.10, xpack.security.enabled=false, xpack.license.self_generated.type=trial, xpack.monitoring.collection.enabled=true]
-                healthcheck:
-                    interval: 20s
-                    retries: 10
-                    test: [CMD-SHELL, 'curl -s -k http://localhost:9200/_cluster/health | grep -vq ''"status":"red"''']
-                image: docker.elastic.co/elasticsearch/elasticsearch:6.3.10-SNAPSHOT
-                labels:
-                    - co.elastic.apm.stack-version=6.3.10
-                    - co.elastic.metrics/module=elasticsearch
-                    - co.elastic.metrics/metricsets=node,node_stats
-                    - co.elastic.metrics/hosts=http://$${data.host}:9200
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:9200:9200']
-                ulimits:
-                    memlock: {hard: -1, soft: -1}
-                volumes: ['esdata:/usr/share/elasticsearch/data']
-
-            kibana:
-                container_name: localtesting_6.3.10_kibana
-                depends_on:
-                    elasticsearch: {condition: service_healthy}
-                environment: {ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200', SERVER_HOST: 0.0.0.0, SERVER_NAME: kibana.example.org, XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co', XPACK_MONITORING_ENABLED: 'true', XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false'}
-                healthcheck:
-                    interval: 10s
-                    retries: 30
-                    start_period: 10s
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
-                    timeout: 5s
-                image: docker.elastic.co/kibana/kibana:6.3.10-SNAPSHOT
-                labels: [co.elastic.apm.stack-version=6.3.10]
-                logging:
-                    driver: json-file
-                    options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:5601:5601']
-            wait-service:
-                container_name: wait
-                depends_on:
-                    apm-server:
-                        condition:
-                            service_healthy
-                    elasticsearch:
-                        condition:
-                            service_healthy
-                    kibana:
-                        condition:
-                            service_healthy
-                image: busybox
-        networks:
-            default: {name: apm-integration-testing}
-        volumes:
-            esdata: {driver: local}
-            pgdata: {driver: local}
-        """)  # noqa: 501
-        self.assertDictEqual(got, want)
-
     def test_version_options(self):
         docker_compose_yml = stringIO()
         image_cache_dir = "/foo"
@@ -944,20 +733,14 @@ class LocalTest(unittest.TestCase):
                 command: [apm-server, -e, --httpprof, ':6060', -E, apm-server.rum.enabled=true, -E, apm-server.rum.event_rate.limit=1000,
                     -E, 'apm-server.host=0.0.0.0:8200', -E, apm-server.read_timeout=1m, -E, apm-server.shutdown_timeout=2m,
                     -E, apm-server.write_timeout=1m, -E, logging.json=true, -E, logging.metrics.enabled=false,
-                    -E, setup.template.settings.index.number_of_replicas=0,
-                    -E, setup.template.settings.index.number_of_shards=1, -E, setup.template.settings.index.refresh_interval=1ms,
                     -E, monitoring.elasticsearch=true, -E, monitoring.enabled=true,
                     -E, 'apm-server.rum.allow_headers=["x-custom-header"]',
-                    -E, apm-server.mode=experimental,
+                    -E, 'apm-server.data_streams.enabled=true',
                     -E, apm-server.kibana.enabled=true, -E, 'apm-server.kibana.host=kibana:5601', -E, apm-server.agent.config.cache.expiration=30s,
                     -E, apm-server.kibana.username=apm_server_user, -E, apm-server.kibana.password=changeme,
-                    -E, apm-server.jaeger.http.enabled=true, -E, "apm-server.jaeger.http.host=0.0.0.0:14268",
-                    -E, apm-server.jaeger.grpc.enabled=true, -E, "apm-server.jaeger.grpc.host=0.0.0.0:14250",
-                    -E, apm-server.sampling.keep_unsampled=true,
                     -E, 'output.elasticsearch.hosts=["http://elasticsearch:9200"]',
                     -E, output.elasticsearch.username=apm_server_user, -E, output.elasticsearch.password=changeme,
-                    -E, output.elasticsearch.enabled=true,
-                    -E, "output.elasticsearch.pipelines=[{pipeline: 'apm'}]", -E, 'apm-server.register.ingest.pipeline.enabled=true'
+                    -E, output.elasticsearch.enabled=true
                     ]
                 container_name: localtesting_8.0.0_apm-server
                 depends_on:
@@ -973,14 +756,14 @@ class LocalTest(unittest.TestCase):
                 healthcheck:
                     interval: 10s
                     retries: 12
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://localhost:8200/']
+                    test: [CMD-SHELL, "curl -s http://localhost:8200/ | grep -q 'publish_ready.*true'"]
                     timeout: 5s
                 image: docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=8.0.0]
                 logging:
                     driver: json-file
                     options: {max-file: '5', max-size: 2m}
-                ports: ['127.0.0.1:8200:8200', '127.0.0.1:6060:6060', '127.0.0.1:14268:14268', '127.0.0.1:14250:14250']
+                ports: ['127.0.0.1:8200:8200', '127.0.0.1:6060:6060']
 
             elasticsearch:
                 container_name: localtesting_8.0.0_elasticsearch
@@ -1026,6 +809,13 @@ class LocalTest(unittest.TestCase):
                     './docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles'
                 ]
 
+            fleet_setup:
+                image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+                command: ['curl', '-X', 'POST', '-H', 'kbn-xsrf: 1', 'http://admin:changeme@kibana:5601/api/fleet/setup']
+                depends_on:
+                    kibana:
+                        condition: service_healthy
+
             kibana:
                 container_name: localtesting_8.0.0_kibana
                 depends_on:
@@ -1047,6 +837,7 @@ class LocalTest(unittest.TestCase):
                     XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
                     XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST: 'http://elasticsearch:9200',
                     XPACK_FLEET_AGENTS_KIBANA_HOST: 'http://kibana:5601',
+                    XPACK_FLEET_PACKAGES: '[{"name":"apm","version":"latest"}]',
                     XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
                     XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'
@@ -1055,8 +846,7 @@ class LocalTest(unittest.TestCase):
                     interval: 10s
                     retries: 30
                     start_period: 10s
-                    test: [CMD, curl, --write-out, '''HTTP %{http_code}''', -k, --fail, --silent, --output, /dev/null, 'http://kibana:5601/api/status']
-                    timeout: 5s
+                    test: ["CMD-SHELL", "curl -s -k http://kibana:5601/api/status | grep -q 'All services are available'"]
                 image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
                 labels: [co.elastic.apm.stack-version=8.0.0]
                 logging:
@@ -1198,7 +988,7 @@ class LocalTest(unittest.TestCase):
         got = yaml.safe_load(docker_compose_yml)
         services = set(got["services"])
         self.assertSetEqual(services, {
-            "apm-server", "elasticsearch", "kibana",
+            "apm-server", "elasticsearch", "kibana", "fleet_setup",
             "filebeat", "heartbeat", "metricbeat", "packetbeat",
             "opbeans-dotnet",
             "opbeans-go",
@@ -1849,10 +1639,6 @@ class LocalTest(unittest.TestCase):
     def test_apm_server_kibana_url(self):
         apmServer = ApmServer(apm_server_kibana_url="http://kibana.example.com:5601").render()["apm-server"]
         self.assertIn("apm-server.kibana.host=http://kibana.example.com:5601", apmServer["command"])
-
-    def test_apm_server_index_refresh_interval(self):
-        apmServer = ApmServer(apm_server_index_refresh_interval="10ms").render()["apm-server"]
-        self.assertIn("setup.template.settings.index.refresh_interval=10ms", apmServer["command"])
 
     def test_parse(self):
         cases = [

--- a/tests/agent/concurrent_requests.py
+++ b/tests/agent/concurrent_requests.py
@@ -60,7 +60,7 @@ class Concurrent:
         def count(self, name):
             return self.no_per_event.get(name, 0) * self.events_no
 
-    def __init__(self, elasticsearch, endpoints, iters=1, index="apm-*"):
+    def __init__(self, elasticsearch, endpoints, iters=1, index="apm-*,traces-apm*,metrics-apm*,logs-apm*"):
         self.num_reqs = 0
         self.index = index
         # TODO: improve ES handling

--- a/tests/fixtures/es.py
+++ b/tests/fixtures/es.py
@@ -16,10 +16,11 @@ def es():
             self.es = elasticsearch.Elasticsearch(url,
                                                   verify_certs=verify,
                                                   connection_class=elasticsearch.RequestsHttpConnection)
-            self.index = "apm-*"
+            self.index = "apm-*,traces-apm*,metrics-apm*,logs-apm*"
 
         def clean(self):
-            self.es.indices.delete(self.index)
+            self.es.indices.delete(index=self.index)
+            self.es.indices.delete_data_stream(name=self.index)
             self.es.indices.refresh()
 
         def term_q(self, filters):
@@ -36,6 +37,7 @@ def es():
         def count(self, q):
             ct = 0
             while ct == 0:
+                self.es.indices.refresh(index=self.index)
                 s = self.es.count(index=self.index, body=q)
                 ct = s['count']
                 if ct:


### PR DESCRIPTION
## What does this PR do?

- Jaeger gRPC is now always on, with no config, on the standard 8200 port.
- Secret token and API Key auth configuration names have changed.
- There is no longer an option to keep unsampled transactions.
- For self-instrumentation, the `apm-server.instrumentaton` config is no longer supported; we now use the libbeat `instrumentation` config.
- ILM configuration and index suffix configuration are no longer supported.
- Agent configuration cannot be disabled.
- Template setup via apm-server is no longer supported.
- Pipeline setup via apm-server is no longer supported.
- Remove the option to write to data streams; it is now enabled implicitly for 8.0+. Update tests to search data streams as well as legacy indices.

We now run a container to call the Fleet setup API when Kibana is enabled, in order to install the APM integration. Update Kibana healthcheck to wait for Kibana to be completely ready before calling the setup API.

Fleet requires security to be enabled, so we no longer disable security by default in CI.