### PR TITLE
[mergify] notify to the assignee if PR was not merged yet

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -67,7 +67,7 @@ pull_request_rules:
       - -closed
       - author=mergify[bot]
       - "#check-success>0"
-      - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
       #- created-at<3 days ago
     actions:
       comment:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -61,3 +61,15 @@ pull_request_rules:
       - head~=^update-stack-version
     actions:
       delete_head_branch:
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
+      #- created-at<3 days ago
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏


### PR DESCRIPTION
## What does this PR do?

Send automated notifications when backported PRs created by `mergify` have not been merged yet. 
This will verify only those PRs created by `mergify` every day and in case they have not been merged yet, then a GitHub comment will be added.

## Why is it important?

Ensure the notifications regarding missing merged backports are addressed.

## Issues

Similar to https://github.com/elastic/e2e-testing/pull/1792