### PR TITLE
Upgrade postgres to v14

### DIFF
--- a/scripts/modules/aux_services.py
+++ b/scripts/modules/aux_services.py
@@ -83,7 +83,7 @@ class Postgres(Service):
         return dict(
             environment=["POSTGRES_DB=opbeans", "POSTGRES_PASSWORD=verysecure"],
             healthcheck={"interval": "10s", "test": ["CMD", "pg_isready", "-h", "postgres", "-U", "postgres"]},
-            image="postgres:10",
+            image="postgres:14",
             labels=None,
             ports=[self.publish_port(self.port, self.SERVICE_PORT, expose=True)],
             volumes=["./docker/opbeans/sql:/docker-entrypoint-initdb.d", "pgdata:/var/lib/postgresql/data"],

--- a/scripts/tests/test_localsetup.py
+++ b/scripts/tests/test_localsetup.py
@@ -348,7 +348,7 @@ class OpbeansServiceTest(ServiceTest):
                             max-size: '2m'
                             max-file: '5'
                     environment:
-                        - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans
+                        - DATABASE_URL=pURLostgres://postgres:verysecure@postgres/opbeans
                         - ELASTIC_APM_SERVICE_NAME=opbeans-python
                         - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                         - ELASTIC_APM_SERVER_URL=http://apm-server:8200
@@ -649,7 +649,7 @@ class PostgresServiceTest(ServiceTest):
         self.assertEqual(
             postgres, yaml.safe_load("""
                 postgres:
-                    image: postgres:10
+                    image: postgres:14
                     container_name: localtesting_6.2.4_postgres
                     environment:
                         - POSTGRES_DB=opbeans

--- a/scripts/tests/test_localsetup.py
+++ b/scripts/tests/test_localsetup.py
@@ -348,7 +348,7 @@ class OpbeansServiceTest(ServiceTest):
                             max-size: '2m'
                             max-file: '5'
                     environment:
-                        - DATABASE_URL=pURLostgres://postgres:verysecure@postgres/opbeans
+                        - DATABASE_URL=postgres://postgres:verysecure@postgres/opbeans
                         - ELASTIC_APM_SERVICE_NAME=opbeans-python
                         - ELASTIC_APM_SERVICE_VERSION=9c2e41c8-fb2f-4b75-a89d-5089fb55fc64
                         - ELASTIC_APM_SERVER_URL=http://apm-server:8200


### PR DESCRIPTION
## What does this PR do?

Upgrades Postgres from v10 to v14

## Why is it important?

v10 is EOL this coming November 2022, and Django has already dropped support
for it. I have no idea if this will cause failures, figured I'd open the
PR and see.

Closes https://github.com/elastic/observability-robots/issues/1357
