### PR TITLE
fix: use npm v8 in expressapp container to workaround slow npm install from github

### DIFF
--- a/docker/nodejs/express/.npmrc
+++ b/docker/nodejs/express/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/docker/nodejs/express/Dockerfile
+++ b/docker/nodejs/express/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:12.18.1
+FROM node:16.15.0
 
 RUN mkdir -p /app
-RUN npm install express
-
-COPY app.js /app
+COPY package.json .npmrc app.js /app/
 
 WORKDIR /app
+RUN npm install
+

--- a/docker/nodejs/express/package.json
+++ b/docker/nodejs/express/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "expressapp",
+  "version": "1.0.0",
+  "private": true,
+  "main": "app.js",
+  "dependencies": {
+    "express": "*"
+  }
+}


### PR DESCRIPTION
The switch to node v16 gets use npm v8, to workaround an issue with
slow 'npm install <any github repo dependency>'. See:
    https://github.com/npm/cli/issues/4896

In our case the github repo dependency was the command given to docker
run this container:
    bash -c "npm install elastic-apm-node#SOME-COMMIT-SHA && node app.js"

This also adds a package.json to more explicitly declare we are working
with a node project workspace. Also avoid generating a package-lock file
we won't use.

Fixes: #1483
