### PR TITLE
Allow `opbeans-loadgen` to run without webserver

### DIFF
--- a/docker/apm-server/teeproxy/Dockerfile
+++ b/docker/apm-server/teeproxy/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang
 ENV CGO_ENABLED=0
 # use fork to quickly pin https://github.com/chrislusf/teeproxy
-RUN go get -v github.com/graphaelli/teeproxy
-RUN go install github.com/graphaelli/teeproxy
+RUN go install github.com/graphaelli/teeproxy@latest
 CMD ["teeproxy"]

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -760,6 +760,6 @@ class OpbeansLoadGenerator(Service):
         )
 
         if not self.non_interactive:
-            content["environment"].append("WS=1")
+            content["environment"].insert(0, "WS=1")
 
         return content

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -709,6 +709,12 @@ class OpbeansLoadGenerator(Service):
     @classmethod
     def add_arguments(cls, parser):
         super(OpbeansLoadGenerator, cls).add_arguments(parser)
+        parser.add_argument(
+            '--loadgen-no-ws',
+            action='store_true',
+            default=False,
+            help='Disable the webserver mode and just run the load generator'
+        )
         for service_class in OpbeansService.__subclasses__():
             parser.add_argument(
                 '--no-%s-loadgen' % service_class.name(),
@@ -727,6 +733,7 @@ class OpbeansLoadGenerator(Service):
         super(OpbeansLoadGenerator, self).__init__(**options)
         self.loadgen_services = []
         self.loadgen_rpms = OrderedDict()
+        self.non_interactive = options.get("loadgen_no_ws")
         # create load for opbeans services
         run_all_opbeans = options.get('run_all_opbeans') or options.get('run_all')
         excluded = ('opbeans_load_generator', 'opbeans_rum', 'opbeans_node', 'opbeans_dotnet01', 'opbeans_go01',
@@ -746,10 +753,13 @@ class OpbeansLoadGenerator(Service):
             ports=["8999:8000"],
             depends_on={service: {'condition': 'service_healthy'} for service in self.loadgen_services},
             environment=[
-                "WS=1",
                 "OPBEANS_URLS={}".format(','.join('{0}:http://{0}:{1}'.format(s, OpbeansService.APPLICATION_PORT) for s in sorted(self.loadgen_services))),  # noqa: E501
                 "OPBEANS_RPMS={}".format(','.join('{}:{}'.format(k, v) for k, v in sorted(self.loadgen_rpms.items())))
             ],
             labels=None,
         )
+
+        if not self.non_interactive:
+            content["environment"].append("WS=1")
+
         return content


### PR DESCRIPTION
## What does this PR do?

This change adds a new flag to the `compose.py` script which allows the
`opbeans-loadgen` to run the specified RPM as configured in the flags.

As an example, before this change, setting the RPMs for each of the
opbeans applications had no effect since the opbeans-loadgen runs as a
WS and is expected to be triggered by the Dyno component.

However, it should also be possible to generate a certain amount of RPMs
without using Dyno, this PR allows just that. It introduces a new flag
`--loadgen-no-ws` which when set won't set the `WS` environment variable
in the container and thus will run the molotov scenarios. If unset, the
loadgen will behave as it previously did.

To test this you can try setting a high number of RPM with and without
the `--loadgen-no-ws` flag. For example:

```console
$ RPM=2000 ./scripts/compose.py build 8.0.0 \
--opbeans-go-loadgen-rpm ${RPM} --opbeans-python-loadgen-rpm ${RPM} \
--opbeans-ruby-loadgen-rpm ${RPM} --with-opbeans-go \
--no-apm-server-self-instrument --with-opbeans-python \
--with-opbeans-ruby --loadgen-no-ws
```

## Why is it important?

See the description.

## Related issues

Part of elastic/apm-server#7216
