### PR TITLE
[automation] Update Elastic stack release version 8.6.0 8.6.0

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -87,8 +87,8 @@ class LocalSetup(object):
         '8.4': '8.4.3',
         '8.5': '8.5.3',
         '8.6': '8.6.0',
-        'main': '8.7.0',
-        'master': '8.7.0',  # keep master alias for backward compatibility. Upgrade the main alias only
+        'main': '8.6.0',
+        'master': '8.6.0',  # keep master alias for backward compatibility. Upgrade the main alias only
     }
 
     def __init__(self, argv=None, services=None):


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 8.6.0 8.6.0