### PR TITLE
Resolve Kibana 8.0 deprecations

### DIFF
--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1035,9 +1035,12 @@ class Kibana(StackService, Service):
                 self.environment["XPACK_SECURITY_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
                 self.environment["XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY"] = "fhjskloppd678ehkdfdlliverpoolfcr"
             if self.at_least_version("7.8"):
-                self.environment["XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST"] = urls[0]
-                self.environment["XPACK_FLEET_AGENTS_KIBANA_HOST"] = "{}://kibana:{}".format(
-                    "https" if self.kibana_tls else "http", self.SERVICE_PORT)
+                if self.at_least_version("7.16.0"):
+                    self.environment["XPACK_FLEET_AGENTS_ELASTICSEARCH_HOSTS"] = json.dumps(urls)
+                else:
+                    self.environment["XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST"] = urls[0]
+                    self.environment["XPACK_FLEET_AGENTS_KIBANA_HOST"] = "{}://kibana:{}".format(
+                        "https" if self.kibana_tls else "http", self.SERVICE_PORT)
             if options.get("xpack_secure"):
                 self.environment["ELASTICSEARCH_PASSWORD"] = "changeme"
                 self.environment["ELASTICSEARCH_USERNAME"] = "kibana_system_user"

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -1053,6 +1053,10 @@ class Kibana(StackService, Service):
             if self.at_least_version("7.6"):
                 if not options.get("no_kibana_apm_servicemaps"):
                     self.environment["XPACK_APM_SERVICEMAPENABLED"] = "true"
+            if self.at_least_version("7.16"):
+                self.environment["XPACK_REPORTING_ROLES_ENABLED"] = "false"
+                self.environment["XPACK_SECURITY_SESSION_IDLETIMEOUT"] = "1M"
+                self.environment["XPACK_SECURITY_SESSION_LIFESPAN"] = "3M"
             if self.kibana_tls:
                 certs = "/usr/share/kibana/config/certs/tls.crt"
                 certsKey = "/usr/share/kibana/config/certs/tls.key"

--- a/scripts/tests/test_localsetup.py
+++ b/scripts/tests/test_localsetup.py
@@ -833,14 +833,16 @@ class LocalTest(unittest.TestCase):
                     TELEMETRY_ENABLED: 'false',
                     XPACK_APM_SERVICEMAPENABLED: 'true',
                     XPACK_MONITORING_ENABLED: 'true',
+                    XPACK_REPORTING_ROLES_ENABLED: 'false',
                     XPACK_SECURITY_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
                     XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: 'fhjskloppd678ehkdfdlliverpoolfcr',
-                    XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST: 'http://elasticsearch:9200',
-                    XPACK_FLEET_AGENTS_KIBANA_HOST: 'http://kibana:5601',
+                    XPACK_FLEET_AGENTS_ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]',
                     XPACK_FLEET_PACKAGES: '[{"name":"apm","version":"latest"}]',
                     XPACK_FLEET_REGISTRYURL: 'https://epr-snapshot.elastic.co',
                     XPACK_XPACK_MAIN_TELEMETRY_ENABLED: 'false',
-                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).'
+                    XPACK_SECURITY_LOGINASSISTANCEMESSAGE: 'Login&#32;details:&#32;`admin/changeme`.&#32;Further&#32;details&#32;[here](https://github.com/elastic/apm-integration-testing#logging-in).',
+                    XPACK_SECURITY_SESSION_IDLETIMEOUT: '1M',
+                    XPACK_SECURITY_SESSION_LIFESPAN: '3M',
                 }
                 healthcheck:
                     interval: 10s


### PR DESCRIPTION
## What does this PR do?

Resolves 2 critical and 3 warning level deprecations reported by kibana 7.16:

![image](https://user-images.githubusercontent.com/83483/147491137-6483b55f-146f-4c29-b090-0d0870c5ceae.png)

## Why is it important?

To help automate 8.0 upgrade testing.  Currently these settings are updated manually while testing.
