### PR TITLE
dotnet-opbeans:  Install the [7.0.100] .NET Core SDK

### DIFF
--- a/docker/opbeans/dotnet/Dockerfile
+++ b/docker/opbeans/dotnet/Dockerfile
@@ -20,6 +20,8 @@ COPY . /src
 RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 3.1.100
 # SDK 5.x is also needed
 RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 5.0.100
+# SDK 7.x is also needed
+RUN curl --retry 5 -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir ${DOTNET_ROOT} -version 7.0.100
 RUN ./run.sh
 
 # Stage 2: Run the opbeans-dotnet app


### PR DESCRIPTION
## What does this PR do?

Fixes the docker build for the `opbeans-dotnet`

## Why is it important?

```
#   #11 7.480 A compatible installed .NET Core SDK for global.json version [7.0.100] from [/src/dotnet-agent/global.json] was not found
#   #11 7.480 Install the [7.0.100] .NET Core SDK or update [/src/dotnet-agent/global.json] with an installed .NET Core SDK:
#   #11 ERROR: executor failed running [/bin/sh -c ./run.sh]: exit code: 145
```

when running `make -C docker test-opbeans-dotnet`


With this change:

```
make -C docker test-opbeans-dotnet
HEAD is now at c706d14 Bats 1.1.0
12-alpine: Pulling from library/node
Digest: sha256:d4b15b3d48f42059a15bd659be60afe21762aae9d6cbea6f124440895c27db68
Status: Image is up to date for node:12-alpine
docker.io/library/node:12-alpine
Synchronizing submodule url for 'tests/test_helper/bats-assert'
Synchronizing submodule url for 'tests/test_helper/bats-support'
1..5
ok 1 opbeans-dotnet - build image
ok 2 opbeans-dotnet - clean test containers
ok 3 opbeans-dotnet - create test container
ok 4 opbeans-dotnet - test container with 0 as exitcode
ok 5 opbeans-dotnet - clean test containers afterwards
/usr/local/bin/tap-xunit -> /usr/local/lib/node_modules/tap-xunit/bin/tap-xunit
/usr/local/bin/txunit -> /usr/local/lib/node_modules/tap-xunit/bin/tap-xunit
+ tap-xunit@2.4.1
added 21 packages from 21 contributors in 4.262s
```

Closes https://github.com/elastic/apm-integration-testing/issues/1555