### PR TITLE
apm: Neutral naming for apm-agent-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ It is possible to configure some options and versions to run by defining environ
 
 * `APM_AGENT_PYTHON_VERSION`: selects the agent Python version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
 
-* `APM_AGENT_RUBY_VERSION`: selects the agent Ruby version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
+* `APM_AGENT_RUBY_VERSION`: selects the agent Ruby version to use. By default it uses the main branch. See [specify an agent version](#specify-an-agent-version)
 
 #### Specify an Agent Version
 

--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update && \
 
 ## Whether the reference is a branch or a git commit to be used within the Gemfile
 ARG RUBY_AGENT_REPO=elastic/apm-agent-ruby
-ARG RUBY_AGENT_VERSION=master
+ARG RUBY_AGENT_VERSION=main
 ENV RUBY_AGENT_REPO=$RUBY_AGENT_REPO
 ENV RUBY_AGENT_VERSION=$RUBY_AGENT_VERSION
 

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -360,7 +360,7 @@ class AgentRubyRails(Service):
         parser.add_argument(
             "--ruby-agent-version",
             default=cls.DEFAULT_AGENT_VERSION,
-            help='Use Ruby agent version (master, 1.x, latest, ...)',
+            help='Use Ruby agent version (main, 1.x, latest, ...)',
         )
         parser.add_argument(
             "--ruby-agent-version-state",


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-ruby

### Issues

**Requires** elastic/apm-agent-ruby#1219