### PR TITLE
Disable build parallelization

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -152,7 +152,7 @@ def runJob(testName, buildOpts = ''){
       string(name: 'MERGE_TARGET', value: "${mergeTarget}"),
       string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
       string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
-      booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
+      booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: true)],
       propagate: true,
       quietPeriod: 10,
       wait: true)


### PR DESCRIPTION
## What does this PR do?

This should disable build parallelization. The number of builds we attempt in parallel seems as if it may be causing problems in the 7.x branch:

<img width="241" alt="Screen Shot 2021-12-07 at 11 35 25 AM" src="https://user-images.githubusercontent.com/111616/145013517-563a0623-a0aa-44e7-9d30-f44b1e2a6782.png">

```
[2021-12-07T03:37:26.768Z] Successfully built 5ec7bf95a010

[2021-12-07T03:37:26.768Z] Successfully tagged apm-integration-testing_agent-java-spring:latest

[2021-12-07T03:37:26.768Z] Building agent-java-spring    ... done

[2021-12-07T03:37:26.768Z] 

[2021-12-07T03:37:26.768Z] ERROR: for agent-go-net-http  UnixHTTPConnectionPool(host='localhost', port=None): Pool is closed.

[2021-12-07T03:37:26.768Z] Couldn't connect to Docker daemon at http+docker://localhost - is it running?

[2021-12-07T03:37:26.768Z] 

[2021-12-07T03:37:26.768Z] If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.

[2021-12-07T03:37:26.768Z] Starting/Building stack services..

[2021-12-07T03:37:26.768Z] 

[2021-12-07T03:37:26.768Z] Traceback (most recent call last):

[2021-12-07T03:37:26.768Z]   File "scripts/compose.py", line 31, in <module>

[2021-12-07T03:37:26.768Z]     main()

[2021-12-07T03:37:26.768Z]   File "scripts/compose.py", line 17, in main

[2021-12-07T03:37:26.768Z]     setup()

[2021-12-07T03:37:26.768Z]   File "/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 208, in __call__

[2021-12-07T03:37:26.768Z]     self.args.func()

[2021-12-07T03:37:26.768Z]   File "/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 599, in start_handler

[2021-12-07T03:37:26.768Z]     self.build_start_handler("start")

[2021-12-07T03:37:26.769Z]   File "/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 748, in build_start_handler

[2021-12-07T03:37:26.769Z]     self.run_docker_compose_process(docker_compose_build + build_services)

[2021-12-07T03:37:26.769Z]   File "/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing/scripts/modules/cli.py", line 485, in run_docker_compose_process

[2021-12-07T03:37:26.769Z]     subprocess.check_call(docker_compose_cmd)

[2021-12-07T03:37:26.769Z]   File "/usr/lib/python3.6/subprocess.py", line 311, in check_call

[2021-12-07T03:37:26.769Z]     raise CalledProcessError(retcode, cmd)

[2021-12-07T03:37:26.769Z] subprocess.CalledProcessError: Command '['docker-compose', '-f', '/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing/docker-compose.yml', '--no-ansi', '--log-level', 'ERROR', 'build', '--pull', '--parallel', 'agent-dotnet', 'agent-go-net-http', 'agent-python-flask', 'agent-python-django', 'agent-nodejs-express', 'agent-rumjs', 'agent-java-spring', 'agent-php-apache', 'agent-ruby-rails']' returned non-zero exit status 1.

[2021-12-07T03:37:26.769Z] Makefile:75: recipe for target 'start-env' failed

[2021-12-07T03:37:26.769Z] make[1]: *** [start-env] Error 1

[2021-12-07T03:37:26.769Z] make[1]: Leaving directory '/var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing'

[2021-12-07T03:37:26.769Z] Makefile:96: recipe for target 'env-agent-all' failed

[2021-12-07T03:37:26.769Z] make: *** [env-agent-all] Error 2

script returned exit code 2
```

This may end up having a significant performance impact on the speed of the APM Integration Tests in CI so we'll need to measure that and then weigh whether or not it's worth it.


