### PR TITLE
chore: remove oss tests for master

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -1,4 +1,3 @@
 APM_SERVER:
   - master
-  - master --apm-server-oss
   - master --ubi8


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
The OSS Docker images version are not generated on 8.1
