### PR TITLE
opbeans-dotnet: use core/aspnet:3.1.7-alpine  docker image

### DIFF
--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-d
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app
-FROM mcr.microsoft.com/dotnet/aspnet:3.1-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.7-alpine AS runtime
 WORKDIR /app
 COPY --from=opbeans-dotnet /src/opbeans-dotnet/opbeans-dotnet/build ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend


### PR DESCRIPTION
## What does this PR do?

Normalise the docker image similar to the one in https://github.com/elastic/opbeans-dotnet/blob/de12bcf9c5901cd64883abab5a41820d3aff40af/Dockerfile#L8

## Why is it important?

It failed without errors immediately after running the docker container.


```bash
python3 scripts/compose.py \
 start 8.2.0 \
  --dotnet-agent-version 38f825b37405c230d8dcf6226895733e21ffe32d \
  --opbeans-dotnet-agent-branch 38f825b37405c230d8dcf6226895733e21ffe32d \
  --with-opbeans-dotnet  \
  --no-apm-server-self-instrument   \
  --apm-server-agent-config-poll=1s
```

