### PR TITLE
fix: set the correct APM Server environment variable for the RUM agent

### DIFF
--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -36,7 +36,7 @@ class AgentRUMJS(Service):
     def _content(self):
         default_environment = {
             "ELASTIC_APM_SERVICE_NAME": "rum",
-            "ELASTIC_APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
+            "APM_SERVER_URL": self.options.get("apm_server_url", DEFAULT_APM_SERVER_URL),
             "ELASTIC_APM_VERIFY_SERVER_CERT": str(not self.options.get("no_verify_server_cert")).lower(),
             "ELASTIC_APM_LOG_LEVEL": self.options.get("apm_log_level") or DEFAULT_APM_LOG_LEVEL
         }


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* replaces `ELASTIC_APM_SERVER_URL` env var with `APM_SERVER_URL`

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The RUM agent check the `APM_SERVER_URL` so because we are passing `ELASTIC_APM_SERVER_URL` the ESS test fails on ESS where the URL is not the default one `https://localhost:8200`. After this change the APM ITs on ESS should pass.
