### PR TITLE
apm-agent-go: 7.x support uses 1.x version

### DIFF
--- a/tests/versions/go.yml
+++ b/tests/versions/go.yml
@@ -1,3 +1,3 @@
 GO_AGENT:
-  - 'github;main'
+  - 'github;1.x'
   - 'release;v1.9.0'


### PR DESCRIPTION
## What does this PR do?

This PR changes the 7.x branch to default to the 1.x branch of both opbeans-go and apm-agent-go. In the main branch we'll test apm-agent-go v2, and in the 7.x branch we'll test v1.

## Why is it important?

We'll be bumping the major version of the Go agent, which will require changes to opbeans-go and the nethttp program's imports at least. We could alternatively create separate services for apm-agent-go v2, but I think that is overly complex.

## Related issues

Relates https://github.com/elastic/apm-integration-testing/pull/1367
