### PR TITLE
opbeans-dotnet: use the way to know the agent version 

### DIFF
--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -9,8 +9,7 @@ git checkout "${OPBEANS_DOTNET_BRANCH}"
 CSPROJ="opbeans-dotnet.csproj"
 
 PACKAGE=Elastic.Apm.NetCoreAll
-CSPROJ_VERSION_BACKWARDS="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
-CSPROJ_VERSION="/src/dotnet-agent/src/integrations/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
 BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
@@ -54,7 +53,8 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
     if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-      DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION_BACKWARDS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+      ## From 1.22 onwards (see https://github.com/elastic/apm-agent-dotnet/pull/2063)
+      DOTNET_AGENT_VERSION=$(dotnet minver -t=v -p=canary.0 -v=e)
       if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
         echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1
       fi

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -9,12 +9,13 @@ git checkout "${OPBEANS_DOTNET_BRANCH}"
 CSPROJ="opbeans-dotnet.csproj"
 
 PACKAGE=Elastic.Apm.NetCoreAll
-CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
-BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
+SRC_AGENT=/src/dotnet-agent
+CSPROJ_VERSION="${SRC_AGENT}/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+BUILD_PROPS="${SRC_AGENT}/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-  git clone https://github.com/"${DOTNET_AGENT_REPO}".git /src/dotnet-agent
-  cd /src/dotnet-agent || exit
+  git clone https://github.com/"${DOTNET_AGENT_REPO}".git $SRC_AGENT
+  cd $SRC_AGENT || exit
   git fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
   git checkout "${DOTNET_AGENT_BRANCH}"
 
@@ -54,10 +55,13 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
     if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
       ## From 1.22 onwards (see https://github.com/elastic/apm-agent-dotnet/pull/2063)
+      pushd $SRC_AGENT
+      dotnet tool restore
       DOTNET_AGENT_VERSION=$(dotnet minver -t=v -p=canary.0 -v=e)
       if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
         echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1
       fi
+      popd
     fi
   fi
 

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -9,7 +9,8 @@ git checkout "${OPBEANS_DOTNET_BRANCH}"
 CSPROJ="opbeans-dotnet.csproj"
 
 PACKAGE=Elastic.Apm.NetCoreAll
-CSPROJ_VERSION="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+CSPROJ_VERSION_BACKWARDS="/src/dotnet-agent/src/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
+CSPROJ_VERSION="/src/dotnet-agent/src/integrations/Elastic.Apm.NetCoreAll/${PACKAGE}.csproj"
 BUILD_PROPS="/src/dotnet-agent/src/Directory.Build.props"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
@@ -53,7 +54,10 @@ if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
     echo 'INFO: search version in the csproj. (only for agent version < 1.3)'
     DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
     if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
-      echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1
+      DOTNET_AGENT_VERSION=$(grep 'PackageVersion' ${CSPROJ_VERSION_BACKWARDS} | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
+      if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
+        echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.' && exit 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
## What does this PR do?

Support new folder structure in the apm-agent-dotnet

## Why is it important?

Otherwise it fails with

```
#   #17 101.6 ++ grep PackageVersion /src/dotnet-agent/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
#   #17 101.6 grep: /src/dotnet-agent/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj: No such file or directory
#   #17 101.6 + DOTNET_AGENT_VERSION=
#   #17 101.7 + '[' -z '' ']'
#   #17 101.7 + echo 'ERROR: DOTNET_AGENT_VERSION could not be calculated.'
#   #17 101.7 ERROR: DOTNET_AGENT_VERSION could not be calculated.
#   #17 101.7 + exit 1
```


See https://github.com/elastic/apm-pipeline-library/actions/runs/5792609381/job/15709594341#step:9:475

## Related issues
see https://github.com/elastic/apm-agent-dotnet/pull/2063
