### PR TITLE
fix: update the pytest-otel version to the minimum that support auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,4 @@ virtualenv==16.7.9
 waiting==1.4.1
 webium==1.2.1
 websocket-client==0.54.0
-pytest-otel==0.0.2
+pytest-otel>=0.0.4


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* bump the version of the pytest_otel plugin

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The feature to send the headers is broken in Otel Python 1.7 so we have to revert the version to 1.5, this change is in pytest-otel 0.0.4

## Related issues
related to  https://github.com/elastic/apm-pipeline-library/pull/1452
