### PR TITLE
ci: add debug traces for the docker containers

### DIFF
--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -243,7 +243,7 @@ def wrappingup(Map params = [:]){
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: "docker-summary.txt,tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
+        artifacts: "docker-compose.yml,docker-summary.txt,tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
     if (isJunit) {
       junit(allowEmptyResults: true, keepLongStdio: true, testResults: testResultsPattern)

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -237,7 +237,7 @@ def wrappingup(Map params = [:]){
   def isJunit = params.containsKey('isJunit') ? params.get('isJunit') : true
   dir("${BASE_DIR}"){
     if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
-      sh(label: 'docker-summary.sh', script: './scripts/docker-summary.sh | tee docker-summary.txt')
+      sh(label: 'docker-summary.sh', script: './scripts/docker-summary.sh 2>&1 | tee docker-summary.txt')
     }
     sh('make stop-env || echo 0')
     def testResultsPattern = 'tests/results/*-junit*.xml'

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -237,13 +237,13 @@ def wrappingup(Map params = [:]){
   def isJunit = params.containsKey('isJunit') ? params.get('isJunit') : true
   dir("${BASE_DIR}"){
     if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
-      sh(label: 'docker-summary.sh', script: './scripts/docker-summary.sh')
+      sh(label: 'docker-summary.sh', script: './scripts/docker-summary.sh | tee docker-summary.txt')
     }
     sh('make stop-env || echo 0')
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: "tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
+        artifacts: "docker-summary.txt,tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
     if (isJunit) {
       junit(allowEmptyResults: true, keepLongStdio: true, testResults: testResultsPattern)

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -243,7 +243,7 @@ def wrappingup(Map params = [:]){
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(
         allowEmptyArchive: true,
-        artifacts: "docker-compose.yml,docker-summary.txt,tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
+        artifacts: "docker-compose.yml,docker-summary.txt,docker-info/*,tests/results/data-*.json,tests/results/packetbeat-*.json,${testResultsPattern}",
         defaultExcludes: false)
     if (isJunit) {
       junit(allowEmptyResults: true, keepLongStdio: true, testResults: testResultsPattern)

--- a/.ci/integrationTestSelector.groovy
+++ b/.ci/integrationTestSelector.groovy
@@ -236,6 +236,9 @@ pipeline {
 def wrappingup(Map params = [:]){
   def isJunit = params.containsKey('isJunit') ? params.get('isJunit') : true
   dir("${BASE_DIR}"){
+    if(currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'){
+      sh(label: 'docker-summary.sh', script: './scripts/docker-summary.sh')
+    }
     sh('make stop-env || echo 0')
     def testResultsPattern = 'tests/results/*-junit*.xml'
     archiveArtifacts(

--- a/scripts/docker-summary.sh
+++ b/scripts/docker-summary.sh
@@ -3,14 +3,17 @@ set -euo pipefail
 
 DOCKER_IDS=$(docker ps -aq)
 
+mkdir -p docker-info
+
 for id in ${DOCKER_IDS}
 do
   echo "***********************************************************"
   echo "***************Docker Container ${id}***************"
   echo "***********************************************************"
-  docker ps -af id=${id} --no-trunc
-  echo "----"
-  docker logs ${id} | tail -n 10 || echo "It is not possible to grab the logs of ${id}"
+  docker ps -af id="${id}" --no-trunc
+  echo "---- docker logs ----"
+  docker logs "${id}" | tail -n 10 || echo "It is not possible to grab the logs of ${id}"
+  docker inspect "${id}" > docker-info/"${id}"-docker-inspect.json
 done
 
 echo "*******************************************************"

--- a/scripts/docker-summary.sh
+++ b/scripts/docker-summary.sh
@@ -15,7 +15,10 @@ do
   docker logs "${id}" | tail -n 10 || echo "It is not possible to grab the logs of ${id}"
   docker inspect "${id}" > docker-info/"${id}"-docker-inspect.json
 done
-
+  echo "***********************************************************"
+  echo "***************Docker Stats***************"
+  echo "***********************************************************"
+  docker stats --no-trunc --no-stream
 echo "*******************************************************"
 echo "***************Docker Containers Summary***************"
 echo "*******************************************************"


### PR DESCRIPTION
## What does this PR do?

* Add extra step to print the docker environment
* Store docker inspect and summary in:
  * `docker-info/*.json`
  * `docker-summary.txt`
* Additionally it stores the docker-compose.yml 

## Why is it important?

https://github.com/elastic/apm-integration-testing/pull/1029 was the replacement but let's add more traces to help with the debugging
