### PR TITLE
tests: stop testing 2.x releases of the APM Node.js agent

### DIFF
--- a/tests/versions/nodejs.yml
+++ b/tests/versions/nodejs.yml
@@ -3,4 +3,3 @@ NODEJS_AGENT:
   # release;version -> npm install elastic-apm-node@version
   - 'github;main'
   - 'release;latest'
-  - 'release;2'


### PR DESCRIPTION
elastic-apm-node@2 is EOL.
https://www.elastic.co/guide/en/apm/agent/nodejs/current/upgrading.html#end-of-life-dates

Fixes: https://github.com/elastic/apm-agent-nodejs/issues/2802
