### PR TITLE
Add retry logic to apt and curl

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -10,6 +10,7 @@ FROM golang:${go_version} AS build
 ARG apm_server_binary
 
 # install make update prerequisites
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -qq update \
     && apt-get -qq install -y python3 python3-pip python3-venv rsync
 

--- a/docker/dotnet/Dockerfile
+++ b/docker/dotnet/Dockerfile
@@ -14,10 +14,10 @@ WORKDIR /src
 COPY . /src
 # install SDK version in global.json of elastic/apm-agent-dotnet
 # Needed when building branches that specify 3.1.100 SDK in global.json
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
+RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 
 # SDK 5.x is also needed
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 5.0.100
+RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 5.0.100
 RUN ./run.sh
 
 # Stage 2: Run the TestAspNetCoreApp app

--- a/docker/java/spring/Dockerfile
+++ b/docker/java/spring/Dockerfile
@@ -24,6 +24,7 @@ RUN ./maven-package.sh "${JAVA_AGENT_BUILT_VERSION}"
 FROM adoptopenjdk:11-jre-hotspot
 COPY --from=0 /app /app
 COPY --from=0 /agent/apm-agent.jar /app
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -qq update \
   && apt-get -qq install -y --no-install-recommends curl \
   && apt-get -qq clean \

--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -17,9 +17,9 @@ WORKDIR /src
 COPY . /src
 # install SDK version in global.json of elastic/apm-agent-dotnet
 # Needed when building branches that specify 3.1.100 SDK in global.json
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
+RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 # SDK 5.x is also needed
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 5.0.100
+RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 5.0.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app

--- a/docker/opbeans/python/Dockerfile
+++ b/docker/opbeans/python/Dockerfile
@@ -4,6 +4,7 @@ FROM ${OPBEANS_PYTHON_IMAGE}:${OPBEANS_PYTHON_VERSION}
 ENV ELASTIC_APM_ENABLE_LOG_CORRELATION=true
 
 # postgresql-client is used for the dbshell command in the entrypoint
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -qq update \
  && apt-get -qq install -y \
     postgresql-client \

--- a/docker/opbeans/rum/Dockerfile
+++ b/docker/opbeans/rum/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt update -qq \
     && apt install -qq -y --no-install-recommends \
       curl \

--- a/docker/php/apache/Dockerfile
+++ b/docker/php/apache/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:7.4-apache
 
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -qq update \
  && apt-get -qq install -y --no-install-recommends \
     autoconf \

--- a/docker/ruby/rails/Dockerfile
+++ b/docker/ruby/rails/Dockerfile
@@ -1,6 +1,7 @@
 ARG RUBY_VERSION=3.0
 FROM ruby:${RUBY_VERSION}
 
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
     build-essential \

--- a/docker/rum/Dockerfile
+++ b/docker/rum/Dockerfile
@@ -4,6 +4,7 @@ ARG RUM_AGENT_BRANCH=main
 ARG RUM_AGENT_REPO=elastic/apm-agent-rum-js
 ARG APM_SERVER_URL
 
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt update -qq \
     && apt install -qq -y \
       curl \


### PR DESCRIPTION
## What does this PR do?

Add retry logic to apt and to curl calls.

## Why is it important?

Hopefully reduce the number of transient upstream failures.

