### PR TITLE
jjbb: keep the mbp tidy

### DIFF
--- a/.ci/jobs/apm-integration-test-downstream.yml
+++ b/.ci/jobs/apm-integration-test-downstream.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
+        head-filter-regex: '(main|PR-.*|\d+\.x)'
         notification-context: 'apm-ci/downstream'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        head-filter-regex: '(main|PR-.*|\d+\.x)'
         notification-context: 'apm-ci/selector'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        head-filter-regex: '(main|PR-.*|\d+\.x)'
         notification-context: 'apm-ci/upgrade'
         property-strategies:
           all-branches:


### PR DESCRIPTION
## What does this PR do?

Filter upstream branches from being created with the MBP. I also used now `main`

## Why is it important?

Normalise the filtering also in some other MBPs.
