### PR TITLE
docs: add warning with the manual required step

### DIFF
--- a/scripts/modules/service.py
+++ b/scripts/modules/service.py
@@ -229,6 +229,11 @@ class StackService(object):
             version=version,
         )
         try:
+            print(
+                '''WARNING: BCs for Elasticsearch require some manual steps as long as it is not using the same docker repo tags.
+                See https://github.com/elastic/apm-integration-testing/issues/1566
+                '''
+            )
             return self.bc["projects"][self.docker_name]["packages"][key]
         except KeyError:
             # help debug manifest issues


### PR DESCRIPTION
## What does this PR do?

Add log entry to highlight when a failure related to a missing docker repo tag

## Why is it important?

Help users so they can get some insights about what's the failure and how to by pass it manually as long as it's not solved in the upstream

## Test

```bash
$ python3 ./scripts/compose.py start 8.7.0 --bc
found latest build candidate for 8.7 - https://staging.elastic.co/8.7.0-1da0dcc5/summary-8.7.0.html at https://staging.elastic.co/latest/8.7.json
WARNING: BCs for Elasticsearch require some manual steps as long as it is not using the same docker repo tags.
                See https://github.com/elastic/apm-integration-testing/issues/1566
                
WARNING: BCs for Elasticsearch require some manual steps as long as it is not using the same docker repo tags.
                See https://github.com/elastic/apm-integration-testing/issues/1566
```

## Issue

Relates to https://github.com/elastic/apm-integration-testing/issues/1566