### PR TITLE
apm-agent-ruby: main is the default branch

### DIFF
--- a/tests/versions/ruby.yml
+++ b/tests/versions/ruby.yml
@@ -2,6 +2,6 @@ RUBY_AGENT:
   # github;version -> gem 'elastic-apm', git: 'https://github.com/elastic/apm-agent-ruby.git', branch: version
   # release;latest -> gem elastic-apm
   # release;version -> gem elastic-apm, version
-  - 'github;master'
+  - 'github;main'
   - 'release;latest'
   - 'github;2.x'


### PR DESCRIPTION
## What does this PR do?

Update main reference for the apm-agent-ruby

## Why is it important?

Leftover from https://github.com/elastic/apm-integration-testing/pull/1378