### PR TITLE
[automation] Update Elastic stack release version 8.4.1 8.4.1

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -89,8 +89,8 @@ class LocalSetup(object):
         '8.2': '8.2.3',
         '8.3': '8.3.3',
         '8.4': '8.4.1',
-        'main': '8.5.0',
-        'master': '8.5.0',  # keep master alias for backward compatibility. Upgrade the main alias only
+        'main': '8.4.1',
+        'master': '8.4.1',  # keep master alias for backward compatibility. Upgrade the main alias only
     }
 
     def __init__(self, argv=None, services=None):


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 8.4.1 8.4.1