### PR TITLE
bump automation: use 7.17 branch

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -16,7 +16,7 @@ else
 fi
 
 ### Queries to the 7.x branch
-GO_VERSION=$(curl -s https://raw.githubusercontent.com/elastic/apm-server/7.x/.go-version)
+GO_VERSION=$(curl -s https://raw.githubusercontent.com/elastic/apm-server/7.17/.go-version)
 
 echo "Update go version ${GO_VERSION}"
 ${SED} -E -e "s#go_version=.*#go_version=${GO_VERSION}#g" docker/apm-server/Dockerfile


### PR DESCRIPTION
## What does this PR do?

Use `7.17` since `7.x` is not a thing anymore

## Why is it important?

Otherwise it won't work the automation