### PR TITLE
[6.x] apm-agent-ruby: healthcheck for 3.1 version is broken (#1361)

### DIFF
--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=latest
+ARG RUBY_VERSION=3.0
 FROM ruby:${RUBY_VERSION}
 
 RUN apt-get -qq update && \

--- a/scripts/compose.py
+++ b/scripts/compose.py
@@ -1028,7 +1028,7 @@ class AgentRubyRails(Service):
     DEFAULT_AGENT_REPO = "elastic/apm-agent-ruby"
     DEFAULT_AGENT_VERSION = "latest"
     DEFAULT_AGENT_VERSION_STATE = "release"
-    DEFAULT_RUBY_VERSION = "latest"
+    DEFAULT_RUBY_VERSION = "3.0"
     SERVICE_PORT = 8020
 
     @classmethod

--- a/scripts/tests/service_tests.py
+++ b/scripts/tests/service_tests.py
@@ -138,7 +138,7 @@ class AgentServiceTest(ServiceTest):
                         dockerfile: Dockerfile
                         context: docker/ruby/rails
                         args:
-                            RUBY_VERSION: latest
+                            RUBY_VERSION: '3.0'
                     container_name: railsapp
                     command: bash -c "bundle install && RAILS_ENV=production bundle exec rails s -b 0.0.0.0 -p 8020"
                     depends_on:


### PR DESCRIPTION
Backports the following commits to 6.x:
 - apm-agent-ruby: healthcheck for 3.1 version is broken (#1361)