### PR TITLE
docker/opbeans/go: strip vN from replacement path

### DIFF
--- a/docker/opbeans/go/Dockerfile
+++ b/docker/opbeans/go/Dockerfile
@@ -26,7 +26,7 @@ RUN (cd /src/go.elastic.co/apm \
 ENV GOFLAGS=-mod=mod
 
 # Add "replace" stanzas to go.mod to use the local agent repo
-RUN go list -m all | grep apm | cut -d' ' -f1 | xargs -i go mod edit -replace {}=/src/{}
+RUN go list -m all | grep apm | cut -d' ' -f1 | sed -e 's_\(.*\)/v[0-9]\+$_\1_' | xargs -i go mod edit -replace {}=/src/{}
 RUN go build
 
 # Stage 1: copy static assets from opbeans/opbeans-frontend and


### PR DESCRIPTION
## What does this PR do?

When replacing go.elastic.co/apm modules for opbeans-go, strip the trailing /vN (e.g. /v2) from the module paths to form the directory structure. The version suffix is only present in module files, not in the directory structure.

## Why is it important?

This will be required to replace modules to a local checkout when we add `/v2` suffixes to APM Agent modules.

## Related issues

Related to https://github.com/elastic/apm-agent-go/issues/1184