### PR TITLE
[7.x] Default to opbeans-go and apm-agent-go 1.x

### DIFF
--- a/docker/go/nethttp/Dockerfile
+++ b/docker/go/nethttp/Dockerfile
@@ -3,7 +3,7 @@ ENV GO111MODULE=on
 WORKDIR /src/testapp
 COPY . /src/testapp
 ARG GO_AGENT_REPO=elastic/apm-agent-go
-ARG GO_AGENT_BRANCH=master
+ARG GO_AGENT_BRANCH=1.x
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/apm-agent-go
 RUN (cd /src/apm-agent-go \
   && git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*' \

--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -5,7 +5,7 @@
 FROM golang:1.15
 ENV GO111MODULE=on
 ARG OPBEANS_GO_REPO=elastic/opbeans-go
-ARG OPBEANS_GO_BRANCH=main
+ARG OPBEANS_GO_BRANCH=1.x
 WORKDIR /src/opbeans-go
 
 RUN git clone https://github.com/${OPBEANS_GO_REPO}.git . \
@@ -14,7 +14,7 @@ RUN git clone https://github.com/${OPBEANS_GO_REPO}.git . \
 RUN rm -fr vendor/go.elastic.co/apm
 
 ARG GO_AGENT_REPO=elastic/apm-agent-go
-ARG GO_AGENT_BRANCH=master
+ARG GO_AGENT_BRANCH=1.x
 
 RUN git clone https://github.com/${GO_AGENT_REPO}.git /src/go.elastic.co/apm
 RUN (cd /src/go.elastic.co/apm \

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -171,9 +171,9 @@ class OpbeansDotnet01(OpbeansDotnet):
 
 class OpbeansGo(OpbeansService):
     SERVICE_PORT = 3003
-    DEFAULT_AGENT_BRANCH = "master"
+    DEFAULT_AGENT_BRANCH = "1.x"
     DEFAULT_AGENT_REPO = "elastic/apm-agent-go"
-    DEFAULT_OPBEANS_BRANCH = "main"
+    DEFAULT_OPBEANS_BRANCH = "1.x"
     DEFAULT_OPBEANS_REPO = "elastic/opbeans-go"
     DEFAULT_SERVICE_NAME = "opbeans-go"
     DEFAULT_ELASTIC_APM_ENVIRONMENT = "production"

--- a/scripts/tests/test_localsetup.py
+++ b/scripts/tests/test_localsetup.py
@@ -117,9 +117,9 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/go
                       args:
-                        - GO_AGENT_BRANCH=master
+                        - GO_AGENT_BRANCH=1.x
                         - GO_AGENT_REPO=elastic/apm-agent-go
-                        - OPBEANS_GO_BRANCH=main
+                        - OPBEANS_GO_BRANCH=1.x
                         - OPBEANS_GO_REPO=elastic/opbeans-go
                     container_name: localtesting_6.3.10_opbeans-go
                     ports:


### PR DESCRIPTION
## What does this PR do?

This PR changes the 7.x branch to default to the 1.x branch of both opbeans-go and apm-agent-go. In the main branch we'll test apm-agent-go v2, and in the 7.x branch we'll test v1.

## Why is it important?

We'll be bumping the major version of the Go agent, which will require changes to opbeans-go and the nethttp program's imports at least. We could alternatively create separate services for apm-agent-go v2, but I think that is overly complex.

## Related issues

https://github.com/elastic/apm-agent-go/issues/1184