### PR TITLE
add opbeans-php

### DIFF
--- a/docker/opbeans/php/Dockerfile
+++ b/docker/opbeans/php/Dockerfile
@@ -1,0 +1,1 @@
+FROM opbeans/opbeans-php

--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -29,7 +29,7 @@ from .aux_services import (  # noqa: F401
     CommandService, Kafka, Logstash, Postgres, Redis, StatsD, Zookeeper, WaitService
 )
 from .opbeans import (  # noqa: F401
-    OpbeansNode, OpbeansRuby, OpbeansPython, OpbeansDotnet,
+    OpbeansNode, OpbeansRuby, OpbeansPhp, OpbeansPython, OpbeansDotnet,
     OpbeansGo, OpbeansJava, OpbeansLoadGenerator, OpbeansGo01, OpbeansDotnet01,
     OpbeansJava01, OpbeansNode01, OpbeansPython01, OpbeansRuby01
 )


### PR DESCRIPTION
## What does this PR do?

adds the opbeans-php application.  Start with:

```
./scripts/compose.py start 8.4.1 --release --with-opbeans-php --opbeans-apm-js-server-url http://localhost:8200
```

The application is reachable on http://localhost:3105 by default:

<img width="2160" alt="image" src="https://user-images.githubusercontent.com/83483/187797214-86c02a5b-7949-48a5-adce-09b1ed939c6f.png">

This will result in 2 services reporting into Elastic APM, opbeans-php and opbeans-react:

<img width="2160" alt="image" src="https://user-images.githubusercontent.com/83483/187797334-bd797e1e-9057-408a-ac4d-705b02c0d0e3.png">

<img width="2160" alt="image" src="https://user-images.githubusercontent.com/83483/187797176-8285628c-e770-4485-8930-7e9a81d6cd2b.png">

## Why is it important?

To simplify running an instrumented PHP application in dev.

## Related issues
Closes #1443 
