### PR TITLE
apm: Neutral naming for apm-agent-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ It is possible to configure some options and versions to run by defining environ
 
 * `APM_AGENT_PHP_VERSION`: selects the agent PHP version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
 
-* `APM_AGENT_PYTHON_VERSION`: selects the agent Python version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
+* `APM_AGENT_PYTHON_VERSION`: selects the agent Python version to use. By default it uses the main branch. See [specify an agent version](#specify-an-agent-version)
 
 * `APM_AGENT_RUBY_VERSION`: selects the agent Ruby version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
 

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -266,7 +266,7 @@ class AgentPython(Service):
         parser.add_argument(
             '--python-agent-package',
             default=cls.DEFAULT_AGENT_PACKAGE,
-            help='Use Python agent version (github;master, github;1.x, github;v3.0.0, release;latest, ...)',
+            help='Use Python agent version (github;main, github;1.x, github;v3.0.0, release;latest, ...)',
         )
         # prevent calling again
         cls._agent_python_arguments_added = True

--- a/tests/versions/python.yml
+++ b/tests/versions/python.yml
@@ -2,6 +2,6 @@ PYTHON_AGENT:
   # github;version -> pip install elastic-apm==git+https://github.com/elastic/apm-agent-python.git@version
   # release;latest -> pip install elastic-apm
   # release;release -> pip install elastic-apm==version
-  - 'github;master'
+  - 'github;main'
   - 'release;latest'
   - 'release;4.2.2'


### PR DESCRIPTION
Neutral naming for elastic/apm-agent-python

**Requires** https://github.com/elastic/apm-agent-python/pull/1447