### PR TITLE
remove EOL versions 7.7 and 7.8

### DIFF
--- a/tests/versions/apm_server.yml
+++ b/tests/versions/apm_server.yml
@@ -6,5 +6,3 @@ APM_SERVER:
   - '7.11;--release'
   - '7.10;--release'
   - '7.9;--release'
-  - '7.8;--release'
-  - '7.7;--release'


### PR DESCRIPTION
## What does this PR do?

7.7 and 7.8 already reached the EOL.

![image](https://user-images.githubusercontent.com/2871786/151188091-7e6ec4c8-1636-4cb4-a5d7-c519ffaafd45.png)

https://www.elastic.co/support/eol