### PR TITLE
chore: EOL of 6.x

### DIFF
--- a/.ci/jobs/apm-integration-test-downstream.yml
+++ b/.ci/jobs/apm-integration-test-downstream.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        head-filter-regex: '(main|PR-.*|\d+\.x)'
+        head-filter-regex: '(main|PR-.*|[78]\.x)'
         notification-context: 'apm-ci/downstream'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-integration-tests-selector-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-selector-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '(main|PR-.*|\d+\.x)'
+        head-filter-regex: '(main|PR-.*|[78]\.x)'
         notification-context: 'apm-ci/selector'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
+++ b/.ci/jobs/apm-integration-tests-upgrade-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '(main|PR-.*|\d+\.x)'
+        head-filter-regex: '(main|PR-.*|[78]\.x)'
         notification-context: 'apm-ci/upgrade'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-integration-tests.yml
+++ b/.ci/jobs/apm-integration-tests.yml
@@ -11,7 +11,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        head-filter-regex: '(main|PR-.*|\d+\.x)'
+        head-filter-regex: '(main|PR-.*|[78]\.x)'
         discover-tags: true
         notification-context: 'apm-ci'
         repo: apm-integration-testing

--- a/.ci/jobs/apm-it-ec.yml
+++ b/.ci/jobs/apm-it-ec.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        head-filter-regex: '(main|PR-.*|\d+\.x)'
+        head-filter-regex: '(main|PR-.*|[78]\.x)'
         discover-tags: true
         notification-context: 'apm-it-ec'
         property-strategies:

--- a/.ci/jobs/apm-it-eck.yml
+++ b/.ci/jobs/apm-it-eck.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        head-filter-regex: '(main|PR-.*|\d+\.x)'
+        head-filter-regex: '(main|PR-.*|[78]\.x)'
         discover-tags: true
         notification-context: 'apm-it-eck'
         property-strategies:


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Stop build 6.x branch

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

6.8 raise its EOL at 2022-02-08
