### PR TITLE
mergify: unblock merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,6 +36,7 @@ pull_request_rules:
           - backport
   - name: automatic merge backported Pull Requests from mergify when CI passes.
     conditions:
+      - check-success=apm-ci/pr-merge
       - author=mergify[bot]
       - label=backport
       - base=7.x
@@ -46,6 +47,7 @@ pull_request_rules:
   - name: automatic merge when CI passes and the file tests/versions/apm_server.yml is modified.
     conditions:
       - files~=^tests/versions/apm_server.yml$
+      - check-success=apm-ci/pr-merge
     actions:
       queue:
         name: auto-merge
@@ -53,6 +55,7 @@ pull_request_rules:
   - name: automatic merge when CI passes and the file scripts/modules/cli.py is modified.
     conditions:
       - files~=^scripts/modules/cli.py$
+      - check-success=apm-ci/pr-merge
     actions:
       queue:
         name: auto-merge


### PR DESCRIPTION
## What does this PR do?

Add a condition to filter when a PR should be added to the merge queue

## Why is it important?

To unblock the merge queue


![image](https://user-images.githubusercontent.com/2871786/150343848-608f436a-42c5-499b-ad7a-5321056b7332.png)


![image](https://user-images.githubusercontent.com/2871786/150343894-33212b0f-d7c0-47c8-80e1-f96ffb1b7d26.png)
