### PR TITLE
[automation] Update go release version 1.19.4

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.18.8
+ARG go_version=1.19.4
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
### What 

Bump go release version with the latest release. 

### Further details 

See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.19.4+label%3ACherryPickApproved) for 1.19.4

 


_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_