### PR TITLE
ci: fail at the end if downstream job failed

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -142,31 +142,27 @@ pipeline {
 def runJob(testName, buildOpts = ''){
   def mergeTarget = env.CHANGE_ID?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
   def jobName = "apm-integration-test-downstream/${env.BRANCH_NAME}"
-  def buildObject
-  try {
-    buildObject = build(job: jobName,
-      parameters: [
+  def buildObject = build(job: jobName,
+    parameters: [
       string(name: 'INTEGRATION_TEST', value: testName),
       string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
       string(name: 'INTEGRATION_TESTING_VERSION', value: "${env.GIT_BASE_COMMIT}"),
       string(name: 'MERGE_TARGET', value: "${mergeTarget}"),
       string(name: 'BUILD_OPTS', value: "${params.BUILD_OPTS} ${buildOpts}"),
       string(name: 'UPSTREAM_BUILD', value: currentBuild.fullDisplayName),
-      booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')],
-      propagate: true,
-      quietPeriod: 10,
-      wait: true)
-  } catch(e) {
-    buildObject = e
-    error("Downstream job for '${testName}' failed")
-  } finally {
-    itsDownstreamJobs["${testName}"] = buildObject
+      booleanParam(name: 'DISABLE_BUILD_PARALLEL', value: '')
+    ],
+    propagate: false,
+    quietPeriod: 10,
+    wait: true)
 
-    catchError(buildResult: 'SUCCESS', message: "Aggregate test results from dowsntream job has failed failed. Let's keep moving.") {
-      dir(testName) {
-        copyArtifacts(projectName: jobName, selector: specific(buildNumber: buildObject.number.toString()))
-        junit(testResults: '**/tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
-      }
+  itsDownstreamJobs["${testName}"] = buildObject
+
+  catchError(buildResult: 'SUCCESS', message: "Aggregate test results from dowsntream job has failed failed. Let's keep moving.") {
+    dir(testName) {
+      copyArtifacts(projectName: jobName, selector: specific(buildNumber: buildObject.number.toString()))
+      junit(testResults: '**/tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
     }
   }
+  error("Downstream job for '${testName}' failed")
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -164,5 +164,7 @@ def runJob(testName, buildOpts = ''){
       junit(testResults: '**/tests/results/*-junit*.xml', allowEmptyResults: true, keepLongStdio: true)
     }
   }
-  error("Downstream job for '${testName}' failed")
+  if (buildObject.resultIsWorseOrEqualTo('UNSTABLE')) {
+    error("Downstream job for '${testName}' failed")
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Simplify the downstreams to first notify test results and then report error.

## Why is it important?

[FlowInterruptedException](https://javadoc.jenkins.io/plugin/workflow-step-api/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.html
) does not provide the build number and https://github.com/elastic/apm-pipeline-library/pull/1638 removed the support for the extended FlowInterruptedException.


Otherwise

```
5:15:16  ERROR: Aggregate test results from dowsntream job has failed failed. Let's keep moving.
05:15:16  org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: No such field found: field org.jenkinsci.plugins.workflow.steps.FlowInterruptedException number
05:15:16  	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.unclassifiedField(SandboxInterceptor.java:426)
05:15:16  	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:410)
05:15:16  	at org.kohsuke.groovy.sandbox.impl.Checker$7.call(Checker.java:353)
05:15:16  	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:357)
05:15:16  	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:29)
05:15:16  	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
05:15:16  	at WorkflowScript.runJob(WorkflowScript:167)

```

### Implementation details
- Remove `try/catch/finally` and use `propagate: false`
- Fetch downstream artifacts since the build object will always contain the build number.
- Report error if the result for the build object is other than `SUCCESS`

### Test

I manually triggered the build `2` and expected behaviour

<img width="1224" alt="image" src="https://user-images.githubusercontent.com/2871786/177150037-3ff69273-a917-428e-8ce8-1168cf0ccacb.png">


So tests are reported, error is captured and gitHub comment with the digestd build report works as expected