### PR TITLE
[docker][nodejs] docker build with agent

### DIFF
--- a/docker/nodejs/express/Dockerfile
+++ b/docker/nodejs/express/Dockerfile
@@ -5,3 +5,6 @@ COPY package.json .npmrc app.js /app/
 
 WORKDIR /app
 RUN npm install
+
+ARG NODE_AGENT_PACKAGE=
+RUN npm install $NODE_AGENT_PACKAGE

--- a/scripts/modules/apm_agents.py
+++ b/scripts/modules/apm_agents.py
@@ -168,8 +168,14 @@ class AgentNodejsExpress(Service):
             environment.update(self.apm_api_key)
 
         return dict(
-            build={"context": "docker/nodejs/express", "dockerfile": "Dockerfile"},
-            command="bash -c \"npm install {} && node app.js\"".format(self.agent_package),
+            build={
+                "context": "docker/nodejs/express",
+                "dockerfile": "Dockerfile",
+                "args": {
+                    "NODE_AGENT_PACKAGE": self.agent_package,
+                },
+            },
+            command="bash -c \"node app.js\"",
             container_name="expressapp",
             healthcheck=curl_healthcheck(self.SERVICE_PORT, "expressapp"),
             depends_on=self.depends_on,


### PR DESCRIPTION
## What does this PR do?

Use the build stage for installing the nodejs agent in the nodejs app

## Why is it important?

Discover incompatibilities earlier rather than during the docker run stage.
