### PR TITLE
[updatecli] Bump elastic stack version to 8.10.2/8.12.0

### DIFF
--- a/scripts/modules/cli.py
+++ b/scripts/modules/cli.py
@@ -92,6 +92,7 @@ class LocalSetup(object):
         '8.9': '8.9.2',
         '8.10': '8.10.2',
         '8.11': '8.11.0',
+        '8.12': '8.12.0',
         # UPDATECLI_AUTOMATION
         "main": "8.11.0",
         "master": "8.11.0",  # keep master alias for backward compatibility. Upgrade the main alias only


### PR DESCRIPTION



<Actions>
    <action id="4e80c928b329d1a0c988e0bbe67b81caa74600429c4a936473bf19b40a18700c">
        <h3>Bump elastic stack to latest version</h3>
        <details id="edbed8ed4d6fc5178540b45d1a034b0986c72aea4695dad5e02499e3cebaa0e0">
            <summary>Update elastic stack version to 8.12.0 (bc)</summary>
            <p>ran shell command &#34;bash .ci/bump-stack-release-version.sh 8.12.0&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

