### PR TITLE
Update dockerfile for opbeans-dotnet to use .NET6

### DIFF
--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -4,7 +4,7 @@
 #   if unset then it uses the build generated above. (TODO: to be done)
 # DOTNET_AGENT_REPO and DOTNET_AGENT_BRANCH parameterise the DOTNET agent
 # repo and branch (or commit) to use.
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS opbeans-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS opbeans-dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 ARG DOTNET_AGENT_REPO=elastic/apm-agent-dotnet
 ARG DOTNET_AGENT_BRANCH=main
@@ -18,6 +18,8 @@ COPY . /src
 # install SDK version in global.json of elastic/apm-agent-dotnet
 # Needed when building branches that specify 3.1.100 SDK in global.json
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
+# SDK 5.x is also needed
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 5.0.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app


### PR DESCRIPTION
Bump .NET version to .NET6

## What does this PR do?

In the main agent repo, I'm updating the code base to build and test on .NET 6. This PR updates the docker file where we build the agent as well.

## Why is it important?

Otherwise we can't build the tests.

## Related issues

PR in the .NET agent repo: https://github.com/elastic/apm-agent-dotnet/pull/1605

Leftovers from https://github.com/elastic/apm-integration-testing/pull/1412