### PR TITLE
use Mapping from collections.abc

### DIFF
--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -1,4 +1,4 @@
-import collections
+import collections, collections.abc
 import json
 import sys
 
@@ -161,7 +161,7 @@ class Service(object):
             if content[prune] is None:
                 del (content[prune])
         if self._env_vars:
-            if isinstance(content["environment"], collections.Mapping):
+            if isinstance(content["environment"], collections.abc.Mapping):
                 for ev in self._env_vars:
                     k, v = ev.split("=", 1)
                     content["environment"][k] = v

--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -1,4 +1,5 @@
-import collections, collections.abc
+import collections
+import collections.abc
 import json
 import sys
 


### PR DESCRIPTION
for compat with python 3.10

This already has a test that warns under python3 < .10, and fails on 3.10 with:

```
AttributeError: module 'collections' has no attribute 'Mapping'
```