### PR TITLE
apm: Neutral naming for apm-agent-rum-js

### DIFF
--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-slim
 
-ARG RUM_AGENT_BRANCH=master
+ARG RUM_AGENT_BRANCH=main
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -8,7 +8,7 @@ from .service import Service, DEFAULT_APM_SERVER_URL, DEFAULT_APM_LOG_LEVEL
 
 class AgentRUMJS(Service):
     SERVICE_PORT = 8000
-    DEFAULT_AGENT_BRANCH = "master"
+    DEFAULT_AGENT_BRANCH = "main"
     DEFAULT_AGENT_REPO = "elastic/apm-agent-rum-js"
 
     def __init__(self, **options):

--- a/tests/versions/rum.yml
+++ b/tests/versions/rum.yml
@@ -1,5 +1,4 @@
 RUM_AGENT:
-  - 'github;master'
+  - 'github;main'
 
 exclude:
-


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-rum-js

### Issues

**Requires** https://github.com/elastic/apm-agent-rum-js/pull/1141

