### PR TITLE
Fix misspellings in flag, help descriptions, and comments

### DIFF
--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -170,7 +170,7 @@ class WaitService(Service):
         self.services = services
 
     def _content(self):
-        # Sorting is not relavant to docker-compose but is included here
+        # Sorting is not relevant to docker-compose but is included here
         # to allow the tests to check for a consistently-ordered list
         for s in sorted(self.services, key=lambda x: x.name()):
             if s.name() != self.name() and s.name() != "opbeans-load-generator":

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -462,7 +462,7 @@ class ApmServer(StackService, Service):
             })
 
         volumes = []
-        # don't unconditionally add this ca so quick start can be depenedency free
+        # don't unconditionally add this ca so quick start can be dependency free
         if self.es_tls or self.kibana_tls:
             volumes.extend([
                 "./scripts/tls/ca/ca.crt:" + self.STACK_CA_PATH,
@@ -500,7 +500,7 @@ class ApmServer(StackService, Service):
                 ren = self.render_managed()
                 return ren
             else:
-                # return starndard apm-server
+                # return standard apm-server
                 return ren
 
         # save a single server for use as backend template

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -330,7 +330,7 @@ class ApmServer(StackService, Service):
             '--apm-server-enable-tls',
             action="store_true",
             dest="apm_server_enable_tls",
-            help="apm-server enable TLS with pre-configured selfsigned certificates.",
+            help="apm-server enable TLS with pre-configured self-signed certificates.",
         )
         parser.add_argument(
             '--apm-server-agent-config-poll',
@@ -805,7 +805,7 @@ class ApmManaged(StackService, Service):
             '--apm-managedr-enable-tls',
             action="store_true",
             dest="apm_server_enable_tls",
-            help="apm-server enable TLS with pre-configured selfsigned certificates.",
+            help="apm-server enable TLS with pre-configured self-signed certificates.",
         )
 
     def docker_service_name(self):
@@ -958,7 +958,7 @@ class Elasticsearch(StackService, Service):
             '--elasticsearch-enable-tls',
             action="store_true",
             dest="elasticsearch_enable_tls",
-            help="elasticsearch enable TLS with pre-configured selfsigned certificates.",
+            help="elasticsearch enable TLS with pre-configured self-signed certificates.",
         )
 
         parser.add_argument(

--- a/scripts/modules/elastic_stack.py
+++ b/scripts/modules/elastic_stack.py
@@ -802,7 +802,7 @@ class ApmManaged(StackService, Service):
             help="apm-server secret token.",
         )
         parser.add_argument(
-            '--apm-managedr-enable-tls',
+            '--apm-managed-enable-tls',
             action="store_true",
             dest="apm_server_enable_tls",
             help="apm-server enable TLS with pre-configured self-signed certificates.",

--- a/scripts/modules/opbeans.py
+++ b/scripts/modules/opbeans.py
@@ -665,7 +665,7 @@ class OpbeansRuby01(OpbeansRuby):
 
 
 class OpbeansRum(Service):
-    # FIXME this might not work with dyno because we are inherting from Service
+    # FIXME this might not work with dyno because we are inheriting from Service
     # OpbeansRum is not really an Opbeans service, so we inherit from Service
     SERVICE_PORT = 9222
 

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -190,7 +190,7 @@ class Service(object):
             '--' + cls.name() + '-env-var',
             action="append",
             dest=cls.option_name() + "_env_vars",
-            help="arbitrary enviornment variables to set"
+            help="arbitrary environment variables to set"
         )
 
     def image_download_url(self):


### PR DESCRIPTION
## What does this PR do?

This PR consists of minor spelling corrections to the help descriptions, a flag for the APM managed server, and a few comments.

## Why is it important?

The flag that enabled TLS support for the APM managed server was misspelled as `apm-managedr-enable-tls`.

An unrecognized argument error was thrown if the correctly spelled version, `apm-managed-enable-tls`, was used instead.

This made it more difficult for a user to enable TLS for the APM managed server.