### PR TITLE
bump golang version for the APM Server

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
-ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.7.0-SNAPSHOT
-ARG go_version=1.19.5
+ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.9.0-SNAPSHOT
+ARG go_version=1.20.7
 ARG apm_server_binary=apm-server
 
 ###############################################################################

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -14,8 +14,6 @@ RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -qq update \
     && apt-get -qq install -y python3 python3-pip python3-venv rsync
 
-RUN pip3 install --upgrade pip
-
 ARG apm_server_branch_or_commit=main
 ARG apm_server_repo=https://github.com/elastic/apm-server.git
 ENV SRC=/go/src/github.com/elastic/apm-server


### PR DESCRIPTION
## What does this PR do?

Bump the golang version for the APM Server to reflect the current versions

## Why is it important?

Otherwise, docker image will fail with:

```
#   5.175 go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19
```

See https://github.com/elastic/apm-pipeline-library/actions/runs/5792609381/job/15699146596#step:9:417