### PR TITLE
recorder: Use intake receiver as recorder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ docker-compose.yml
 docker/
 htmlcov/
 venv/
+traces/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ target/
 
 # For the cache java dependencies
 docker/java/spring/.m2
+
+traces/

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ build-env-%: venv
 env-%: venv
 	$(MAKE) start-env
 
+.PHONY: copy-traces
+copy-traces:
+	docker cp $(shell docker-compose ps | grep intake-receiver | awk '{print $$1}'):/traces .
+
 test: test-all test-helps ## Run all the tests
 
 test-agent-%-version: venv

--- a/docker/intake-receiver/Dockerfile
+++ b/docker/intake-receiver/Dockerfile
@@ -1,0 +1,14 @@
+ARG go_version=1.17.7
+FROM golang:${go_version} AS build
+ENV CGO_ENABLED=0
+# TODO(marclop) After https://github.com/elastic/apm-server/pull/7416 is merged, replace git clone
+# with 'go install https://github.com/elastic/apm-server/cmd/intake-receiver@latest'.
+RUN git clone --single-branch --branch f-add-intake-receiver https://github.com/marclop/apm-server /apm-server
+RUN cd /apm-server/cmd/intake-receiver && go build .
+
+FROM alpine
+COPY --from=build /apm-server/cmd/intake-receiver/intake-receiver /intake-receiver
+RUN apk update && apk add curl jq
+ENTRYPOINT [ "/intake-receiver" ]
+
+CMD [ "-host=0.0.0.0:8200" ]

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -219,7 +219,7 @@ class ApmServer(StackService, Service):
                 self.apm_server_count = 2
             if apm_server_record:
                 self.apm_server_tee_build = {
-                    "context": "docker/apm-server/recorder",
+                    "context": "docker/intake-receiver",
                 }
             else:
                 # always build 8.0


### PR DESCRIPTION
## What does this PR do?

Swaps the current APM Server recorder for the newly introduced (and WIP)
Intake Receiver. Allowing us to capture and store the traces generated
by the Opbeans applications into ndjson files for benchmarking purposes.

The current patch uses my personal fork of APM Server to download and
install the Intake Receiver command. It will be replaced by `go install`
once we've merged the open PR in the APM Server repo.

## Why is it important?

To allow us to capture pre-generated traces into ndjson files and continue
the work on the Benchmarking 2.0 effort.

## How to test this

I've been using 5000 RPM and the following command to generate and copy the traces to my computer:

```console
$ RPM=5000; ./scripts/compose.py start 8.0.0 --opbeans-go-loadgen-rpm ${RPM} --opbeans-python-loadgen-rpm ${RPM} --opbeans-node-loadgen-rpm $((${RPM} * 2)) --opbeans-ruby-loadgen-rpm ${RPM} --with-opbeans-go --no-apm-server-self-instrument --with-opbeans-python --with-opbeans-ruby --with-opbeans-node --apm-server-record --loadgen-no-ws; sleep 180; make copy-traces; docker-compose down
$ grep -vc metadata traces/*
traces/go-2.0.0.ndjson:5234
traces/nodejs-3.29.0.ndjson:2020
traces/python-6.7.2.ndjson:7019
traces/ruby-4.5.0.ndjson:3753
```

## Related issues

Part of elastic/apm-server#7216
