### PR TITLE
Neutral naming for apm-agent-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ It is possible to configure some options and versions to run by defining environ
 
 * `APM_SERVER_BRANCH`: selects the APM Server version to use on tests. By default it uses the master branch. You can choose any branch or tag from the Github repo.
 
-* `APM_AGENT_DOTNET_VERSION`: selects the agent .NET version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
+* `APM_AGENT_DOTNET_VERSION`: selects the agent .NET version to use. By default it uses the main branch. See [specify an agent version](#specify-an-agent-version)
 
 * `APM_AGENT_GO_VERSION`: selects the agent Go version to use. By default it uses the master branch. See [specify an agent version](#specify-an-agent-version)
 

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
-ARG DOTNET_AGENT_BRANCH=master
+ARG DOTNET_AGENT_BRANCH=main
 ARG DOTNET_AGENT_VERSION=
 # Workaround for https://github.com/dotnet/sdk/issues/14497
 ARG DOTNET_HOST_PATH=/usr/share/dotnet/dotnet

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS opbeans-dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
-ARG DOTNET_AGENT_BRANCH=master
+ARG DOTNET_AGENT_BRANCH=main
 ARG DOTNET_AGENT_VERSION=
 ARG OPBEANS_DOTNET_REPO=elastic/opbeans-dotnet
 ARG OPBEANS_DOTNET_BRANCH=main

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -542,7 +542,7 @@ class AgentJavaSpring(Service):
 
 class AgentDotnet(Service):
     SERVICE_PORT = 8100
-    DEFAULT_AGENT_VERSION = "master"
+    DEFAULT_AGENT_VERSION = "main"
     DEFAULT_AGENT_RELEASE = ""
     DEFAULT_AGENT_REPO = "elastic/apm-agent-dotnet"
 
@@ -552,7 +552,7 @@ class AgentDotnet(Service):
         parser.add_argument(
             "--dotnet-agent-version",
             default=cls.DEFAULT_AGENT_VERSION,
-            help='Use .NET agent version (master, 0.0.0.2, 0.0.0.1, ...)',
+            help='Use .NET agent version (main, 0.0.0.2, 0.0.0.1, ...)',
         )
         parser.add_argument(
             "--dotnet-agent-release",

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -84,7 +84,7 @@ class OpbeansService(Service):
 
 class OpbeansDotnet(OpbeansService):
     SERVICE_PORT = 3004
-    DEFAULT_AGENT_BRANCH = "master"
+    DEFAULT_AGENT_BRANCH = "main"
     DEFAULT_AGENT_REPO = "elastic/apm-agent-dotnet"
     DEFAULT_SERVICE_NAME = "opbeans-dotnet"
     DEFAULT_AGENT_VERSION = ""

--- a/scripts/tests/test_localsetup.py
+++ b/scripts/tests/test_localsetup.py
@@ -54,7 +54,7 @@ class OpbeansServiceTest(ServiceTest):
                       dockerfile: Dockerfile
                       context: docker/opbeans/dotnet
                       args:
-                        - DOTNET_AGENT_BRANCH=master
+                        - DOTNET_AGENT_BRANCH=main
                         - DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
                         - DOTNET_AGENT_VERSION=
                         - OPBEANS_DOTNET_BRANCH=main

--- a/scripts/tests/test_service.py
+++ b/scripts/tests/test_service.py
@@ -389,7 +389,7 @@ class AgentServiceTest(ServiceTest):
                 agent-dotnet:
                     build:
                         args:
-                            DOTNET_AGENT_BRANCH: master
+                            DOTNET_AGENT_BRANCH: main
                             DOTNET_AGENT_VERSION: ""
                             DOTNET_AGENT_REPO: elastic/apm-agent-dotnet
                         dockerfile: Dockerfile

--- a/tests/versions/dotnet.yml
+++ b/tests/versions/dotnet.yml
@@ -1,2 +1,2 @@
 DOTNET_AGENT:
-  - 'github;master'
+  - 'github;main'


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-dotnet

### Issues

**Requires** https://github.com/elastic/apm-agent-dotnet/pull/1606