### PR TITLE
mergify: remove auto-backport to 7.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=main
+      - label=backport
     actions:
       backport:
         assignees:


### PR DESCRIPTION
## What does this PR do?

7.17 will only contain patches, so there is no need to backport from main

## Why is it important?

Simplify the branch strategy and backports policy