### PR TITLE
[Automation] Update go release version to 1.18.5

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.17.11
+ARG go_version=1.18.5
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
Bump version matching the same as the apm-server