### PR TITLE
fix docker image for the apm-server

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
-ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.0.0-SNAPSHOT
-ARG go_version=1.18.9
+ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.7.0-SNAPSHOT
+ARG go_version=1.19.5
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

Bump versions for the apm-server

## Why is it important?


Otherwise docker image generation fails

Closes https://github.com/elastic/apm-integration-testing/issues/1553