### PR TITLE
fix bump automation to update cli.py

### DIFF
--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -23,8 +23,11 @@ fi
 
 CLI_FILE=scripts/modules/cli.py
 echo "Update stack with versions ${RELEASE_VERSION} in ${CLI_FILE}"
-# Update patch.
+# Update patch for major.minor
 ${SED} -E -e "s#('${MINOR_MAJOR_RELEASE_VERSION}'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
+# Update patch for master and main
+${SED} -E -e "s#('main'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
+${SED} -E -e "s#('master'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
 # Create a new minor release entry
 if grep -q "${MINOR_MAJOR_RELEASE_VERSION}" ${CLI_FILE} ; then
 	echo "No required changes in the ${CLI_FILE}"

--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -29,7 +29,7 @@ ${SED} -E -e "s#('${MINOR_MAJOR_RELEASE_VERSION}'): '[0-9]+\.[0-9]+\.[0-9]'#\1: 
 ${SED} -E -e "s#('main'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
 ${SED} -E -e "s#('master'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
 # Create a new minor release entry
-if grep -q "${MINOR_MAJOR_RELEASE_VERSION}" ${CLI_FILE} ; then
+if grep -q "'${MINOR_MAJOR_RELEASE_VERSION}'" ${CLI_FILE} ; then
 	echo "No required changes in the ${CLI_FILE}"
 else
 	TEMP_FILE=$(mktemp)

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -85,8 +85,9 @@ class LocalSetup(object):
         '7.15': '7.15.2',
         '7.16': '7.16.3',
         '7.17': '7.17.1',
-        'main': '8.1.0',
-        'master': '8.1.0',  # keep master alias for backward compatibility. Upgrade the main alias only
+        '8.1': '8.1.2',
+        'main': '8.1.2',
+        'master': '8.1.2',  # keep master alias for backward compatibility. Upgrade the main alias only
     }
 
     def __init__(self, argv=None, services=None):

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -85,8 +85,8 @@ class LocalSetup(object):
         '7.15': '7.15.2',
         '7.16': '7.16.3',
         '7.17': '7.17.1',
-        'master': '8.1.0',  # keep master alias for backward compatibility. Upgrade the main alias only
         'main': '8.1.0',
+        'master': '8.1.0',  # keep master alias for backward compatibility. Upgrade the main alias only
     }
 
     def __init__(self, argv=None, services=None):


### PR DESCRIPTION
## What does this PR do?

Update the `main`/`master` and `<major>.<minor>` aliases

## Why is it important?

Otherwise the patches/minor releases are not updated

## Test

If I ran `.ci/bump-stack-release-version.sh 8.1.2 ` then the `diff` produced:

```diff
diff --git a/.ci/bump-stack-release-version.sh b/.ci/bump-stack-release-version.sh
index 4f5627d..058d296 100755
--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -29,7 +29,7 @@ ${SED} -E -e "s#('${MINOR_MAJOR_RELEASE_VERSION}'): '[0-9]+\.[0-9]+\.[0-9]'#\1:
 ${SED} -E -e "s#('main'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
 ${SED} -E -e "s#('master'): '[0-9]+\.[0-9]+\.[0-9]'#\1: '${RELEASE_VERSION}'#g" ${CLI_FILE}
 # Create a new minor release entry
-if grep -q "${MINOR_MAJOR_RELEASE_VERSION}" ${CLI_FILE} ; then
+if grep -q "'${MINOR_MAJOR_RELEASE_VERSION}'" ${CLI_FILE} ; then
 	echo "No required changes in the ${CLI_FILE}"
 else
 	TEMP_FILE=$(mktemp)
diff --git a/scripts/modules/cli.py b/scripts/modules/cli.py
index 5e99acb..ad789dd 100644
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -85,8 +85,9 @@ class LocalSetup(object):
         '7.15': '7.15.2',
         '7.16': '7.16.3',
         '7.17': '7.17.1',
-        'master': '8.1.0',  # keep master alias for backward compatibility. Upgrade the main alias only
-        'main': '8.1.0',
+        '8.1': '8.1.2',
+        'main': '8.1.2',
+        'master': '8.1.2',  # keep master alias for backward compatibility. Upgrade the main alias only
     }
 
     def __init__(self, argv=None, services=None):
```

