### PR TITLE
Fixed multiple span->end() calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ target/
 
 # For the cache java dependencies
 docker/java/spring/.m2
-
-docker/opbeans-loadgen

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ target/
 
 # For the cache java dependencies
 docker/java/spring/.m2
+
+docker/opbeans-loadgen

--- a/docker/php/apache/app/foo/index.php
+++ b/docker/php/apache/app/foo/index.php
@@ -14,12 +14,12 @@ function dummyFuncToAddDepthToStacktrace(int $depthLeft): void
     global $span;
 
     // It's 2 because current dummyFuncToAddDepthToStacktrace frame
-    // and $span->end() frame are counted
+    // and frame for call to $span->end() below are included in span's stacktrace
     if ($depthLeft > 2) {
         dummyFuncToAddDepthToStacktrace($depthLeft - 1);
+    } else {
+        $span->end();
     }
-
-    $span->end();
 }
 
 dummyFuncToAddDepthToStacktrace(16);


### PR DESCRIPTION
## What does this PR do?

PHP test app incorrectly calls span->end() more than once.

## Why is it important?
- Somebody looking at the test PHP application might think that it's okay to call `span->end()` more than once which is not the case
- The rest of the calls to `span->end()` (i.e., the calls after the first one) cause the agent to log some warning message which might be confusing when investigate unrelated issues.