### PR TITLE
display APM Server under Elastic Agent version

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -915,7 +915,7 @@ class LocalSetup(object):
                     command, stderr=open(os.devnull, 'w'), shell=True).decode('utf8').strip()
             except subprocess.CalledProcessError:
                 # Handle errors
-                print('\tContainer "{}" is not running or an error occurred'.format(name))
+                print('\tContainer "{}" is not running or an error occurred running: {}'.format(name, command))
                 return False
 
             return output
@@ -934,6 +934,14 @@ class LocalSetup(object):
             print("\nAPM Server (image built: %s UTC):" % container.created)
 
             version = run_container_command('apm-server', 'apm-server version')
+
+            if version:
+                print("\t{0}".format(version))
+
+        def print_apm_managed_version(container):
+            print("\nElastic Agent managed APM Server (image built: %s UTC):" % container.created)
+
+            version = run_container_command('apm-server', '/usr/share/elastic-agent/elastic-agent version --binary-only')
 
             if version:
                 print("\t{0}".format(version))
@@ -992,6 +1000,7 @@ class LocalSetup(object):
 
         dispatch = {
             'apm-server': print_apm_server_version,
+            'apm-managed': print_apm_managed_version,
             'elasticsearch': print_elasticsearch_version,
             'kibana': print_kibana_version,
             'opbeans-node': print_opbeans_node_version,

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -941,7 +941,8 @@ class LocalSetup(object):
         def print_apm_managed_version(container):
             print("\nElastic Agent managed APM Server (image built: %s UTC):" % container.created)
 
-            version = run_container_command('apm-server', '/usr/share/elastic-agent/elastic-agent version --binary-only')
+            version = run_container_command('apm-server',
+                                            '/usr/share/elastic-agent/elastic-agent version --binary-only')
 
             if version:
                 print("\t{0}".format(version))


### PR DESCRIPTION
## What does this PR do?

Collects the version of Elastic Agent running in the stack, like:

```
$ ./scripts/compose.py version
Getting current version numbers for services...

Elastic Agent managed APM Server (image built: 2022-08-10 04:31:22 UTC):
	Binary: 8.5.0-SNAPSHOT (build: dc5b1a2ec19c04e54f663be166e54f892d3c3385 at 2022-08-10 04:25:59 +0000 UTC)

Kibana (image built: 2022-08-09 11:40:11 UTC):
	Version: 8.5.0-SNAPSHOT
	Branch: main
	Build SHA: 6655eeff50554078e3f427828846399066cc29e3
	Build number: 55383

Elasticsearch (image built: 2022-08-10 04:29:56 UTC):
	Version: 8.5.0-SNAPSHOT, Build: docker/895baf011cc1a5cbc4645a1841080ec214d17cbb/2022-08-10T00:21:36.258296167Z, JVM: 18.0.2
```

## Why is it important?

Speeds up troubleshooting by simplifying collection of stack component versions.
