### PR TITLE
fix: apm-server docker image generation and enable updatecli

### DIFF
--- a/.ci/bump-elastic-stack-snapshot.yml
+++ b/.ci/bump-elastic-stack-snapshot.yml
@@ -46,7 +46,7 @@ sources:
 
 targets:
   update-cli:
-    name: 'Update cli.py - main to {{ source "major-minor-patch" }} (bc)'
+    name: 'Update cli.py - main to {{ source "major-minor-patch" }}'
     kind: file
     sourceid: major-minor-patch
     scmid: default

--- a/.ci/bump-elastic-stack-snapshot.yml
+++ b/.ci/bump-elastic-stack-snapshot.yml
@@ -46,7 +46,7 @@ sources:
 
 targets:
   update-cli:
-    name: "Update cli.py - main"
+    name: 'Update cli.py - main to {{ source "major-minor-patch" }} (bc)'
     kind: file
     sourceid: major-minor-patch
     scmid: default

--- a/.ci/bump-elastic-stack.yml
+++ b/.ci/bump-elastic-stack.yml
@@ -58,6 +58,14 @@ sources:
     spec:
       command: echo {{ source "latestVersion" }}
 
+  apm-server-image:
+    name: Get apm-server-image
+    kind: shell
+    dependson:
+      - latestRelease
+    spec:
+      command: echo docker.elastic.co/apm/apm-server:{{ source "latestRelease" }}-SNAPSHOT
+
 conditions:
   dockerTag:
     name: Is docker image elasticsearch:{{ source "latestRelease" }} published
@@ -93,3 +101,13 @@ targets:
     kind: shell
     spec:
       command: bash .ci/bump-stack-release-version.sh
+
+  dockerfile.apmserver:
+    name: 'Update the value of ARG apm_server_base_image in the Dockerfile to {{ source "apm-server-image" }}'
+    sourceID: apm-server-image
+    kind: dockerfile
+    spec:
+      file: docker/apm-server/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "apm_server_base_image"

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,0 +1,47 @@
+---
+name: Bump golang-version to latest version
+pipelineid: 'updatecli-bump-golang'
+
+actions:
+  default:
+    title: '[updatecli] Bump Golang version to {{ source "go-version" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - automation
+        - backport-skip
+        - dependencies
+      description: |-
+        ### What
+        Bump go release version with the latest release used by the apm-server
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm-integration-testing
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
+sources:
+  go-version:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-server/main/.go-version
+      line: 1
+
+targets:
+  dockerfile.apmserver:
+    name: 'Update the value of ARG go_version in the Dockerfile to {{ source "go-version" }}'
+    sourceID: go-version
+    kind: dockerfile
+    spec:
+      file: docker/apm-server/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "go_version"

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -1,0 +1,24 @@
+---
+name: bump-golang
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 20 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/bump-golang.yml

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,6 @@
-ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.9.0-SNAPSHOT
+ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.10.4-SNAPSHOT
 ARG go_version=1.21.3
+
 ARG apm_server_binary=apm-server
 
 ###############################################################################

--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG apm_server_base_image=docker.elastic.co/apm/apm-server:8.9.0-SNAPSHOT
-ARG go_version=1.20.7
+ARG go_version=1.21.3
 ARG apm_server_binary=apm-server
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

Fix the versions for Golang and APM Server so it can work the docker image generation.
Support updatecli for bumping the golang version and apm-server docker image 

## Why is it important?

Fix the broken docker image generation in https://github.com/elastic/apm-pipeline-library/actions/runs/6701511746/job/18209071010

Support further automation with the auto-bump
