### PR TITLE
[automation] Update Elastic stack release version 7.17.2 7.17.3

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -86,8 +86,8 @@ class LocalSetup(object):
         '7.16': '7.16.3',
         '7.17': '7.17.2',
         '8.1': '8.1.2',
-        'main': '8.1.2',
-        'master': '8.1.2',  # keep master alias for backward compatibility. Upgrade the main alias only
+        'main': '7.17.2',
+        'master': '7.17.2',  # keep master alias for backward compatibility. Upgrade the main alias only
     }
 
     def __init__(self, argv=None, services=None):


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 7.17.2 7.17.3